### PR TITLE
Address libwebp crash in recent mac builds

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -138,6 +138,11 @@ jobs:
             - uses: actions/checkout@v2
             - run: git fetch --prune --unshallow
 
+            - name: Install homebrew dependencies
+              run: |
+                  brew update
+                  brew install mercurial pandoc
+
             - name: Restore conda cache
               uses: actions/cache@v1
               with:

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -162,8 +162,8 @@ jobs:
                   conda env create -p ./env --file requirements-all.yml
                   conda init bash
 
-                  # Force libwebp to install from conda-forge.
-                  conda install -p ./env --yes --channel conda-forge libwebp
+                  # Libtiff from conda defaults channel gets around issue with missing libwebp
+                  conda install -p ./env --yes libtiff
 
             - name: Build binaries
               shell: bash

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -163,7 +163,7 @@ jobs:
                   conda init bash
 
                   # Force libwebp to install from the defaults channel.
-                  conda install -p ./env --yes --override-channels --channel defaults libwebp
+                  conda upgrade -p ./env --yes libwebp
 
             - name: Build binaries
               shell: bash

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -8,9 +8,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-              with:
-                  # Fetch complete history for accurate versioning
-                  fetch-depth: 0
 
             - name: Set up python 3.7
               uses: actions/setup-python@v1
@@ -18,7 +15,7 @@ jobs:
                   python-version: 3.7
 
             - name: Set up environment
-              run: python -m pip install --upgrade pip setuptools setuptools_scm flake8
+              run: python -m pip install --upgrade pip flake8
 
             - name: Lint with flake8
               run: |
@@ -36,9 +33,7 @@ jobs:
             PYTHON_ARCH: x86
         steps:
             - uses: actions/checkout@v2
-              with:
-                  # Fetch complete history for accurate versioning
-                  fetch-depth: 0
+            - run: git fetch --prune --unshallow
 
             - name: Restore pip cache
               uses: actions/cache@v1
@@ -141,9 +136,7 @@ jobs:
             PYTHON_ARCH: x86
         steps:
             - uses: actions/checkout@v2
-              with:
-                  # Fetch complete history for accurate versioning
-                  fetch-depth: 0
+            - run: git fetch --prune --unshallow
 
             - name: Install homebrew dependencies
               run: |
@@ -173,6 +166,9 @@ jobs:
                         requirements-gui.txt > requirements-all.yml
                   conda env create -p ./env --file requirements-all.yml
                   conda init bash
+
+                  # Force libwebp to install from the defaults channel.
+                  conda activate ./env && conda upgrade --yes --override-channels --channel defaults libwebp
 
             - name: Build binaries
               shell: bash

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -163,7 +163,7 @@ jobs:
                   conda init bash
 
                   # Force libwebp to install from the defaults channel.
-                  conda upgrade -p ./env --yes libwebp
+                  conda install -p ./env --yes libwebp
 
             - name: Build binaries
               shell: bash

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -163,7 +163,7 @@ jobs:
                   conda init bash
 
                   # Force libwebp to install from the defaults channel.
-                  conda activate ./env && conda upgrade --yes --override-channels --channel defaults libwebp
+                  conda install -p ./env --yes --override-channels --channel defaults libwebp
 
             - name: Build binaries
               shell: bash

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -138,11 +138,6 @@ jobs:
             - uses: actions/checkout@v2
             - run: git fetch --prune --unshallow
 
-            - name: Install homebrew dependencies
-              run: |
-                  brew update
-                  brew install mercurial pandoc
-
             - name: Restore conda cache
               uses: actions/cache@v1
               with:

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -162,8 +162,8 @@ jobs:
                   conda env create -p ./env --file requirements-all.yml
                   conda init bash
 
-                  # Force libwebp to install from the defaults channel.
-                  conda install -p ./env --yes libwebp
+                  # Force libwebp to install from conda-forge.
+                  conda install -p ./env --yes --channel conda-forge libwebp
 
             - name: Build binaries
               shell: bash


### PR DESCRIPTION
This PR adjusts the mac build environment setup to address the build failures noted in #63.

While in there, I also updated some of the git checkout stuff to pull all revisions and tags for accurate versioning for build artifacts.