### PR TITLE
Bugfix/98 update compiler flags osx catalina

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,16 +93,16 @@ jobs:
               uses: goanpeca/setup-miniconda@v1.1.2
               with:
                   activate-environment: env
-                  auto-update-conda: true 
+                  auto-update-conda: true
                   python-version: ${{ matrix.python-version }}
                   channels: conda-forge, anaconda
-            
+
             - name: Install dependencies MacOS
               if: matrix.os != 'windows-latest'
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools
-                  conda install Cython requests numpy
+                  conda install Cython requests numpy zlib
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,7 +102,7 @@ jobs:
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools
-                  conda install Cython requests numpy zlib
+                  conda install Cython requests numpy "gdal=2.4.2"
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,7 +102,7 @@ jobs:
               shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools
-                  conda install Cython requests numpy "gdal=2.4.2"
+                  conda install Cython requests numpy
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
                   python setup.py install

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,7 @@
 
 Unreleased Changes
 ------------------
+* Fixed a compilation issue on Mac OS X Catalina.
 * Fixed minor bug in Coastal Vulnerability shore point creation. Also added a
   check to fail fast when zero shore points are found within the AOI.
 * The Finfish Aquaculture model no longer generates histograms for

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-"""setup.py module for natcap.invest
+# encoding=UTF-8
+"""setup.py module for natcap.invest.
 
 InVEST - Integrated Valuation of Ecosystem Services and Tradeoffs
 
@@ -7,6 +8,8 @@ Common functionality provided by setup.py:
 
 For other commands, try `python setup.py --help-commands`
 """
+import platform
+
 from setuptools.extension import Extension
 from setuptools import setup
 import Cython.Build
@@ -17,10 +20,12 @@ import numpy
 # non-comment, non-environment-specifier contents.
 _REQUIREMENTS = [req.split(';')[0].split('#')[0].strip() for req in
                  open('requirements.txt').readlines()
-                 if not req.startswith(('#', 'hg+', 'git+')) and len(req.strip()) > 0]
+                 if (not req.startswith(('#', 'hg+', 'git+'))
+                     and len(req.strip()) > 0)]
 _GUI_REQUIREMENTS = [req.split(';')[0].split('#')[0].strip() for req in
                      open('requirements-gui.txt').readlines()
-                     if not req.startswith(('#', 'hg+')) and len(req.strip()) > 0]
+                     if not (req.startswith(('#', 'hg+'))
+                             and len(req.strip()) > 0)]
 README = open('README_PYTHON.rst').read().format(
     requirements='\n'.join(['    ' + r for r in _REQUIREMENTS]))
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,13 @@ _GUI_REQUIREMENTS = [req.split(';')[0].split('#')[0].strip() for req in
 README = open('README_PYTHON.rst').read().format(
     requirements='\n'.join(['    ' + r for r in _REQUIREMENTS]))
 
+# Since OSX Mavericks, the stdlib has been renamed.  So if we're on OSX, we
+# need to be sure to define which standard c++ library to use.  I don't have
+# access to a pre-Mavericks mac, so hopefully this won't break on someone's
+# older system.  Tested and it works on Mac OSX Catalina.
+compiler_and_linker_args = []
+if platform.system() == 'Darwin':
+    compiler_and_linker_args = ['-stdlib=libc++']
 
 setup(
     name='natcap.invest',


### PR DESCRIPTION
This PR adds a compilation flag for `setup.py` that updates the location of the standard C++ library that was moved on Mac OS X Catalina.