### PR TITLE
Bumping pandas requirement to gte 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 
 GDAL>=2.0,<3.0
 Pyro4==4.77  # pip-only
-pandas>=0.22.0
+pandas>=1.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 scipy>=0.16.1


### PR DESCRIPTION
This simple PR bumps pandas to gte 1.0 to make sure that we are testing against pandas 1.0 API updates. 

Fixes issue #97 