### PR TITLE
Adding MacOS to the matrix for running model tests.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,6 +109,7 @@ jobs:
 
             - name: Run model tests on MacOS
               if: matrix.os != 'windows-latest'
+              shell: bash -l {0}
               run: |
                   which python
                   make PYTHON="/usr/local/miniconda/envs/env/bin/python" test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,10 @@ jobs:
             matrix:
                 python-version: [3.6, 3.7]
                 python-architecture: [x86, x64]
-                os: [windows-latest]
+                os: [windows-latest, macos-latest]
+                exclude:
+                    - os: macos-latest
+                      python-architecture: x86
 
         steps:
             - uses: actions/checkout@v2
@@ -67,13 +70,15 @@ jobs:
                   path: data/invest-test-data
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
-            - name: Set up python
+            - name: Set up Windows python
+              if: matrix.os == 'windows-latest'
               uses: actions/setup-python@v1
               with:
                 python-version: ${{ matrix.python-version }}
                 architecture: ${{ matrix.python-architecture }}
 
-            - name: Install dependencies
+            - name: Install dependencies Windows
+              if: matrix.os == 'windows-latest'
               env:
                   PIP_EXTRA_INDEX_URL: "http://pypi.naturalcapitalproject.org/simple/"
                   PIP_TRUSTED_HOST: "pypi.naturalcapitalproject.org"
@@ -83,8 +88,36 @@ jobs:
                   python -m pip install -r requirements.txt -r requirements-dev.txt
                   python setup.py install
 
-            - name: Run model tests
-              run: make test
+            - name: Set up MacOS python
+              if: matrix.os != 'windows-latest'
+              uses: goanpeca/setup-miniconda@v1.1.2
+              with:
+                  activate-environment: env
+                  auto-update-conda: true 
+                  python-version: ${{ matrix.python-version }}
+                  channels: conda-forge, anaconda
+            
+            - name: Install dependencies MacOS
+              if: matrix.os != 'windows-latest'
+              shell: bash -l {0}
+              run: |
+                  conda upgrade -y pip setuptools
+                  conda install Cython requests numpy
+                  python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
+                  conda env update --file requirements-all.yml
+                  python setup.py install
+
+            - name: Run model tests on MacOS
+              if: matrix.os != 'windows-latest'
+              run: |
+                  which python
+                  make PYTHON="/usr/local/miniconda/envs/env/bin/python" test
+
+            - name: Run model tests on Windows
+              if: matrix.os == 'windows-latest'
+              run: |
+                  make test
+
 
     validate-sampledata:
         name: "Validate sample datastacks"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,18 +107,10 @@ jobs:
                   conda env update --file requirements-all.yml
                   python setup.py install
 
-            - name: Run model tests on MacOS
-              if: matrix.os != 'windows-latest'
+            - name: Run model tests
               shell: bash -l {0}
               run: |
-                  which python
-                  make PYTHON="/usr/local/miniconda/envs/env/bin/python" test
-
-            - name: Run model tests on Windows
-              if: matrix.os == 'windows-latest'
-              run: |
                   make test
-
 
     validate-sampledata:
         name: "Validate sample datastacks"


### PR DESCRIPTION
This PR adds github Actions jobs for model tests on Python 3.6 and Python 3.7 on macos-latest.

There are a handful of failing tests right now, but I think I would like to address that in separate issues for those models, rather than adding fixes as part of this PR. Those failures all reproduce on ubuntu as well.