### PR TITLE
Automated bugfix releases

### DIFF
--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -141,7 +141,7 @@ jobs:
                       hub issue create \
                           --message "Release natcap.invest $BUGFIX_VERSION on PyPI" \
                           --message "When built, remember to upload wheels for $BUGFIX_VERSION to PyPI." \
-                          --message "Wheels will be uploaded to $(cat $RELEASE_URL_FILE)"
+                          --message "Wheels will be uploaded to $(cat $RELEASE_URL_FILE)" \
                           --labels task
 
                       # Create a new pull request from the new autorelease

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -10,11 +10,11 @@ jobs:
         name: Create a bugfix release
         runs-on: ubuntu-latest
         env:
-            TARGET_BRANCH: feature/automated-releases
+            SOURCE_BRANCH: feature/automated-releases
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ env.TARGET_BRANCH }}
+                  ref: ${{ env.SOURCE_BRANCH }}
                   fetch-depth: 0  # fetch complete history
 
             - run: git fetch origin +refs/tags/*:refs/tags/*
@@ -29,14 +29,14 @@ jobs:
 
             - name: Testing for and preparing the release
               env:
-                  TARGET_BRANCH: ${{ env.TARGET_BRANCH }}
+                  SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   # Redirecting stderr to /dev/null to keep actions logs
                   # reflecting the expected state of the program.
-                  if hub ci-status $TARGET_BRANCH 2> /dev/null
+                  if hub ci-status $SOURCE_BRANCH 2> /dev/null
                   then
-                      echo "There are test failures on $TARGET_BRANCH; aborting release."
+                      echo "There are test failures on $SOURCE_BRANCH; aborting release."
                       exit 1
                   fi
 
@@ -44,12 +44,12 @@ jobs:
                   # git-describe exits 0 if a tag is found, 128 if not.
                   # Redirecting stderr to /dev/null to keep the expected
                   # 'fatal' error message out of the actions logs.
-                  if git describe --exact-match --tags $TARGET_BRANCH 2> /dev/null
+                  if git describe --exact-match --tags $SOURCE_BRANCH 2> /dev/null
                   then
-                      echo "The latest commit on $TARGET_BRANCH already has a tag"
+                      echo "The latest commit on $SOURCE_BRANCH already has a tag"
                   else
                       LATEST_TAG=$(git describe --tags | awk -F '-' '{print $1}')
-                      echo "Latest tag on $TARGET_BRANCH is $LATEST_TAG"
+                      echo "Latest tag on $SOURCE_BRANCH is $LATEST_TAG"
                       if [[ $LATEST_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
                       then
                           echo "$LATEST_TAG identified as a full release."
@@ -79,6 +79,8 @@ jobs:
                       # Commit changes and make an annotated tag.
                       git add Makefile HISTORY.rst
                       git status | cat  # for debugging.
+                      TARGET_BRANCH=autorelease/$BUGFIX_VERSION
+                      git checkout -b $TARGET_BRANCH
                       git commit -m "Auto-committing updates for the $BUGFIX_VERSION release"
                       git tag -a $BUGFIX_VERSION -m "$BUGFIX_VERSION release."
 
@@ -111,6 +113,7 @@ jobs:
                       #       See the list/descriptions of available scopes at:
                       #       https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
                       GITHUB_TOKEN=${{ secrets.USER_ACCESS_TOKEN }} hub release create \
+                          --draft \
                           --file $RELEASE_MESSAGE_FILE \
                           --commitish $TARGET_BRANCH \
                           $BUGFIX_VERSION
@@ -122,6 +125,15 @@ jobs:
                           --message "Release natcap.invest $BUGFIX_VERSION on PyPI" \
                           --message "When built, remember to upload wheels for $BUGFIX_VERSION to PyPI." \
                           --labels task
+
+                      # Create a new pull request from the new autorelease
+                      # branch back into the source branch.
+                      hub pull-request \
+                          --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
+                          --head $GITHUB_REPOSITORY:$TARGET_BRANCH \
+                          --reviewer "natcap/software-team" \
+                          --assign "natcap/software-team" \
+                          --message $(envsubst ci/release/bugfix-autorelease-branch-pr-body.md)
                   fi
 
             # Notify us on slack only on failure.

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -71,7 +71,7 @@ jobs:
 
                       # If $TARGET_BRANCH already exists, that means there's already
                       # a PR open for it and we shouldn't do another release.
-                      if git ls-remote --exit-code --heads git@github.com:$GITHUB_REPOSITORY.git $TARGET_BRANCH
+                      if git ls-remote --exit-code --heads https://github.com/$GITHUB_REPOSITORY.git $TARGET_BRANCH
                       then
                           echo "The branch $TARGET_BRANCH already exists."
                           echo "This is most likely because there's an "

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -31,6 +31,7 @@ jobs:
             - run: sudo apt-get update --fix-missing && sudo apt-get install pandoc gettext-base
 
             - name: Testing for and preparing the release
+              shell: bash -x {0}
               env:
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -84,15 +84,13 @@ jobs:
 
                       # Only push revisions needed to push the tag created.
                       # NOTE: If changes were pushed to $TARGET_BRANCH before
-                      # we try to push this release, the push will fail and
-                      # we'll avoid the race condition.
-                      #
-                      # NOTE: ${{ secrets.USER_AND_ACCESS_TOKEN }} must be set to <username>:<token>
-                      # NOTE: The User Access Token used must have repository push permissions.
-                      # NOTE: If the target repo is public, then only the ``public_repo`` permission is needed.
-                      # NOTE: See the list/descriptions of available scopes at:
-                      # https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
-                      GIT_REPO=https://${{ secrets.USER_AND_ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
+                      #       we try to push this release, the push will fail and
+                      #       we'll avoid the race condition.
+                      # NOTE: This push will NOT trigger other workflows because it's
+                      #       authenticated with $GITHUB_TOKEN.  By design, events
+                      #       authenticated with this token will not cause
+                      #       recursive workflow calls.
+                      GIT_REPO=https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
                       git push --tags $GIT_REPO $TARGET_BRANCH
 
                       RELEASE_MESSAGE_FILE=release_message.md
@@ -107,6 +105,11 @@ jobs:
                       #       this release object being created.  See the
                       #       upload-binaries-to-release build job in
                       #       .github/workflows/binary-applications.yml.
+                      # NOTE: The User Access Token used must have repository
+                      #       push permissions.  If the target repo is public, then
+                      #       only the ``public_repo`` permission is needed.
+                      #       See the list/descriptions of available scopes at:
+                      #       https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
                       GITHUB_TOKEN=${{ secrets.USER_ACCESS_TOKEN }} hub release create \
                           --file $RELEASE_MESSAGE_FILE \
                           --commitish $TARGET_BRANCH \

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -115,10 +115,11 @@ jobs:
                       #       only the ``public_repo`` permission is needed.
                       #       See the list/descriptions of available scopes at:
                       #       https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
+                      RELEASE_URL_FILE=release_url.txt
                       GITHUB_TOKEN=${{ secrets.USER_ACCESS_TOKEN }} hub release create \
                           --file $RELEASE_MESSAGE_FILE \
                           --commitish $TARGET_BRANCH \
-                          $BUGFIX_VERSION
+                          $BUGFIX_VERSION > $RELEASE_URL_FILE
 
                       # Python wheels are created in response to the release.
                       # Create an issue for uploading the wheels to PyPI here
@@ -126,6 +127,7 @@ jobs:
                       hub issue create \
                           --message "Release natcap.invest $BUGFIX_VERSION on PyPI" \
                           --message "When built, remember to upload wheels for $BUGFIX_VERSION to PyPI." \
+                          --message "Wheels will be uploaded to $(cat $RELEASE_URL_FILE)"
                           --labels task
 
                       # Create a new pull request from the new autorelease

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -82,7 +82,7 @@ jobs:
                       # Commit changes and make an annotated tag.
                       git add Makefile HISTORY.rst
                       git status | cat  # for debugging.
-                      TARGET_BRANCH=autorelease/$BUGFIX_VERSION
+                      export TARGET_BRANCH=autorelease/$BUGFIX_VERSION
                       git checkout -b $TARGET_BRANCH
                       git commit -m "Auto-committing updates for the $BUGFIX_VERSION release"
                       git tag -a $BUGFIX_VERSION -m "$BUGFIX_VERSION release."
@@ -136,8 +136,8 @@ jobs:
                       hub pull-request \
                           --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --head $GITHUB_REPOSITORY:$TARGET_BRANCH \
-                          --reviewer "natcap/software-team" \
-                          --assign "natcap/software-team" \
+                          --reviewer "$GITHUB_ACTOR" \
+                          --assign "$GITHUB_ACTOR" \
                           --file $PRMSG
                   fi
 

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -2,8 +2,8 @@ name: Automated Bugfix Release
 on:
     schedule:
         # Noon PST on Friday of each week
-        - cron: '0 20 * * 5'
-        #- cron: '*/5 * * * *'
+        #- cron: '0 20 * * 5'
+        - cron: '*/5 * * * *'
 
 jobs:
     create-bugfix-release:

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -116,7 +116,6 @@ jobs:
                       #       See the list/descriptions of available scopes at:
                       #       https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
                       GITHUB_TOKEN=${{ secrets.USER_ACCESS_TOKEN }} hub release create \
