### PR TITLE
Bugfix/103 mac not reading ansi csv

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -51,6 +51,8 @@ Unreleased Changes
   ``basestring``, ``unicode``, ``six``, unicode casting, etc...
 * Update api-docs conf file to mock sdr.sdr_core and to use updated unittest
   mock
+* InVEST's CSV encoding requirements are now described in the validation
+  error message displayed when a CSV cannot be opened.
 
 3.8.0 (2020-02-07)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 92206b9a9fff0aa975adf5bcddfaa3347b20f857
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := 62f9fb6c14459d501f21acc5342cf2fa70ac8b80
+GIT_UG_REPO_REV              := 7e6ed574cbdcc24199e57fa48bd36fb46e460635
 
 
 ENV = env

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -1,6 +1,6 @@
 """Common validation utilities for InVEST models."""
 import ast
-import collections
+import codecs
 import inspect
 import logging
 import pprint
@@ -11,7 +11,6 @@ import importlib
 import pygeoprocessing
 import pandas
 import xlrd
-import xlwt
 from osgeo import gdal, osr
 import numpy
 
@@ -491,7 +490,7 @@ def check_boolean(value):
 def check_csv(filepath, required_fields=None, excel_ok=False):
     """Validate a table.
 
-    Parameters:
+    Args:
         filepath (string): The string filepath to the table.
         required_fields=None (list): A case-insensitive list of fieldnames that
             must exist in the table.  If None, fieldnames will not be checked.
@@ -511,7 +510,7 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
         encoding = None
         with open(filepath) as file_obj:
             first_line = file_obj.readline()
-            if first_line.startswith('\xef\xbb\xbf'):
+            if first_line.startswith(codecs.BOM_UTF8):
                 encoding = 'utf-8-sig'
         dataframe = pandas.read_csv(
             filepath, sep=None, engine='python', encoding=encoding)
@@ -522,8 +521,7 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
             except xlrd.biffh.XLRDError:
                 return "File could not be opened as a CSV or Excel file."
         else:
-            return ("File could not be opened as a CSV. "
-                    "CSV must be encoded as ASCII, UTF-8, or UTF-8-sig.")
+            return ("File could not be opened as a CSV.")
 
     if required_fields:
         fields_in_table = set([name.upper() for name in dataframe.columns])

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -525,7 +525,8 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
             except xlrd.biffh.XLRDError:
                 return "File could not be opened as a CSV or Excel file."
         else:
-            return ("File could not be opened as a CSV.")
+            return ("File could not be opened as a CSV. "
+                    "File must be encoded as a UTF-8 CSV.")
 
     if required_fields:
         fields_in_table = set([name.upper() for name in dataframe.columns])

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -508,7 +508,7 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
     try:
         # Check if the file encoding is UTF-8 BOM first
         encoding = None
-        with open(filepath) as file_obj:
+        with open(filepath, 'rb') as file_obj:
             first_line = file_obj.readline()
             if first_line.startswith(codecs.BOM_UTF8):
                 encoding = 'utf-8-sig'

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -72,7 +72,7 @@ def _evaluate_expression(expression, variable_map):
 
     The expression must be able to be evaluated as a python expression.
 
-    Parameters:
+    Args:
         expression (string): A string expression that returns a value.
         variable_map (dict): A dict mapping string variable names to their
             python object values.  This is the variable map that will be used
@@ -113,7 +113,7 @@ def _evaluate_expression(expression, variable_map):
 def get_invalid_keys(validation_warnings):
     """Get the invalid keys from a validation warnings list.
 
-    Parameters:
+    Args:
         validation_warnings (list): A list of two-tuples where the first
             item is an iterable of string args keys affected and the second
             item is a string error message.
@@ -138,7 +138,7 @@ def get_sufficient_keys(args):
         1. Present within ``args``
         2. Does not have a value of ``''`` or ``None``.
 
-    Parameters:
+    Args:
         args (dict): An args dict of string keys to serializeable values.
 
     Returns:
@@ -155,7 +155,7 @@ def get_sufficient_keys(args):
 def check_directory(dirpath, exists=False, permissions='rx'):
     """Validate a directory.
 
-    Parameters:
+    Args:
         dirpath (string): The directory path to validate.
         exists=False (bool): If ``True``, the directory at ``dirpath``
             must already exist on the filesystem.
@@ -195,7 +195,7 @@ def check_directory(dirpath, exists=False, permissions='rx'):
 def check_file(filepath, permissions='r'):
     """Validate a single file.
 
-    Parameters:
+    Args:
         filepath (string): The filepath to validate.
         permissions='r' (string): A string that includes the lowercase
             characters ``r``, ``w`` and/or ``x`` indicating required
@@ -219,7 +219,7 @@ def check_permissions(path, permissions):
 
     This function uses ``os.access`` to determine permissions access.
 
