### PR TITLE
Bugfix/cli 25 newline in log

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Unreleased Changes
 ------------------
+* Fixed a bug in CLI logging where logfiles created by the CLI were 
+  incompatible with the ``natcap.invest.datastack`` operation that
+  allows the UI to load model arguments from logfiles.
 * Automated tests are now configured to use Github Actions for 32- and 64-bit
   build targets for Python 3.6 and 3.7 on Windows.  We are still using
   AppVeyor for our binary builds for the time being.

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -511,6 +511,7 @@ def main(user_args=None):
                                      name=parsed_datastack.model_name,
                                      logging_level=log_level):
             LOGGER.log(datastack.ARGS_LOG_LEVEL,
+                       'Starting model with parameters: \n%s',
                        datastack.format_args_dict(parsed_datastack.args,
                                                   parsed_datastack.model_name))
 


### PR DESCRIPTION
This PR makes the logging from `cli.py` identical to that from `model.py` when a model starts execution. This actually has implications for `datastack.extract_parameters_from_logfile`, which expects to find a line starting with "Arguments".