-                          --draft \
                           --file $RELEASE_MESSAGE_FILE \
                           --commitish $TARGET_BRANCH \
                           $BUGFIX_VERSION

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -31,7 +31,7 @@ jobs:
             - run: sudo apt-get update --fix-missing && sudo apt-get install pandoc gettext-base
 
             - name: Testing for and preparing the release
-              shell: bash -x {0}
+              shell: bash -ex {0}
               env:
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,8 +132,8 @@ jobs:
                       RELEASE_URL_FILE=release_url.txt
                       GITHUB_TOKEN=${{ secrets.USER_ACCESS_TOKEN }} hub release create \
                           --file $RELEASE_MESSAGE_FILE \
-                          --commitish $TARGET_BRANCH \
-                          $BUGFIX_VERSION > $RELEASE_URL_FILE
+                          --commitish "$TARGET_BRANCH" \
+                          "$BUGFIX_VERSION" > $RELEASE_URL_FILE
 
                       # Python wheels are created in response to the release.
                       # Create an issue for uploading the wheels to PyPI here

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -71,7 +71,7 @@ jobs:
 
                       # If $TARGET_BRANCH already exists, that means there's already
                       # a PR open for it and we shouldn't do another release.
-                      if git rev-parse --verify $TARGET_BRANCH
+                      if git ls-remote --exit-code --heads git@github.com:$GITHUB_REPOSITORY.git $TARGET_BRANCH
                       then
                           echo "The branch $TARGET_BRANCH already exists."
                           echo "This is most likely because there's an "

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -2,15 +2,14 @@ name: Automated Bugfix Release
 on:
     schedule:
         # Noon PST on Friday of each week
