### PR TITLE
Task/tests 84 tests on macos

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,7 +70,8 @@ jobs:
                   path: data/invest-test-data
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
-            - name: Set up python
+            - name: Set up Windows python
+              if: matrix.os == 'windows-latest'
               uses: actions/setup-python@v1
               with:
                 python-version: ${{ matrix.python-version }}
@@ -87,7 +88,7 @@ jobs:
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
 
-            - name: Install dependencies MacOS
+            - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
               uses: goanpeca/setup-miniconda@v1.1.2
               with:
@@ -98,6 +99,9 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   conda-channels: defaults
                   channels: conda-forge, anaconda
+            
+            - name: Install dependencies MacOS
+              if: matrix.os != 'windows-latest'
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,8 +104,10 @@ jobs:
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools
-                  conda install Cython requests
-                  make env
+                  conda install Cython requests numpy
+                  python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
+                  conda env update --file requirements-all.yml
+                  python setup.py install
 
             - name: Run model tests
               run: make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,7 +96,6 @@ jobs:
                   activate-environment: pyenv
                   auto-update-conda: true 
                   python-version: ${{ matrix.python-version }}
-                  python-version: ${{ matrix.python-version }}
                   conda-channels: defaults
                   channels: conda-forge, anaconda
             

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,9 @@ jobs:
                 python-version: [3.6, 3.7]
                 python-architecture: [x86, x64]
                 os: [windows-latest, macos-latest]
+                exclude:
+                    - os: macos-latest
+                      python-arch: x86
 
         steps:
             - uses: actions/checkout@v2
@@ -86,7 +89,20 @@ jobs:
 
             - name: Install dependencies MacOS
               if: matrix.os != 'windows-latest'
-              run: make env
+              uses: goanpeca/setup-miniconda@v1.1.2
+                  with:
+                      update-conda: false
+                      activate-environment: pyenv
+                      auto-update-conda: true 
+                      python-version: ${{ matrix.python-version }}
+                      python-version: ${{ matrix.python-version }}
+                      conda-channels: defaults
+                      channels: conda-forge, anaconda
+              shell: bash -l {0}
+              run: |
+                  conda upgrade -y pip setuptools
+                  conda install Cython requests
+                  make env
 
             - name: Run model tests
               run: make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
               uses: goanpeca/setup-miniconda@v1.1.2
               with:
                   update-conda: false
-                  activate-environment: pyenv
+                  activate-environment: env
                   auto-update-conda: true 
                   python-version: ${{ matrix.python-version }}
                   conda-channels: defaults

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,10 +108,12 @@ jobs:
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
+                  which python
 
             - name: Run model tests
               run: |
-                make PYTHON=python test
+                  which python
+                  make PYTHON=python test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,6 +87,7 @@ jobs:
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
+                  make test
 
             - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
@@ -108,9 +109,10 @@ jobs:
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
+                  make test
 
-            - name: Run model tests
-              run: make test
+            # - name: Run model tests
+            #   run: make test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,11 +83,11 @@ jobs:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
                   PIP_PREFER_BINARY: 1
-                  PYTHON: $(where python)
               run: |
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
+                  echo ::set-env name=PYTHON::$(where python)
 
             - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
@@ -103,20 +103,17 @@ jobs:
             - name: Install dependencies MacOS
               if: matrix.os != 'windows-latest'
               shell: bash -l {0}
-              env:
-                  PYTHON: $(which python)
               run: |
                   conda upgrade -y pip setuptools
                   conda install Cython requests numpy
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
+                  echo ::set-env name=PYTHON::$(which python)
 
             - name: Run model tests
               run: |
-                echo $PYTHON
-                echo "$PYTHON"
-                make PYTHON="$PYTHON" test
+                make PYTHON=$PYTHON test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,11 +83,11 @@ jobs:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
                   PIP_PREFER_BINARY: 1
+                  PYTHON: $(where python)
               run: |
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
-                  echo ::set-env name=PYTHON::$(where python)
 
             - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
@@ -103,17 +103,17 @@ jobs:
             - name: Install dependencies MacOS
               if: matrix.os != 'windows-latest'
               shell: bash -l {0}
+              env:
+                  PYTHON: $(which python)
               run: |
                   conda upgrade -y pip setuptools
                   conda install Cython requests numpy
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
-                  echo ::set-env name=PYTHON::$(which python)
 
             - name: Run model tests
               run: |
-                echo $PYTHON
                 make PYTHON=$PYTHON test
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,6 @@ jobs:
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
-                  echo ::set-env name=PYTHON::$(where python)
 
             - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