-    Parameters:
+    Args:
         path (string): The path to examine for permissions.
         permissions (string): a string including the characters ``r``, ``w``
             and/or ``x`` (lowercase), indicating read, write, and execute
@@ -241,7 +241,7 @@ def check_permissions(path, permissions):
 def _check_projection(srs, projected, projection_units):
     """Validate a GDAL projection.
 
-    Parameters:
+    Args:
         srs (osr.SpatialReference): A GDAL Spatial Reference object
             representing the spatial reference of a GDAL dataset.
         projected (bool): Whether the spatial reference must be projected in
@@ -278,7 +278,7 @@ def _check_projection(srs, projected, projection_units):
 def check_raster(filepath, projected=False, projection_units=None):
     """Validate a GDAL Raster on disk.
 
-    Parameters:
+    Args:
         filepath (string): The path to the raster on disk.  The file must exist
             and be readable.
         projected=False (bool): Whether the spatial reference must be projected
@@ -316,7 +316,7 @@ def check_raster(filepath, projected=False, projection_units=None):
 def load_fields_from_vector(filepath, layer_id=0):
     """Load fieldnames from a given vector.
 
-    Parameters:
+    Args:
         filepath (string): The path to a GDAL-compatible vector on disk.
         layer_id=0 (string or int): The identifier for the layer to use.
 
@@ -343,7 +343,7 @@ def check_vector(filepath, required_fields=None, projected=False,
         If the provided vector has multiple layers, only the first layer will
         be checked.
 
-    Parameters:
+    Args:
         filepath (string): The path to the vector on disk.  The file must exist
             and be readable.
         required_fields=None (list): The string fieldnames (case-insensitive)
@@ -390,7 +390,7 @@ def check_vector(filepath, required_fields=None, projected=False,
 def check_freestyle_string(value, regexp=None):
     """Validate an arbitrary string.
 
-    Parameters:
+    Args:
         value: The value to check.  Must be able to be cast to a string.
         regexp=None (dict): A dict representing validation parameters for a
             regular expression.  ``regexp['pattern']`` is required, and its
@@ -418,7 +418,7 @@ def check_freestyle_string(value, regexp=None):
 def check_option_string(value, options):
     """Validate that a string is in a list of options.
 
-    Parameters:
+    Args:
         value (string): The string value to test.
         options (list): A list of strings to test against.
 
@@ -434,7 +434,7 @@ def check_option_string(value, options):
 def check_number(value, expression=None):
     """Validate numbers.
 
-    Parameters:
+    Args:
         value: A python value. This should be able to be cast to a float.
         expression=None (string): A string expression to be evaluated with the
             intent of determining that the value is within a specific range.
@@ -475,7 +475,7 @@ def check_boolean(value):
     returned.
 
 
-    Parameters:
+    Args:
         value: The value to evaluate.
 
     Returns:
@@ -538,7 +538,7 @@ def check_spatial_overlap(spatial_filepaths_list,
                           different_projections_ok=False):
     """Check that the given spatial files spatially overlap.
 
-    Parameters:
+    Args:
         spatial_filepaths_list (list): A list of files that can be opened with
             GDAL.  Must be on the local filesystem.
         different_projections_ok=False (bool): Whether it's OK for the input
@@ -608,7 +608,7 @@ def validate(args, spec, spatial_overlap_opts=None):
     ``spec``.  If ``spatial_overlap_opts`` is also provided, valid spatial
     inputs will be checked for spatial overlap.
 
-    Parameters:
+    Args:
         args (dict): The InVEST model args dict to validate.
         spec (dict): The InVEST model spec dict to validate against.
         spatial_overlap_opts=None (dict): A dict.  If provided, the key

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -522,7 +522,8 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
             except xlrd.biffh.XLRDError:
                 return "File could not be opened as a CSV or Excel file."
         else:
-            return "File could not be opened as a CSV"
+            return ("File could not be opened as a CSV. "
+                    "CSV must be encoded as ASCII, UTF-8, or UTF-8-sig.")
 
     if required_fields:
         fields_in_table = set([name.upper() for name in dataframe.columns])

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -266,11 +266,12 @@ def _check_projection(srs, projected, projection_units):
         layer_units_name = srs.GetLinearUnitsName().lower()
 
         if projection_units in valid_meter_units:
-            if not layer_units_name in valid_meter_units:
+            if layer_units_name not in valid_meter_units:
                 return "Layer must be projected in meters"
         else:
             if layer_units_name.lower() != projection_units.lower():
-                return "Layer must be projected in %s" % projection_units.lower()
+                return ("Layer must be projected in %s"
+                        % projection_units.lower())
 
     return None
 
@@ -312,6 +313,7 @@ def check_raster(filepath, projected=False, projection_units=None):
 
     gdal_dataset = None
     return None
+
 
 def load_fields_from_vector(filepath, layer_id=0):
     """Load fieldnames from a given vector.