-        #- cron: '0 20 * * 5'
-        - cron: '*/5 * * * *'
+        - cron: '0 20 * * 5'
 
 jobs:
     create-bugfix-release:
         name: Create a bugfix release
         runs-on: ubuntu-latest
         env:
-            SOURCE_BRANCH: feature/automated-releases
+            SOURCE_BRANCH: master
         steps:
             - uses: actions/checkout@v2
               with:
@@ -31,7 +30,7 @@ jobs:
             - run: sudo apt-get update --fix-missing && sudo apt-get install pandoc gettext-base
 
             - name: Testing for and preparing the release
-              shell: bash -ex {0}
+              shell: bash
               env:
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -64,7 +64,21 @@ jobs:
                           exit 1
                       fi
 
+                      # Exporting these variables is necessary for envsubst.
                       export BUGFIX_VERSION=$(python setup.py --version | awk -F '.' '{print $1"."$2"."$3+1}')
+                      export TARGET_BRANCH=autorelease/$BUGFIX_VERSION
+
+                      # If $TARGET_BRANCH already exists, that means there's already
+                      # a PR open for it and we shouldn't do another release.
+                      if git rev-parse --verify $TARGET_BRANCH
+                      then
+                          echo "The branch $TARGET_BRANCH already exists."
+                          echo "This is most likely because there's an "
+                          echo "outstanding PR for it."
+                          echo ""
+                          echo "Exiting the release process."
+                          exit 0
+                      fi
 
                       # Update the UG hash in the Makefile
                       # This could be done with curl and sed, but it'll be easier
@@ -82,7 +96,6 @@ jobs:
                       # Commit changes and make an annotated tag.
                       git add Makefile HISTORY.rst
                       git status | cat  # for debugging.
-                      export TARGET_BRANCH=autorelease/$BUGFIX_VERSION
                       git checkout -b $TARGET_BRANCH
                       git commit -m "Auto-committing updates for the $BUGFIX_VERSION release"
                       git tag -a $BUGFIX_VERSION -m "$BUGFIX_VERSION release."

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -99,9 +99,9 @@ jobs:
                       git status | cat  # for debugging.
                       git checkout -b $TARGET_BRANCH
                       git commit -m "Auto-committing updates for the $BUGFIX_VERSION release"
-                      git tag -a $BUGFIX_VERSION -m "$BUGFIX_VERSION release."
 
-                      # Only push revisions needed to push the tag created.
+                      # Only push the target branch.  The tag will be created
+                      # as part of the github release.
                       # NOTE: If changes were pushed to $TARGET_BRANCH before
                       #       we try to push this release, the push will fail and
                       #       we'll avoid the race condition.
@@ -110,7 +110,7 @@ jobs:
                       #       authenticated with this token will not cause
                       #       recursive workflow calls.
                       GIT_REPO=https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-                      git push --tags $GIT_REPO $TARGET_BRANCH
+                      git push $GIT_REPO $TARGET_BRANCH
 
                       RELEASE_MESSAGE_FILE=release_message.md
                       VERSION=$BUGFIX_VERSION ./ci/release/build-release-text-from-history.sh > $RELEASE_MESSAGE_FILE

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -2,8 +2,8 @@ name: Automated Bugfix Release
 on:
     schedule:
         # Noon PST on Friday of each week
-        #- cron: '0 20 * * 5'
-        - cron: '*/5 * * * *'
+        - cron: '0 20 * * 5'
+        #- cron: '*/5 * * * *'
 
 jobs:
     create-bugfix-release:

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -25,7 +25,10 @@ jobs:
 
             - run: pip install --upgrade requests toml
             - run: pip install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