@@ -109,11 +108,10 @@ jobs:
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
-                  echo ::set-env name=PYTHON::$(which python)
 
             - name: Run model tests
               run: |
-                make test
+                make PYTHON=python test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,7 @@ jobs:
             - name: Run model tests
               run: |
                 echo $PYTHON
-                make test
+                make PYTHON=$PYTHON test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,11 +92,9 @@ jobs:
               if: matrix.os != 'windows-latest'
               uses: goanpeca/setup-miniconda@v1.1.2
               with:
-                  update-conda: false
                   activate-environment: env
                   auto-update-conda: true 
                   python-version: ${{ matrix.python-version }}
-                  conda-channels: defaults
                   channels: conda-forge, anaconda
             
             - name: Install dependencies MacOS
@@ -110,12 +108,13 @@ jobs:
                   python setup.py install
                   which python
 
-            - name: Run model tests
+            - name: Run model tests on MacOS
               if: matrix.os != 'windows-latest'
               run: |
+                  which python
                   make PYTHON="/usr/local/miniconda/envs/env/bin/python" test
 
-            - name: Run model tests
+            - name: Run model tests on Windows
               if: matrix.os == 'windows-latest'
               run: |
                   make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
                   PIP_PREFER_BINARY: 1
-                  PYTHON: $(where python)
+                  PYTHON: ${{(where python)}}
               run: |
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
@@ -104,7 +104,7 @@ jobs:
               if: matrix.os != 'windows-latest'
               shell: bash -l {0}
               env:
-                  PYTHON: $(which python)
+                  PYTHON: ${{(which python)}}
               run: |
                   conda upgrade -y pip setuptools
                   conda install Cython requests numpy
@@ -114,7 +114,10 @@ jobs:
 
             - name: Run model tests
               run: |
-                make PYTHON=$PYTHON test
+                echo $PYTHON
+                echo "$PYTHON"
+                echo ${{ PYTHON }}
+                make PYTHON="$PYTHON" test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,9 +111,14 @@ jobs:
                   which python
 
             - name: Run model tests
+              if: matrix.os != 'windows-latest'
               run: |
-                  which python
-                  make PYTHON=python test
+                  make PYTHON="/usr/local/miniconda/envs/env/bin/python" test
+
+            - name: Run model tests
+              if: matrix.os == 'windows-latest'
+              run: |
+                  make test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
             matrix:
                 python-version: [3.6, 3.7]
                 python-architecture: [x86, x64]
-                os: [windows-latest]
+                os: [windows-latest, macos-latest]
 
         steps:
             - uses: actions/checkout@v2
@@ -73,7 +73,8 @@ jobs:
                 python-version: ${{ matrix.python-version }}
                 architecture: ${{ matrix.python-architecture }}
 
-            - name: Install dependencies
+            - name: Install dependencies Windows
+              if: matrix.os == 'windows-latest'
               env:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
@@ -83,8 +84,13 @@ jobs:
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
 
+            - name: Install dependencies MacOS
+              if: matrix.os != 'windows-latest'
+              run: make env
+
             - name: Run model tests
               run: make test
+
 
     validate-sampledata:
         name: "Validate sample datastacks"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,14 +90,14 @@ jobs:
             - name: Install dependencies MacOS
               if: matrix.os != 'windows-latest'
               uses: goanpeca/setup-miniconda@v1.1.2
-                  with:
-                      update-conda: false
-                      activate-environment: pyenv
-                      auto-update-conda: true 
-                      python-version: ${{ matrix.python-version }}
-                      python-version: ${{ matrix.python-version }}
-                      conda-channels: defaults
-                      channels: conda-forge, anaconda
+              with:
+                  update-conda: false
+                  activate-environment: pyenv
+                  auto-update-conda: true 
+                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.python-version }}
+                  conda-channels: defaults
+                  channels: conda-forge, anaconda
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,7 +83,7 @@ jobs:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
                   PIP_PREFER_BINARY: 1
-                  PYTHON: ${{(where python)}}
+                  PYTHON: $(where python)
               run: |
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
@@ -104,7 +104,7 @@ jobs:
               if: matrix.os != 'windows-latest'
               shell: bash -l {0}
               env:
-                  PYTHON: ${{(which python)}}
+                  PYTHON: $(which python)
               run: |
                   conda upgrade -y pip setuptools
                   conda install Cython requests numpy

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,7 +116,6 @@ jobs:
               run: |
                 echo $PYTHON
                 echo "$PYTHON"
