### PR TITLE
Patching psutil security vulnerability in psutil CVE-2019-18874.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 
 Unreleased Changes
 ------------------
+* Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
+  a double-free vulnerability documented in CVE-2019-18874.
 * Adding a GitHub Actions workflow for building python wheels for Mac and Windows
   as well as a source distribution.
 * Updating links in ``setup.py``, ``README.rst`` and ``README_PYTHON.rst`` to

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ Shapely>=1.6.4,<1.7.0
 six
 pygeoprocessing>=1.9.2
 taskgraph[niced_processes]>=0.8.2
-psutil!=5.6.0
+psutil>=5.6.6
 chardet>=3.0.4
 matplotlib
 xlrd>=1.2.0


### PR DESCRIPTION
This updates the `psutil` dependency to avoid a double free vulnerability in `psutil`.