### PR TITLE
Task/134 check python wheels

### DIFF
--- a/.github/workflows/build-py-dists.yml
+++ b/.github/workflows/build-py-dists.yml
@@ -42,11 +42,13 @@ jobs:
             - name: Install dependencies
               shell: bash
               run: |
-                  pip install ${{ matrix.numpy }} toml
+                  pip install ${{ matrix.numpy }} toml twine
                   pip install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
 
             - name: Build wheel
-              run: python setup.py bdist_wheel
+              run: |
+                  python setup.py bdist_wheel
+                  python -m twine check dist/*
 
             - uses: actions/upload-artifact@v1
               with:
@@ -84,11 +86,13 @@ jobs:
             - name: Install python dependencies
               shell: bash
               run: |
-                pip install toml
+                pip install toml twine
                 pip install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
 
             - name: Build source distribution
-              run: python setup.py build_ext sdist
+              run: |
+                  python setup.py build_ext sdist
+                  python -m twine check dist/*
 
             - uses: actions/upload-artifact@v1
               with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 scipy>=0.16.1
 Shapely>=1.6.4,<1.7.0
-pygeoprocessing>=1.9.2,<2.0
+pygeoprocessing>=1.9.2,<2.0  # pip-only
 taskgraph[niced_processes]>=0.8.2
 psutil>=5.6.6
 chardet>=3.0.4

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     install_requires=_REQUIREMENTS,
     setup_requires=['setuptools_scm', 'numpy', 'cython'],
     license='BSD',
+    long_description_content_type='text/x-rst',
     zip_safe=False,
     keywords='gis invest',
     classifiers=[


### PR DESCRIPTION
This PR adds `python -m twine check` to the InVEST wheel distributions that are built through github actions.

All of the changes for this PR are in `.github/workflows/build-py-dists.yml`.  The other changed files were merged into this branch during development to fix a build issue and have already been merged into InVEST in PR #131 