-                echo ${{ PYTHON }}
                 make PYTHON="$PYTHON" test
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
 
             - name: Run model tests
               run: |
-                make PYTHON=$PYTHON test
+                make test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
                   python -m pip install --upgrade pip nose setuptools
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
-                  make test
+                  echo ::set-env name=PYTHON::$(where python)
 
             - name: Set up MacOS python
               if: matrix.os != 'windows-latest'
@@ -109,10 +109,12 @@ jobs:
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install
-                  make test
+                  echo ::set-env name=PYTHON::$(which python)
 
-            # - name: Run model tests
-            #   run: make test
+            - name: Run model tests
+              run: |
+                echo $PYTHON
+                make test
 
 
     validate-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
                 os: [windows-latest, macos-latest]
                 exclude:
                     - os: macos-latest
-                      python-arch: x86
+                      python-architecture: x86
 
         steps:
             - uses: actions/checkout@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,9 @@
 
 Unreleased Changes
 ------------------
+* The Finfish Aquaculture model know longer generates histograms for
+  uncertainity analysis due to issues with matplotlib that make invest
+  unstable. See https://github.com/natcap/invest/issues/87 for more.
 * Fixing an issue with SDR's ``LS`` calculations.  The ``x`` term is now
   the weighted mean of proportional flow from the current pixel into its
   neighbors.  Note that for ease of debugging, this has been implemented as a

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -10,15 +10,15 @@ import urllib.request
 import tempfile
 import shutil
 
+import shapely
+import shapely.geometry
+import shapely.wkt
+import shapely.prepared
 import rtree
 import Pyro4
 from osgeo import ogr
 from osgeo import gdal
 from osgeo import osr
-import shapely
-import shapely.geometry
-import shapely.wkt
-import shapely.prepared
 import pygeoprocessing
 import numpy
 import numpy.linalg

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -544,7 +544,6 @@ class AboutDialog(QtWidgets.QDialog):
         for lib_name, lib_license, lib_homepage in [
                 ('PyInstaller', 'GPL', 'http://pyinstaller.org'),
                 ('GDAL', 'MIT and others', 'http://gdal.org'),
-                ('matplotlib', 'BSD', 'http://matplotlib.org'),
                 ('numpy', 'BSD', 'http://numpy.org'),
                 ('pyamg', 'BSD', 'http://github.com/pyamg/pyamg'),
                 ('pygeoprocessing', 'BSD',

--- a/tests/test_finfish.py
+++ b/tests/test_finfish.py
@@ -14,6 +14,13 @@ REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data',
     'aquaculture')
 
+EXPECTED_FILE_LIST = [
+    'output/Finfish_Harvest.dbf',
+    'output/Finfish_Harvest.prj',
+    'output/Finfish_Harvest.shp',
+    'output/Finfish_Harvest.shx',
+    'output/Harvest_Results.html']
+
 
 def _make_harvest_shp(workspace_dir):
     """Within workspace, make an output folder with dummy Finfish_Harvest.shp.
@@ -74,10 +81,8 @@ class FinfishTests(unittest.TestCase):
         _make_harvest_shp(self.workspace_dir)  # to test if it's recreated
 
         natcap.invest.finfish_aquaculture.finfish_aquaculture.execute(args)
-
         FinfishTests._test_same_files(
-            os.path.join(REGRESSION_DATA, 'expected_file_list.txt'),
-            args['workspace_dir'])
+            EXPECTED_FILE_LIST, args['workspace_dir'])
         pygeoprocessing.testing.assert_vectors_equal(
             os.path.join(REGRESSION_DATA, 'Finfish_Harvest.shp'),
             os.path.join(self.workspace_dir, 'output', 'Finfish_Harvest.shp'), 1E-6)
@@ -93,20 +98,18 @@ class FinfishTests(unittest.TestCase):
         natcap.invest.finfish_aquaculture.finfish_aquaculture.execute(args)
 
         FinfishTests._test_same_files(
-            os.path.join(
-                REGRESSION_DATA, 'expected_file_list_no_valuation.txt'),
-            args['workspace_dir'])
+            EXPECTED_FILE_LIST, args['workspace_dir'])
         pygeoprocessing.testing.assert_vectors_equal(
             os.path.join(REGRESSION_DATA, 'Finfish_Harvest_no_valuation.shp'),
             os.path.join(self.workspace_dir, 'output', 'Finfish_Harvest.shp'), 1E-6)
 
     @staticmethod
-    def _test_same_files(base_list_path, directory_path):
-        """Assert files in `base_list_path` are in `directory_path`.
+    def _test_same_files(base_path_list, directory_path):
+        """Assert files in `base_path_list` are in `directory_path`.
 
         Parameters:
-            base_list_path (string): a path to a file that has one relative
-                file path per line.
+            base_path_list (list): list of strings which are relative
+                file paths.
             directory_path (string): a path to a directory whose contents will
                 be checked against the files listed in `base_list_file`
 
@@ -118,19 +121,18 @@ class FinfishTests(unittest.TestCase):
                 that don't exist in the directory indicated by `path`
         """
         missing_files = []
-        with open(base_list_path, 'r') as file_list:
-            for file_path in file_list:
-                full_path = os.path.join(
-                    directory_path,
-                    file_path.rstrip().replace('\\', os.path.sep))
-                if full_path == '':
-                    continue
-                if not os.path.isfile(full_path):
-                    missing_files.append(full_path)
+        for file_path in base_path_list:
+            full_path = os.path.join(
+                directory_path,
+                file_path.rstrip().replace('//', os.path.sep))
+            if full_path == '':
+                continue
+            if not os.path.isfile(full_path):
+                missing_files.append(full_path)
         if len(missing_files) > 0:
             raise AssertionError(
                 "The following files were expected but not found: " +
-                '\n'.join(missing_files))
+                '/n'.join(missing_files))
 
 
 class FinfishValidationTests(unittest.TestCase):

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -318,6 +318,7 @@ class TestRecServer(unittest.TestCase):
             os.path.join(REGRESSION_DATA, 'file_list_empty_local_server.txt'),
             self.workspace_dir)
 
