### PR TITLE
Using the compiler/linker args defined on mac.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup(
             sources=[
                 'src/natcap/invest/recreation/out_of_core_quadtree.pyx'],
             include_dirs=[numpy.get_include()],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++"),
         Extension(
             name="natcap.invest.scenic_quality.viewshed",
@@ -99,21 +101,32 @@ setup(
                 'src/natcap/invest/scenic_quality/viewshed.pyx'],
             include_dirs=[numpy.get_include(),
                           'src/natcap/invest/scenic_quality'],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++"),
         Extension(
             name="natcap.invest.ndr.ndr_core",
             sources=['src/natcap/invest/ndr/ndr_core.pyx'],
             include_dirs=[numpy.get_include()],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++"),
         Extension(
             name="natcap.invest.sdr.sdr_core",
             sources=['src/natcap/invest/sdr/sdr_core.pyx'],
             include_dirs=[numpy.get_include()],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++"),
         Extension(
-            name="natcap.invest.seasonal_water_yield.seasonal_water_yield_core",
-            sources=['src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx'],
+            name=("natcap.invest.seasonal_water_yield."
+                  "seasonal_water_yield_core"),
+            sources=[
+                ("src/natcap/invest/seasonal_water_yield/"
+                 "seasonal_water_yield_core.pyx")],
             include_dirs=[numpy.get_include()],
+            extra_compile_args=compiler_and_linker_args,
+            extra_link_args=compiler_and_linker_args,
             language="c++"),
     ],
     cmdclass={'build_ext': Cython.Build.build_ext},


### PR DESCRIPTION
This PR changes `setup.py` to actually use the compiler and linker flags that are set when on mac.  It fixes the issue locally.

Also there's some lite PEP8ing.

Fixes #109