-            - run: sudo apt-get update --fix-missing && sudo apt-get install pandoc
+
+            # Pandoc needed for pandoc-based text conversion.
+            # gettext-base needed for the envsubst program.
+            - run: sudo apt-get update --fix-missing && sudo apt-get install pandoc gettext-base
 
             - name: Testing for and preparing the release
               env:

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -128,12 +128,14 @@ jobs:
 
                       # Create a new pull request from the new autorelease
                       # branch back into the source branch.
+                      PRMSG=prmsg.txt
+                      envsubst ci/release/bugfix-autorelease-branch-pr-body.md > $PRMSG
                       hub pull-request \
                           --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --head $GITHUB_REPOSITORY:$TARGET_BRANCH \
                           --reviewer "natcap/software-team" \
                           --assign "natcap/software-team" \
-                          --message $(envsubst ci/release/bugfix-autorelease-branch-pr-body.md)
+                          --file $PRMSG
                   fi
 
             # Notify us on slack only on failure.

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -132,7 +132,8 @@ jobs:
                       # Create a new pull request from the new autorelease
                       # branch back into the source branch.
                       PRMSG=prmsg.txt
-                      envsubst ci/release/bugfix-autorelease-branch-pr-body.md > $PRMSG
+                      cat ci/release/bugfix-autorelease-branch-pr-body.md | envsubst > $PRMSG
+                      cat $PRMSG  # For debugging
                       hub pull-request \
                           --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --head $GITHUB_REPOSITORY:$TARGET_BRANCH \

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -314,13 +314,21 @@ jobs:
                 if hub release show ${GITHUB_REF:10}
                 then
                     ls -la dist
-                    hub release edit \
-                        --attach $(make jprint-USERGUIDE_ZIP_FILE) \
-                        --attach $(make jprint-MAC_BINARIES_ZIP_FILE) \
-                        --attach $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) \
-                        --attach $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) \
-                        # Don't change the body of the release
-                        -m "" ${GITHUB_REF:10}
+                    FILELIST=release_file_list.txt
+                    $(make jprint-USERGUIDE_ZIP_FILE) >> $FILELIST
+                    $(make jprint-MAC_BINARIES_ZIP_FILE) >> $FILELIST
+                    $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) >> $FILELIST
+                    $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) >> $FILELIST
+
+                    # Make sure the file contains what it should
+                    cat $FILELIST
+
+                    set -x  # for debugging
+                    for FILE in `cat $FILELIST`
+                    do
+                        hub release edit -a $FILE -m "" ${GITHUB_REF:10}
+                    done
+                    set +x
                 else:
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"
                 fi

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -4,7 +4,7 @@ on:
     push:
     pull_request:
     release:
-        types: [created]
+        types: [published]
 
 jobs:
     check-syntax-errors:

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -161,7 +161,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0  # fetch complete history
-            - run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Fetch git tags
               run: git fetch origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -320,8 +320,7 @@ jobs:
                         --attach $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) \
                         --attach $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) \
                         # Don't change the body of the release
-                        --message "" \
-                        ${GITHUB_REF:10}
+                        -m "" ${GITHUB_REF:10}
                 else:
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"
                 fi

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -37,7 +37,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0  # fetch complete history
-            - run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Fetch git tags
               run: git fetch origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -3,8 +3,6 @@ name: Build InVEST App Binaries
 on:
     push:
     pull_request:
-    release:
-        types: [published]
 
 jobs:
     check-syntax-errors:

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -322,10 +322,10 @@ jobs:
                 then
                     ls -la dist
                     FILELIST=release_file_list.txt
-                    $(make jprint-USERGUIDE_ZIP_FILE) >> $FILELIST
-                    $(make jprint-MAC_BINARIES_ZIP_FILE) >> $FILELIST
-                    $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) >> $FILELIST
-                    $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) >> $FILELIST
+                    make jprint-USERGUIDE_ZIP_FILE >> $FILELIST
+                    make jprint-MAC_BINARIES_ZIP_FILE >> $FILELIST
+                    make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE >> $FILELIST
+                    make jprint-SAMPLEDATA_SINGLE_ARCHIVE >> $FILELIST
 
                     # Make sure the file contains what it should
                     cat $FILELIST

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -319,6 +319,7 @@ jobs:
                         --attach $(make jprint-MAC_BINARIES_ZIP_FILE) \
                         --attach $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) \
                         --attach $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) \
+                        --message "" \  # Don't change the body of the release
                         ${GITHUB_REF:10}
                 else:
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -319,7 +319,6 @@ jobs:
                         --attach $(make jprint-MAC_BINARIES_ZIP_FILE) \
                         --attach $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) \
                         --attach $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) \
-                        --message $(hub release show ${GITHUB_REF:10}) \
                         ${GITHUB_REF:10}
                 else:
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -319,7 +319,8 @@ jobs:
                         --attach $(make jprint-MAC_BINARIES_ZIP_FILE) \
                         --attach $(make PYTHON_ARCH=x86 jprint-WINDOWS_INSTALLER_FILE) \
                         --attach $(make jprint-SAMPLEDATA_SINGLE_ARCHIVE) \