@@ -375,7 +377,8 @@ def check_vector(filepath, required_fields=None, projected=False,
 
     if required_fields:
         fieldnames = set([defn.GetName().upper() for defn in layer.schema])
-        missing_fields = set(field.upper() for field in required_fields) - fieldnames
+        missing_fields = (
+            set(field.upper() for field in required_fields) - fieldnames)
         if missing_fields:
             return "Fields are missing from the first layer: %s" % sorted(
                 missing_fields)
@@ -410,7 +413,8 @@ def check_freestyle_string(value, regexp=None):
                 flags = re.IGNORECASE
         matches = re.findall(regexp['pattern'], str(value), flags)
         if not matches:
-            return "Value did not match expected pattern %s" % regexp['pattern']
+            return ("Value did not match expected pattern %s"
+                    % regexp['pattern'])
 
     return None
 
@@ -462,7 +466,7 @@ def check_number(value, expression=None):
         # "value > 0" or "(value >= 0) & (value < 1)".  An exception will
         # be raised if asteval can't evaluate the expression.
         result = _evaluate_expression(expression, {'value': float(value)})
-        if result == False:  # A python bool object is returned.
+        if not result:  # A python bool object is returned.
             return "Value does not meet condition %s" % expression
 
     return None
@@ -708,7 +712,7 @@ def validate(args, spec, spatial_overlap_opts=None):
             if warning_msg:
                 validation_warnings.append(([key], warning_msg))
                 invalid_keys.add(key)
-        except Exception as error:
+        except Exception:
             LOGGER.exception(
                 'Error when validating key %s with value %s',
                 key, args[key])
@@ -733,7 +737,6 @@ def validate(args, spec, spatial_overlap_opts=None):
             else:
                 sufficient_inputs[key] = True
 
-    sorted_args_keys = sorted(list(sufficient_inputs.keys()))
     for key in conditionally_required_keys:
         if key in invalid_keys:
             continue
@@ -865,11 +868,13 @@ def invest_validator(validate_func):
                     validator_func = _VALIDATION_FUNCS[input_type]
 
                     try:
-                        validation_options = args_key_spec['validation_options']
+                        validation_options = (
+                            args_key_spec['validation_options'])
                     except KeyError:
                         validation_options = {}
 
-                    error_msg = validator_func(args_value, **validation_options)
+                    error_msg = (
+                        validator_func(args_value, **validation_options))
 
                 if error_msg is None:
                     warnings_ = []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -611,15 +611,15 @@ class CSVValidation(unittest.TestCase):
         from natcap.invest import validation
 
         df = pandas.DataFrame([
-            {'fØØ': 1, 'bar': 2, 'baz': 3},  # special character here.
+            {'fЮЮ': 1, 'bar': 2, 'baz': 3},  # special characters here.
             {'foo': 2, 'bar': 3, 'baz': 4},
             {'foo': 3, 'bar': 4, 'baz': 5}])
 
         target_file = os.path.join(self.workspace_dir, 'test.csv')
 
-        # This saves the CSV with the Windows Vietnamese codepage.
-        # https://en.wikipedia.org/wiki/Windows-1258
-        df.to_csv(target_file, encoding='Windows-1258')
+        # Save the CSV with the Windows Cyrillic codepage.
+        # https://en.wikipedia.org/wiki/ISO/IEC_8859-5
+        df.to_csv(target_file, encoding='iso8859_5')
 
         error_msg = validation.check_csv(target_file)
         self.assertTrue(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -607,7 +607,7 @@ class CSVValidation(unittest.TestCase):
         self.assertTrue('missing from this table' in error_msg)
 
     def test_csv_not_utf_8(self):
-        """Validation: test that we raise an error when CSV is not UTF-8."""
+        """Validation: test that non-UTF8 CSVs can validate."""
         from natcap.invest import validation
 
         df = pandas.DataFrame([
@@ -622,7 +622,7 @@ class CSVValidation(unittest.TestCase):
         df.to_csv(target_file, encoding='iso8859_5')
 
         error_msg = validation.check_csv(target_file)
-        self.assertTrue('could not be opened as a CSV' in error_msg)
+        self.assertEquals(error_msg, None)
 
     def test_excel_missing_fieldnames(self):
         """Validation: test that we can check missing fieldnames in excel."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -622,8 +622,7 @@ class CSVValidation(unittest.TestCase):
         df.to_csv(target_file, encoding='iso8859_5')
 
         error_msg = validation.check_csv(target_file)
-        self.assertTrue(
-            'must be encoded as ASCII, UTF-8, or UTF-8-sig' in error_msg)
+        self.assertTrue('could not be opened as a CSV' in error_msg)
 
     def test_excel_missing_fieldnames(self):
         """Validation: test that we can check missing fieldnames in excel."""


### PR DESCRIPTION
This PR fixes #103 (and is related to #111 ) by describing InVEST's CSV encoding requirements (UTF-8/UTF-8-SIG/ASCII) in the validation error message displayed when the table cannot be read.