### PR TITLE
NDR bugfix for incorrectly-cast nodata value when normalizing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,6 @@
 
 Unreleased Changes
 ------------------
-* Fixed an issue with NDR's raster normalization routine, where normalizing
-  an input Float64 raster with a nodata value outside of the range of possible
-  Float32 values would not properly cast the nodata value.
 * Fixed an issue with NDR's raster normalization function so that Float64
   nodata values are now correctly cast to Float32.  This issue was affecting
   the summary vector, where the ``surf_n``, ``sub_n`` and ``n_export_tot``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 
 Unreleased Changes
 ------------------
+* Fixed an issue with NDR's raster normalization routine, where normalizing
+  an input Float64 raster with a nodata value outside of the range of possible
+  Float32 values would not properly cast the nodata value.
+* Fixed an issue with NDR's raster normalization function so that Float64
+  nodata values are now correctly cast to Float32.  This issue was affecting
+  the summary vector, where the ``surf_n``, ``sub_n`` and ``n_export_tot``
+  columns would contain values of ``-inf``.
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its
   neighbors.  Note that for ease of debugging, this has been implemented as a
@@ -35,7 +42,7 @@ Unreleased Changes
 * Makefile has been updated to fetch the version string from ``git`` rather
   than ``hg``.  A mercurial client is still needed in order to clone the
   InVEST User's Guide.
-* Removing Python 2 compatibility code such as ``future``, ``pyqt4``, 
+* Removing Python 2 compatibility code such as ``future``, ``pyqt4``,
   ``basestring``, ``unicode``, ``six``, unicode casting, etc...
 * Update api-docs conf file to mock sdr.sdr_core and to use updated unittest
   mock

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -1,18 +1,16 @@
 """InVEST Nutrient Delivery Ratio (NDR) module."""
-import pickle
 import itertools
 import logging
 import os
+import pickle
 
-from osgeo import gdal
-from osgeo import ogr
 import numpy
-import taskgraph
 import pygeoprocessing
 import pygeoprocessing.routing
+from osgeo import gdal, ogr
+import taskgraph
 
-from .. import validation
-from .. import utils
+from .. import utils, validation
 from . import ndr_core
 
 LOGGER = logging.getLogger(__name__)
@@ -373,11 +371,7 @@ def execute(args):
         args['workspace_dir'], 'intermediate_outputs')
     output_dir = os.path.join(args['workspace_dir'])
     cache_dir = os.path.join(intermediate_output_dir, 'cache_dir')
-    for dir_path in [output_dir, intermediate_output_dir, cache_dir]:
-        try:
-            os.makedirs(dir_path)
-        except OSError:
-            pass
+    utils.make_directories([output_dir, intermediate_output_dir, cache_dir])
 
     try:
         n_workers = int(args['n_workers'])
@@ -880,17 +874,23 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
 
     def _normalize_raster_op(array):
         """Divide values by mean."""
+        result = numpy.empty(array.shape, dtype=numpy.float32)
+        result[:] = numpy.float32(base_nodata)
         valid_mask = ~numpy.isclose(array, base_nodata)
-        result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
-        result[:] = base_nodata
         result[valid_mask] = array[valid_mask]
         if value_mean != 0:
             result[valid_mask] /= value_mean
         return result
 
+    # It's possible for base_nodata to extend outside what can be represented
+    # in a float32, yet GDAL expects a python float.  Casting to numpy.float32
+    # and back to a python float allows for the nodata value to reflect the
+    # actual nodata pixel values.
+    target_nodata = float(numpy.float32(base_nodata))
     pygeoprocessing.raster_calculator(
         [base_raster_path_band], _normalize_raster_op,
-        target_normalized_raster_path, gdal.GDT_Float32, base_nodata)
+        target_normalized_raster_path, gdal.GDT_Float32,
+        target_nodata)
 
 
 def _calculate_load(

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -1,11 +1,13 @@
 """InVEST NDR model tests."""
 import collections
-import unittest
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
+import unittest
 
 import numpy
+import pygeoprocessing
+from osgeo import gdal
 from osgeo import ogr
 
 REGRESSION_DATA = os.path.join(
@@ -47,6 +49,60 @@ class NDRTests(unittest.TestCase):
             'workspace_dir': workspace_dir,
         }
         return args.copy()
+
+    def test_normalize_raster_float64(self):
+        """NDR _normalize_raster handle float64.
+
+        Regression test for an issue raised on the forums when normalizing a
+        Float64 raster that has a nodata value that exceeds Float32 space.  The
+        output raster, in the buggy version, would have pixel values of -inf
+        where they should have been nodata.
+
+        https://community.naturalcapitalproject.org/t/ndr-null-values-in-watershed-results/914
+        """
+        from natcap.invest.ndr import ndr
+
+        float64_raster_path = os.path.join(self.workspace_dir,
+                                           'float64_raster.tif')
+        driver = gdal.GetDriverByName('GTiff')
+        raster = driver.Create(float64_raster_path,
+                               4,  # xsize
+                               4,  # ysize
+                               1,  # n_bands
+                               gdal.GDT_Float64)
+        source_nodata = -1.797693e+308  # taken from user's data
+        band = raster.GetRasterBand(1)
+        band.SetNoDataValue(source_nodata)
+        source_array = numpy.empty((4, 4), dtype=numpy.float64)
+        source_array[0:2][:] = 5.5  # Something, anything.
+        source_array[2:][:] = source_nodata
+        band.WriteArray(source_array)
+        band = None
+        raster = None
+        driver = None
+
+        normalized_raster_path = os.path.join(self.workspace_dir,
+                                              'normalized.tif')
+        ndr._normalize_raster((float64_raster_path, 1), normalized_raster_path)
+
+        normalized_raster_nodata = pygeoprocessing.get_raster_info(
+            normalized_raster_path)['nodata'][0]
+
+        normalized_array = gdal.OpenEx(normalized_raster_path).ReadAsArray()
+        expected_array = numpy.array(
+            [[1., 1., 1., 1.],
+             [1., 1., 1., 1.],
+             [normalized_raster_nodata]*4,
+             [normalized_raster_nodata]*4], dtype=numpy.float32)
+
+        # Assert that the output values match the target nodata value
+        self.assertEqual(
+            8,  # Nodata pixels
+            numpy.count_nonzero(numpy.isclose(normalized_array,
+                                              normalized_raster_nodata)))
+
+        numpy.testing.assert_array_almost_equal(
+            normalized_array, expected_array)
 
     def test_missing_headers(self):
         """NDR biphysical headers missing should raise a ValueError."""


### PR DESCRIPTION
This PR addresses an issue with the normalization routine in NDR (`ndr._normalize_raster`) that was exposed by a user on the forums (see #76).

As discussed in #76 , the issue has to do with a mismatch between the nodata value given (a float64) and how it's cast to a float32 independently of the pixel values themselves.

I was hoping to confirm with the user that it did indeed correct her issue, but I haven't heard back.