### PR TITLE
Minor updates to release automation

### DIFF
--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -146,7 +146,8 @@ jobs:
                           --message "Release natcap.invest $BUGFIX_VERSION on PyPI" \
                           --message "When built, remember to upload wheels for $BUGFIX_VERSION to PyPI." \
                           --message "Wheels will be uploaded to $(cat $RELEASE_URL_FILE)" \
-                          --labels task
+                          --labels task \
+                          --assign $RELEASE_MANAGER
 
                       # Create a new pull request from the new autorelease
                       # branch back into the source branch.

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -4,6 +4,10 @@ on:
         # Noon PST on Friday of each week
         - cron: '0 20 * * 5'
 
+env:
+    # This is to be updated on a roughly monthly schedule and will rotate.
+    RELEASE_MANAGER: "phargogh"
+
 jobs:
     create-bugfix-release:
         name: Create a bugfix release
@@ -34,6 +38,7 @@ jobs:
               env:
                   SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_MANAGER: ${{ env.RELEASE_MANAGER }}
               run: |
                   # Redirecting stderr to /dev/null to keep actions logs
                   # reflecting the expected state of the program.
@@ -151,8 +156,8 @@ jobs:
                       hub pull-request \
                           --base $GITHUB_REPOSITORY:$SOURCE_BRANCH \
                           --head $GITHUB_REPOSITORY:$TARGET_BRANCH \
-                          --reviewer "$GITHUB_ACTOR" \
-                          --assign "$GITHUB_ACTOR" \
+                          --reviewer $RELEASE_MANAGER \
+                          --assign $RELEASE_MANAGER \
                           --file $PRMSG
                   fi
 

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -1,8 +1,8 @@
 name: Automated Bugfix Release
 on:
     schedule:
-        # Noon PST on Friday of each week
-        - cron: '0 20 * * 5'
+        # 9am PST on Friday of each week
+        - cron: '0 17 * * 5'
 
 env:
     # This is to be updated on a roughly monthly schedule and will rotate.

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -332,6 +332,6 @@ jobs:
                         hub release edit -a $FILE -m "" ${GITHUB_REF:10}
                     done
                     set +x
-                else:
+                else
                     echo "Release for ${GITHUB_REF:10} not found; skipping binary upload"
                 fi

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -217,6 +217,7 @@ jobs:
             - name: Deploy artifacts to GCS
               # Secrets not available in PR so don't use GCP.
               if: github.event_name != 'pull_request'
+              shell: bash -l {0}  # needed for conda activation
               run: make deploy
 
             - name: Upload binaries artifact

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -203,7 +203,7 @@ jobs:
               shell: bash -l {0}
               run: |
                   make install
-                  make mac_zipfile userguide
+                  make mac_zipfile
 
             - name: Set up GCP
               # Secrets not available in PR so don't use GCP.


### PR DESCRIPTION
This PR addresses a couple of minor issues in our automated release configuration:

* Corrects a bash syntaxerror that caused binary release uploads to fail
* The binary upload job should now upload files to the correct place (`Makefile` couldn't detect the correct version string due to an unactivated conda environment)
* A `RELEASE_MANAGER` environment variable is set along the lines of what we were talking about within @natcap/software-team about having a monthly rotating release manager.  Having this defined in the YML file keeps everything clear and in plaintext, at the cost of a PR to change the assignee.  This seemed a superior solution to defining a secret.