### PR TITLE
Bugfix/finfish 87 remove matplotlib

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,8 @@
 
 Unreleased Changes
 ------------------
-* The Finfish Aquaculture model know longer generates histograms for
-  uncertainity analysis due to issues with matplotlib that make invest
+* The Finfish Aquaculture model no longer generates histograms for
+  uncertainity analysis due to issues with matplotlib that make InVEST
   unstable. See https://github.com/natcap/invest/issues/87 for more.
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Unreleased Changes
 ------------------
+* The Finfish Aquaculture model know longer generates histograms for
+  uncertainity analysis due to issues with matplotlib that make invest
+  unstable. See https://github.com/natcap/invest/issues/87 for more.
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its
   neighbors.  Note that for ease of debugging, this has been implemented as a

--- a/doc/api-docs/installing.rst
+++ b/doc/api-docs/installing.rst
@@ -40,7 +40,7 @@ Ubuntu & Debian
 
 ::
 
-    $ sudo apt-get install python3-dev python3-setuptools python3-gdal python3-rtree python3-shapely python3-matplotlib
+    $ sudo apt-get install python3-dev python3-setuptools python3-gdal python3-rtree python3-shapely
 
 
 Fedora
@@ -48,7 +48,7 @@ Fedora
 
 ::
 
-    $ sudo yum install python3-devel python3-setuptools python3-gdal python3-rtree python3-shapely python3-matplotlib
+    $ sudo yum install python3-devel python3-setuptools python3-gdal python3-rtree python3-shapely
 
 .. _InstallingOnMac:
 
@@ -58,9 +58,9 @@ Mac OS X
 The easiest way to install binary packages on Mac OS X is through a package
 manager such as `Homebrew <http://brew.sh>`_::
 
-    $ brew install gdal spatialindex pyqt matplotlib
+    $ brew install gdal spatialindex pyqt
 
-The GDAL, PyQt and matplotlib packages include their respective python packages.
+The GDAL and PyQt packages include their respective python packages.
 The others will allow their corresponding python packages to be compiled
 against these binaries via ``pip``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,5 @@ pygeoprocessing>=1.9.2
 taskgraph[niced_processes]>=0.8.2
 psutil>=5.6.6
 chardet>=3.0.4
-matplotlib
 xlrd>=1.2.0
 xlwt

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -544,7 +544,6 @@ class AboutDialog(QtWidgets.QDialog):
         for lib_name, lib_license, lib_homepage in [
                 ('PyInstaller', 'GPL', 'http://pyinstaller.org'),
                 ('GDAL', 'MIT and others', 'http://gdal.org'),
-                ('matplotlib', 'BSD', 'http://matplotlib.org'),
                 ('numpy', 'BSD', 'http://numpy.org'),
                 ('pyamg', 'BSD', 'http://github.com/pyamg/pyamg'),
                 ('pygeoprocessing', 'BSD',

--- a/tests/test_finfish.py
+++ b/tests/test_finfish.py
@@ -14,6 +14,13 @@ REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data',
     'aquaculture')
 
+EXPECTED_FILE_LIST = [
+    'output/Finfish_Harvest.dbf',
+    'output/Finfish_Harvest.prj',
+    'output/Finfish_Harvest.shp',
+    'output/Finfish_Harvest.shx',
+    'output/Harvest_Results.html']
+
 
 def _make_harvest_shp(workspace_dir):
     """Within workspace, make an output folder with dummy Finfish_Harvest.shp.
@@ -74,10 +81,8 @@ class FinfishTests(unittest.TestCase):
         _make_harvest_shp(self.workspace_dir)  # to test if it's recreated
 
         natcap.invest.finfish_aquaculture.finfish_aquaculture.execute(args)
-
         FinfishTests._test_same_files(
-            os.path.join(REGRESSION_DATA, 'expected_file_list.txt'),
-            args['workspace_dir'])
+            EXPECTED_FILE_LIST, args['workspace_dir'])
         pygeoprocessing.testing.assert_vectors_equal(
             os.path.join(REGRESSION_DATA, 'Finfish_Harvest.shp'),
             os.path.join(self.workspace_dir, 'output', 'Finfish_Harvest.shp'), 1E-6)
@@ -93,20 +98,18 @@ class FinfishTests(unittest.TestCase):
         natcap.invest.finfish_aquaculture.finfish_aquaculture.execute(args)
 
         FinfishTests._test_same_files(
-            os.path.join(
-                REGRESSION_DATA, 'expected_file_list_no_valuation.txt'),
-            args['workspace_dir'])
+            EXPECTED_FILE_LIST, args['workspace_dir'])
         pygeoprocessing.testing.assert_vectors_equal(
             os.path.join(REGRESSION_DATA, 'Finfish_Harvest_no_valuation.shp'),
             os.path.join(self.workspace_dir, 'output', 'Finfish_Harvest.shp'), 1E-6)
 
     @staticmethod
-    def _test_same_files(base_list_path, directory_path):
-        """Assert files in `base_list_path` are in `directory_path`.
+    def _test_same_files(base_path_list, directory_path):
+        """Assert files in `base_path_list` are in `directory_path`.
 
         Parameters:
-            base_list_path (string): a path to a file that has one relative
-                file path per line.
+            base_path_list (list): list of strings which are relative
+                file paths.
             directory_path (string): a path to a directory whose contents will
                 be checked against the files listed in `base_list_file`
 
@@ -118,19 +121,18 @@ class FinfishTests(unittest.TestCase):
                 that don't exist in the directory indicated by `path`
         """
         missing_files = []
-        with open(base_list_path, 'r') as file_list:
-            for file_path in file_list:
-                full_path = os.path.join(
-                    directory_path,
-                    file_path.rstrip().replace('\\', os.path.sep))
-                if full_path == '':
-                    continue
-                if not os.path.isfile(full_path):
-                    missing_files.append(full_path)
+        for file_path in base_path_list:
+            full_path = os.path.join(
+                directory_path,
+                file_path.rstrip().replace('//', os.path.sep))
+            if full_path == '':
+                continue
+            if not os.path.isfile(full_path):
+                missing_files.append(full_path)
         if len(missing_files) > 0:
             raise AssertionError(
                 "The following files were expected but not found: " +
-                '\n'.join(missing_files))
+                '/n'.join(missing_files))
 
 
 class FinfishValidationTests(unittest.TestCase):


### PR DESCRIPTION
This PR removes the matplotlib dependency from invest. It was only used in the finfish model. It's functionality is not replaced with anything else -- we're just no longer generating plots as part of that model.