-                        --message "" \  # Don't change the body of the release
+                        # Don't change the body of the release
+                        --message "" \
                         ${GITHUB_REF:10}
                 else:
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -4,7 +4,7 @@ on:
     push:
     pull_request:
     release:
-        types: [published]
+        types: [created]
 
 jobs:
     check-syntax-errors:

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -2,8 +2,7 @@ name: Python distributions
 on:
     push:
     pull_request:
-    release:
-        types: [published]
+
 jobs:
     build-wheels:
         name: Wheel

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -3,7 +3,7 @@ on:
     push:
     pull_request:
     release:
-        types: [published]
+        types: [created]
 jobs:
     build-wheels:
         name: Wheel

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -59,10 +59,9 @@ jobs:
               run: |
                 if hub release show ${GITHUB_REF:10}
                 then
-                    hub release edit \
-                        --attach $(find dist -name "*.whl") \
-                        # Don't change the body of the release
-                        -m "" ${GITHUB_REF:10}
+                    set -x
+                    hub release edit -a $(find dist -name "*.whl") -m "" ${GITHUB_REF:10}
+                    set +x
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping wheel upload."
                 fi

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -57,8 +57,6 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                echo $GITHUB_REF
-                echo ${GITHUB_REF:10}
                 if hub release show ${GITHUB_REF:10}
                 then
                     hub release edit \
@@ -101,8 +99,6 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: |
-                echo $GITHUB_REF
-                echo ${GITHUB_REF:10}
                 if hub release show ${GITHUB_REF:10}
                 then
                     hub release edit \

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -59,7 +59,7 @@ jobs:
               run: |
                 if hub release show ${GITHUB_REF:10}
                 then
-                    set -x
+                    set -x  # for debugging
                     hub release edit -a $(find dist -name "*.whl") -m "" ${GITHUB_REF:10}
                     set +x
                 else
@@ -98,14 +98,11 @@ jobs:
                   HUB_VERBOSE: 1
               shell: bash
               run: |
-                TAG=${GITHUB_REF:10}
-                echo $TAG
-                if hub release show ${TAG}
+                if hub release show ${GITHUB_REF:10}
                 then
-                    hub release edit \
-                        --attach $(find dist -name "*.tar.gz") \
-                        # Don't change the body of the release
-                        -m "" ${TAG}
+                    set -x  # for debugging
+                    hub release edit -a $(find dist -name "*.tar.gz") -m "" ${GITHUB_REF:10}
+                    set +x
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."
                 fi

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -61,6 +61,7 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.whl") \
+                        --message "" \  # Don't change the body of the release
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping wheel upload."
@@ -101,6 +102,7 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.tar.gz") \
+                        --message "" \  # Don't change the body of the release
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -61,7 +61,6 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.whl") \
-                        --message $(hub release show ${GITHUB_REF:10}) \
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping wheel upload."
@@ -102,7 +101,6 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.tar.gz") \
-                        --message $(hub release show ${GITHUB_REF:10}) \
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -57,6 +57,8 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
+                echo $GITHUB_REF
+                echo ${GITHUB_REF:10}
                 if hub release show ${GITHUB_REF:10}
                 then
                     hub release edit \
@@ -98,6 +100,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               shell: bash
               run: |
+                echo $GITHUB_REF
+                echo ${GITHUB_REF:10}
                 if hub release show ${GITHUB_REF:10}
                 then
                     hub release edit \

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -63,7 +63,8 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.whl") \
-                        --message "" \  # Don't change the body of the release
+                        # Don't change the body of the release
+                        --message "" \
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping wheel upload."
@@ -106,7 +107,8 @@ jobs:
                 then
                     hub release edit \
                         --attach $(find dist -name "*.tar.gz") \
-                        --message "" \  # Don't change the body of the release
+                        # Don't change the body of the release
+                        --message "" \
                          ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -62,8 +62,7 @@ jobs:
                     hub release edit \
                         --attach $(find dist -name "*.whl") \
                         # Don't change the body of the release
-                        --message "" \
-                         ${GITHUB_REF:10}
+                        -m "" ${GITHUB_REF:10}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping wheel upload."
                 fi
@@ -107,8 +106,7 @@ jobs:
                     hub release edit \
                         --attach $(find dist -name "*.tar.gz") \
                         # Don't change the body of the release