+    @_timeout(30.0)
     def test_local_aggregate_points(self):
         """Recreation test single threaded local AOI aggregate calculation."""
         from natcap.invest.recreation import recmodel_server

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -13,6 +13,8 @@ import logging
 import json
 import queue
 
+import psutil
+
 import Pyro4
 import pygeoprocessing
 import pygeoprocessing.testing
@@ -269,6 +271,8 @@ class TestRecServer(unittest.TestCase):
         """Recreation test a client call to simple server."""
         from natcap.invest.recreation import recmodel_server
         from natcap.invest.recreation import recmodel_client
+        print('After Imports')
+        print(psutil.Process().open_files())
 
         empty_point_data_path = os.path.join(
             self.workspace_dir, 'empty_table.csv')
@@ -296,6 +300,8 @@ class TestRecServer(unittest.TestCase):
             target=recmodel_server.execute, args=(server_args,))
         server_thread.daemon = True
         server_thread.start()
+        print('After Thread Start')
+        print(psutil.Process().open_files())
 
         client_args = {
             'aoi_path': os.path.join(
@@ -311,6 +317,8 @@ class TestRecServer(unittest.TestCase):
             'workspace_dir': self.workspace_dir,
         }
         recmodel_client.execute(client_args)
+        print('After Execute')
+        print(psutil.Process().open_files())
 
         # testing for file existence seems reasonable since mostly we are
         # testing that a local server starts and a client connects to it

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -13,8 +13,6 @@ import logging
 import json
 import queue
 
-import psutil
-
 import Pyro4
 import pygeoprocessing
 import pygeoprocessing.testing
@@ -271,8 +269,6 @@ class TestRecServer(unittest.TestCase):
         """Recreation test a client call to simple server."""
         from natcap.invest.recreation import recmodel_server
         from natcap.invest.recreation import recmodel_client
-        print('After Imports')
-        print(psutil.Process().open_files())
 
         empty_point_data_path = os.path.join(
             self.workspace_dir, 'empty_table.csv')
@@ -300,8 +296,6 @@ class TestRecServer(unittest.TestCase):
             target=recmodel_server.execute, args=(server_args,))
         server_thread.daemon = True
         server_thread.start()
-        print('After Thread Start')
-        print(psutil.Process().open_files())
 
         client_args = {
             'aoi_path': os.path.join(
@@ -317,8 +311,6 @@ class TestRecServer(unittest.TestCase):
             'workspace_dir': self.workspace_dir,
         }
         recmodel_client.execute(client_args)
-        print('After Execute')
-        print(psutil.Process().open_files())
 
         # testing for file existence seems reasonable since mostly we are
         # testing that a local server starts and a client connects to it


### PR DESCRIPTION
This PR adds github Actions jobs for model tests on Python 3.6 and Python 3.7 on macos-latest. 

There are a handful of failing tests right now, but I think I would like to address that in separate issues for those models, rather than adding fixes as part of this PR. Those failures all reproduce on ubuntu as well.