### PR TITLE
Bugfix/ufrm 23 soils error handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 
 Unreleased Changes
 ------------------
+* Added error-handling in Urban Flood Risk Mitigation to provide a helpful
+  error message.
 * Automated tests are now configured to use Github Actions for 32- and 64-bit
   build targets for Python 3.6 and 3.7 on Windows.  We are still using
   AppVeyor for our binary builds for the time being.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,9 @@
 
 Unreleased Changes
 ------------------
-* Added error-handling in Urban Flood Risk Mitigation to provide a helpful
-  error message.
+* Added error-handling in Urban Flood Risk Mitigation to tell users to
+  "Check that the Soil Group raster does not contain values other than 
+  (1, 2, 3, 4)" when a ``ValueError`` is raised from ``_lu_to_cn_op``.
 * Fixed a bug in CLI logging where logfiles created by the CLI were 
   incompatible with the ``natcap.invest.datastack`` operation that
   allows the UI to load model arguments from logfiles.

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -53,7 +53,6 @@ ARGS_SPEC = {
             "name": "Depth of rainfall in mm"
         },
         "lulc_path": {
-            "validation_options": {},
             "type": "raster",
             "validation_options": {
                 "projected": True,

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -824,9 +824,14 @@ def _lu_to_cn_op(
 
     # soil arrays are 1.0 - 4.0, remap to 0 - 3 and choose from the per
     # pixel CN array
-    result[valid_mask] = numpy.choose(
-        soil_choose_array,
-        per_pixel_cn_array)
+    try:
+        result[valid_mask] = numpy.choose(
+            soil_choose_array,
+            per_pixel_cn_array)
+    except ValueError as error:
+        err_msg = 'Check that the Soil Group raster does not contain values ' \
+            'other than (1, 2, 3, 4)'
+        raise ValueError(str(error) + '\n' + err_msg)
 
     return result
 

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -7,6 +7,7 @@ import os
 
 from osgeo import gdal
 import numpy
+import pygeoprocessing
 
 
 class UFRMTests(unittest.TestCase):
@@ -91,6 +92,29 @@ class UFRMTests(unittest.TestCase):
         # expected result observed from regression run.
         expected_result = 156070.36
         self.assertAlmostEqual(result_sum, expected_result, places=0)
+
+    def test_ufrm_value_error_on_bad_soil(self):
+        """UFRM: assert exception on bad soil raster values."""
+        from natcap.invest import urban_flood_risk_mitigation
+        args = self._make_args()
+
+        bad_soil_raster = os.path.join(self.workspace_dir, 'bad_soilgroups.tif')
+        value_map = {
+            1: 1,
+            2: 2,
+            3: 9,  # only 1, 2, 3, 4 are valid values for this raster.
+            4: 4
+        }
+        pygeoprocessing.reclassify_raster(
+            (args['soils_hydrological_group_raster_path'], 1), value_map,
+            bad_soil_raster, gdal.GDT_Int16, -9)
+        args['soils_hydrological_group_raster_path'] = bad_soil_raster
+        
+        with self.assertRaises(ValueError) as cm:
+            urban_flood_risk_mitigation.execute(args)
+            actual_message = str(cm.exception)
+            expected_message = 'Check that the Soil Group raster does not contain'
+            self.assertTrue(expected_message in actual_message)
 
     def test_validate(self):
         """UFRM: test validate function."""


### PR DESCRIPTION
This PR adds some error handling to what is likely to be a commonly occurring `ValueError` in the UFRM model. It happens when an input soil raster contains unacceptable values. 