### PR TITLE
Updating actions checkout to v2. Fixes #45

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -8,6 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Set up python 3.7
               uses: actions/setup-python@v1
@@ -33,6 +36,9 @@ jobs:
             PYTHON_ARCH: x86
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Restore pip cache
               uses: actions/cache@v1
@@ -135,6 +141,9 @@ jobs:
             PYTHON_ARCH: x86
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Install homebrew dependencies
               run: |

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -7,7 +7,7 @@ jobs:
         name: "Check for syntax errors"
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Set up python 3.7
               uses: actions/setup-python@v1
@@ -32,7 +32,7 @@ jobs:
             PYTHON_VERSION: 3.7
             PYTHON_ARCH: x86
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Restore pip cache
               uses: actions/cache@v1
@@ -134,7 +134,7 @@ jobs:
             PYTHON_VERSION: 3.7
             PYTHON_ARCH: x86
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Install homebrew dependencies
               run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Set up python 3.7
               uses: actions/setup-python@v1
@@ -43,6 +46,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache
@@ -86,6 +92,9 @@ jobs:
         needs: check-syntax-errors
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Restore pip cache
               uses: actions/cache@v1
@@ -126,6 +135,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
         name: "Check for syntax errors"
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Set up python 3.7
               uses: actions/setup-python@v1
@@ -42,7 +42,7 @@ jobs:
                 os: [windows-latest]
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache
@@ -85,7 +85,7 @@ jobs:
         runs-on: windows-latest
         needs: check-syntax-errors
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Restore pip cache
               uses: actions/cache@v1
@@ -125,7 +125,7 @@ jobs:
                 os: [windows-latest]
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -26,6 +26,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Set up python ${{ matrix.python-version }} ${{ matrix.python-arch }}
               uses: actions/setup-python@v1
@@ -49,6 +52,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  # Fetch complete history for accurate versioning
+                  fetch-depth: 0
 
             - name: Set up python
               uses: actions/setup-python@v1

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -25,7 +25,7 @@ jobs:
                       python-arch: x86
 
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Set up python ${{ matrix.python-version }} ${{ matrix.python-arch }}
               uses: actions/setup-python@v1
@@ -48,7 +48,7 @@ jobs:
         name: Source Dist
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
 
             - name: Set up python
               uses: actions/setup-python@v1


### PR DESCRIPTION
This PR updates the checkout functionality in github actions to use the updated `v2` version of checkout to avoid a possible race condition in the workflows that we learned about in https://github.com/natcap/taskgraph/pull/14.