-                        --message "" \
-                        ${TAG}
+                        -m "" ${TAG}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."
                 fi

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -29,7 +29,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v2
-            - run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Fetch git tags
               run: git fetch origin +refs/tags/*:refs/tags/*
@@ -73,7 +72,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Fetch git tags
               run: git fetch origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -97,15 +97,18 @@ jobs:
             - name: Upload distribution to release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  HUB_VERBOSE: 1
               shell: bash
               run: |
-                if hub release show ${GITHUB_REF:10}
+                TAG=${GITHUB_REF:10}
+                echo $TAG
+                if hub release show ${TAG}
                 then
                     hub release edit \
                         --attach $(find dist -name "*.tar.gz") \
                         # Don't change the body of the release
                         --message "" \
-                         ${GITHUB_REF:10}
+                        ${TAG}
                 else
                     echo "Release for ${GITHUB_REF:10} not found; skipping sdist upload."
                 fi

--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -3,7 +3,7 @@ on:
     push:
     pull_request:
     release:
-        types: [created]
+        types: [published]
 jobs:
     build-wheels:
         name: Wheel

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.8 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.13 (2020-04-15)
+Unreleased Changes
 -------------------
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.5 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.10 (2020-04-15)
+Unreleased Changes
 -------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.3 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.6 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.9 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.7 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.4 (2020-04-15)
+Unreleased Changes
 ------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,12 @@
 .. :changelog:
 
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.8.13 (2020-04-15)
+-------------------
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its
   neighbors.  Note that for ease of debugging, this has been implemented as a

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,7 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
-
-3.8.11 (2020-04-15)
+Unreleased Changes
 -------------------
 * Bumping the ``psutil`` dependency requirement to ``psutil>=5.6.6`` to address
   a double-free vulnerability documented in CVE-2019-18874.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 0dfeed7f216f6c1f9af815aabb3e7e04f8cf662b
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := 19f4e740cd8a44c7565d19ad68c069c53866aaf8
+GIT_UG_REPO_REV              := 7868ad9b6b5346ebfc5ab9704cf02b4ea5671205
 
 
 ENV = env

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -4,7 +4,7 @@ This PR includes changes needed to perform the $BUGFIX_VERSION release.
 When the PR was created, the bugfix release tag $BUGFIX_VERSION should have
 been created on `$TARGET_BRANCH`, which should also have triggered builds
 for python wheels as well as Windows and Mac binaries.  These binaries
-will be automatically uploaded to the draft release object at
+will be automatically uploaded to the release object at
 https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 
 ## If something doesn't look right
@@ -36,7 +36,7 @@ https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 
 1. Approve and merge this PR.
 2. Delete the branch `$TARGET_BRANCH` once the PR is merged.
-3. Publish the draft release object at
+3. Take a look at the release object and make sure everything is there:
    https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 4. Upload python wheels to PyPI.  An issue was created for this,
    so remember to mark progress there as well.

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -9,17 +9,34 @@ https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 
 ## If something doesn't look right
 
-1. PR whatever changes are needed into this branch (`$SOURCE_BRANCH`)
-2. Continue until things look right.
+1. Decline this PR.  Do not delete the `$TARGET_BRANCH` branch.
+2. Go to the created release object and delete the binaries that have been
+   automatically uploaded there.
+3. PR whatever changes are needed into `$TARGET_BRANCH`.
+   ```shell
+   $ git checkout master
+   $ git pull upstream master
+   $ git checkout $TARGET_BRANCH
+   < make and commit any needed changes >
+   $ git push origin $TARGET_BRANCH
+   ```
+4. Once things look right, tag `$TARGET_BRANCH` with `$BUGFIX_VERSION` and
+   push to `$TARGET_BRANCH`.
+   ```shell
+   $ git checkout $TARGET_BRANCH
+   $ git tag --force $BUGFIX_VERSION
+   $ git push git@github.com:natcap/invest.git $TARGET_BRANCH $BUGFIX_VERSION
+   ```
+   Re-tagging and pushing the files to `$TARGET_BRANCH` will cause the release
+   binaries to be rebuilt and re-uploaded to the release object.
+5. Submit a PR from `natcap/invest:$TARGET_BRANCH` into `natcap/invest:$SOURCE_BRANCH`.
+
 
 ## If everything looks OK
 
-Approve and merge this branch.  You can delete this PR branch if you like.  It
-will be automatically deleted once the PR is merged if it still exists.
-
-## What happens once the PR is merged
-
-When this PR is merged, a workflow will:
-
-1. Remove the branch `$SOURCE_BRANCH` if it still exists.
-2. Publish the draft release.
+1. Approve and merge this PR.
+2. Delete the branch `$TARGET_BRANCH` once the PR is merged.
+3. Publish the draft release object at
+   https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
+4. Upload python wheels to PyPI.  An issue was created for this,
+   so remember to mark progress there as well.

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -48,3 +48,8 @@ https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
    https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 4. Upload python wheels to PyPI.  An issue was created for this,
    so remember to mark progress there as well.
+5. Double-check that the NatCap website's automation has picked up the updated
+   release links, or update them by hand if needed.
+6. Take a look at the Release Checklist
+   (https://github.com/natcap/invest/wiki/Release-Checklist) and take care of
+   anything else that needs to be taken care of.

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -13,7 +13,13 @@ https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
 
 1. Decline this PR.  Do not delete the `$TARGET_BRANCH` branch.
 2. Go to the created release object and delete the binaries that have been
-   automatically uploaded there.
+   automatically uploaded there:
+     1. Go to https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
+     2. Click "Edit"
+     3. For each binary file, click the "X" button on the right-hand side.
+     4. Click the green "Update Release" button at the bottom of the
+        release page.
+     5. Click the red "Delete" button to delete the release.
 3. PR whatever changes are needed into `$TARGET_BRANCH`.
    ```shell
    $ git checkout master

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -1,0 +1,25 @@
+Auto: Release $BUGFIX_VERSION and merge into $SOURCE_BRANCH
+
+This PR includes changes needed to perform the $BUGFIX_VERSION release.
+When the PR was created, the bugfix release tag $BUGFIX_VERSION should have
+been created on `$TARGET_BRANCH`, which should also have triggered builds
+for python wheels as well as Windows and Mac binaries.  These binaries
+will be automatically uploaded to the draft release object at
+https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
+
+## If something doesn't look right
+
+1. PR whatever changes are needed into this branch (`$SOURCE_BRANCH`)
+2. Continue until things look right.
+
+## If everything looks OK
+
+Approve and merge this branch.  You can delete this PR branch if you like.  It
+will be automatically deleted once the PR is merged if it still exists.
+
+## What happens once the PR is merged
+
+When this PR is merged, a workflow will:
+
+1. Remove the branch `$SOURCE_BRANCH` if it still exists.
+2. Publish the draft release.

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -1,5 +1,7 @@
 Auto: Release $BUGFIX_VERSION and merge into $SOURCE_BRANCH
 
+# Release $BUGFIX_VERSION
+
 This PR includes changes needed to perform the $BUGFIX_VERSION release.
 When the PR was created, the bugfix release tag $BUGFIX_VERSION should have
 been created on `$TARGET_BRANCH`, which should also have triggered builds

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -25,11 +25,11 @@ https://github.com/$GITHUB_REPOSITORY/releases/tag/$BUGFIX_VERSION.
    ```shell
    $ git checkout $TARGET_BRANCH
    $ git tag --force $BUGFIX_VERSION
-   $ git push git@github.com:natcap/invest.git $TARGET_BRANCH $BUGFIX_VERSION
+   $ git push git@github.com:$GITHUB_REPOSITORY.git $TARGET_BRANCH $BUGFIX_VERSION
    ```
    Re-tagging and pushing the files to `$TARGET_BRANCH` will cause the release
    binaries to be rebuilt and re-uploaded to the release object.
-5. Submit a PR from `natcap/invest:$TARGET_BRANCH` into `natcap/invest:$SOURCE_BRANCH`.
+5. Submit a PR from `$GITHUB_REPOSITORY:$TARGET_BRANCH` into `$GITHUB_REPOSITORY:$SOURCE_BRANCH`.
 
 
 ## If everything looks OK

--- a/ci/release/build-release-text-from-history.sh
+++ b/ci/release/build-release-text-from-history.sh
@@ -3,8 +3,10 @@
 # This script prepares the body of text for a github release object to be
 # created through the `hub` command-line utility.
 #
-# This requires the GITHUB_REF environment variable to be declared,
-# which must be in the git refs format of a tag (examples: refs/tags/3.8.0)
+# This requires the $VERSION environment variable to be declared,
+# which must be in the format of an InVEST release version.
+#
+# This script also requires the pandoc executable to be on the PATH.
 
 : "${VERSION:?Need to set VERSION.  Example: VERSION=3.8.0}"
 
@@ -19,7 +21,8 @@ echo "This bugfix release includes the following fixes and features:" >> $RELEAS
 echo "" >> $RELEASE_MESSAGE_RST_FILE  # extra line to clarify we're starting a bulleted list.
 
 # Read HISTORY from the released tag up until the first
-# blank line
+# blank line.
+# The tail +3 cuts off the version string and underline of the title.
 sed -n "/$VERSION/,/^$/p" HISTORY.rst | tail -n +3 >> $RELEASE_MESSAGE_RST_FILE
 
 pandoc \

--- a/ci/release/increment-userguide-revision.py
+++ b/ci/release/increment-userguide-revision.py
@@ -1,17 +1,35 @@
 # encoding=UTF-8
+"""Increment the User's Guide revision in Makefile.
+
+This script fetches the latest user's guide revision on the master branch from
+the github repository and updates it in the Makefile.
+
+To invoke:
+    $ pip install requests
+    $ python ci/release/increment-userguide-revision.py
+"""
 
 import shutil
 import os
-import pprint
 import requests
 
-
-def get_latest_rev_on_userguide():
-    r = requests.get('https://api.github.com/repos/natcap/invest.users-guide/commits/master')
-    return r.json()['sha']
+API_TARGET = (
+    'https://api.github.com/repos/natcap/invest.users-guide/commits/master')
 
 
-def update_userguide_rev_in_makefile(new_rev):
+def update_userguide_rev_in_makefile():
+    """Update the userguide revision in the Makefile.
+
+    Fetches the latest user's guide revision from the master branch and updates
+    it in the Makefile.
+
+    Returns:
+        ``None``
+
+    """
+    req = requests.get(API_TARGET)
+    new_rev = req.json()['sha']
+
     if not os.path.exists('build'):
         os.makedirs('build')
     new_makefile_path = os.path.join('build', 'Makefile')
@@ -35,5 +53,4 @@ def update_userguide_rev_in_makefile(new_rev):
 
 
 if __name__ == '__main__':
-    sha = get_latest_rev_on_userguide()
-    update_userguide_rev_in_makefile(sha)
+    update_userguide_rev_in_makefile()

--- a/ci/release/update-history.py
+++ b/ci/release/update-history.py
@@ -60,11 +60,8 @@ def note_release_section(version, date_string):
     if not unreleased_changes_section_found:
         raise ValueError(
             'Could not find the Unreleased Changes section of HISTORY. '
-            'This happens when there are commits on master since the '
+            'This can happen when there are commits on master since the '
             'latest tag but there are no changes recorded in HISTORY. '
-            'To fix this, uncomment the "Unreleased Changes" section, '
-            'add in whatever notes should have been added before, '
-            'and PR these changes back into master.'
         )
 
     print('HISTORY has been updated to release version %s on %s' % (


### PR DESCRIPTION
# Automated Bugfix Releases

This PR sets up automation to perform bugfix releases based on `master` (or whatever the repo default branch is) on a weekly schedule assuming that:

1. The latest commit on `master` does not have any failing tests.
2. The latest commit on `master` has not already been tagged (so, nothing has been merged into `master` since the last bugfix release).
3. The most recent tag on `master` conforms to `^major.minor.bugfix$` notation.  This automation cannot currently special cases like alpha/beta/release candidate tags.
3. The last bugfix release PR is not still in progress.

## What happens weekly
Once a week, a GitHub Actions workflow will fire up to check for the above conditions.  If the conditions are all satisfied, the following actions are taken:

1. The new bugfix version string is determined
2. `Makefile` is updated to reflect the latest commit hash on `master` in the User's Guide
3. `HISTORY.rst` is updated with today's date, and the 'Unreleased Changes' section is commented out in RST.
4. Both the above file changes are committed and pushed to a new branch: `autorelease/$BUGFIX_VERSION`.  (NB: branch restrictions on the repository have been relaxed to allow pushes to `autorelease/*`)  This new branch gives us an easy way to discard the release if needed.
5. A new release object is created for the new bugfix version on the `autorelease/$BUGFIX_VERSION` branch that was just created.  This also creates the `$BUGFIX_VERSION` tag on the branch. ([example](https://github.com/phargogh/invest/releases/tag/3.8.14))
6. A new issue is created in the issue tracker with a reminder to submit the built python packages to PyPI. ([example](https://github.com/phargogh/invest/issues/38))
7. A new Pull Request is opened between `autorelease/$BUGFIX_VERSION` and `master` that includes the changes and a pile of explanatory text about what to do when things go wrong. ([example](https://github.com/phargogh/invest/pull/39))

### On bugfix release errors
While I've taken care to handle most of the kind of ambiguous errors I encountered when developing this workflow, it's very possible that some other errors will arise.  If any part of the release logic above fails, a slack message will be issued to our slack workspace ([example](https://stanford-natcap.slack.com/archives/CUNTH5DPF/p1587153748000100)) to notify us of the failure.

Errors when building the python/binary distributions are not reported in the same way.

### On bugfix release success
If a new bugfix release is created, we'll be notified in the slack channel as well, only the notifications will be in the form of 1) commits pushed to `autorelease/$BUGFIX_VERSION` 2) the `$BUGFIX_VERSION` release created, and 3) the new issue about posting to PyPI.

In response to the release object being created, 2 new build jobs are triggered:

1. Python distributions (a source distribution as well as various platform-specific wheels) are built and uploaded to the new release object.
2. Windows and Mac application binaries are built and uploaded to the new release object.

All of the above builds also archive their own artifacts AND ALSO upload to the releases bucket, so if an upload to the release happens to fail, there are multiple ways to retrieve the artifacts.

Tests are not retriggered by a release.

## Required setup

There are several new pieces of setup to allow this automation to take place, all of which have already been enacted on `natcap/invest`:

1. Branch restrictions must be relaxed to allow pushes to `autorelease/*`.
2. A new secret must be created, `USER_AUTH_TOKEN` with the `public_repo` OAuth scope to enable the release creation to trigger workflows.

## Relevant changes to existing InVEST components

While working on this, it became necessary to make a few improvements to some of our build infrastructure.  These include:

1. The binary workflow has been rejiggered a bit:
    1. Sample data zipfiles are now generated by a separate workflow job to help cut down build time in the Windows build.
    2. Binary artifacts are uploaded to the release only after the binary jobs are finished.
2. A new `Makefile` recipe has been added to nicely extract specific parameter values.
3. `make deploy` will now deploy whatever build targets are found in `dist/`, rather than some OS-specific configuration of files. 