### PR TITLE
Bugfix/171 sq too many open files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,9 +1,12 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Scenic Quality
+    * Fixing an issue in Scenic Quality where the creation of the weighted sum
+      of visibility rasters could cause "Too Many Open Files" errors and/or
+      ``MemoryError`` when the model is run with many viewpoints.
 
 3.8.4 (2020-06-05)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Unreleased Changes
     * Fixing an issue in Scenic Quality where the creation of the weighted sum
       of visibility rasters could cause "Too Many Open Files" errors and/or
       ``MemoryError`` when the model is run with many viewpoints.
+* SDR:
+    * Removed the unused parameter ``args['target_pixel_size']`` from the SDR
+      ``execute`` docstring.
 
 3.8.4 (2020-06-05)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ Unreleased Changes
     * Fixing an issue in Scenic Quality where the creation of the weighted sum
       of visibility rasters could cause "Too Many Open Files" errors and/or
       ``MemoryError`` when the model is run with many viewpoints.
+    * Progress logging has been added to several loops that may take a longer
+      time when the model is run with thousands of points at a time.
+    * A major part of the model's execution was optimized for speed,
+      particularly when the model is run with many, many points.
 * SDR:
     * Removed the unused parameter ``args['target_pixel_size']`` from the SDR
       ``execute`` docstring.

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -4,9 +4,6 @@ import math
 import logging
 import tempfile
 import shutil
-import itertools
-import heapq
-import struct
 
 import numpy
 from osgeo import gdal
@@ -311,7 +308,8 @@ def execute(args):
             geometry = point.GetGeometryRef()
             viewpoint = (geometry.GetX(), geometry.GetY())
 
-            if not _viewpoint_within_raster(viewpoint, file_registry['clipped_dem']):
+            if not _viewpoint_within_raster(
+                    viewpoint, file_registry['clipped_dem']):
                 LOGGER.info(
                     ('Feature %s in layer %s is outside of the DEM bounding '
                      'box. Skipping.'), layer_name, point.GetFID())
@@ -408,7 +406,7 @@ def execute(args):
                       viewshed_valuation_path),
                 target_path_list=[viewshed_valuation_path],
                 dependent_task_list=[viewshed_task],
-                task_name='calculate_valuation_for_viewshed_%s' % feature_index)
+                task_name=f'calculate_valuation_for_viewshed_{feature_index}')
             valuation_tasks.append(valuation_task)
             valuation_filepaths.append(viewshed_valuation_path)
 

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -464,13 +464,13 @@ def _determine_valid_viewpoints(dem_path, structures_path):
         LOGGER.info('Layer %s has %s features', layer_name,
                     structures_layer.GetFeatureCount())
 
+        radius_fieldname = None
         fieldnames = set(
             column.GetName() for column in structures_layer.schema)
-        radius_fieldname = None
-        for possible_radius_fieldname in ('RADIUS', 'RADIUS2'):
-            if possible_radius_fieldname in fieldnames:
-                radius_fieldname = possible_radius_fieldname
-                break
+        possible_radius_fieldnames = set(
+            ['RADIUS', 'RADIUS2']).intersection(fieldnames)
+        if possible_radius_fieldnames:
+            radius_fieldname = possible_radius_fieldnames.pop()
 
         height_present = False
         height_fieldname = 'HEIGHT'

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -433,7 +433,8 @@ def _determine_valid_viewpoints(dem_path, structures_path):
         LOGGER.info('Layer %s has %s features', layer_name,
                     structures_layer.GetFeatureCount())
 
-        fieldnames = set(column.GetName() for column in structures_layer.schema)
+        fieldnames = set(
+            column.GetName() for column in structures_layer.schema)
         radius_fieldname = None
         for possible_radius_fieldname in ('RADIUS', 'RADIUS2'):
             if possible_radius_fieldname in fieldnames:
@@ -516,7 +517,6 @@ def _determine_valid_viewpoints(dem_path, structures_path):
         intersecting_points = list(spatial_index.intersection(
             block_geom.bounds, objects=True))
         if len(intersecting_points) == 0:
-            import pdb; pdb.set_trace()
             continue
 
         dem_block = dem_band.ReadAsArray(**block_data)

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -304,7 +304,19 @@ def execute(args):
         LOGGER.info('Layer %s has %s features', layer_name,
                     structures_layer.GetFeatureCount())
 
+        last_log_time = time.time()
+        n_features_touched = -1
         for point in structures_layer:
+            n_features_touched += 1
+            if time.time() - last_log_time > 5.0:
+                LOGGER.info(
+                    ("Setting up viewshed calculations for layer %s, approx. "
+                     "%.2f%%complete."),
+                    layer_name,
+                    100.0*(n_features_touched /
+                           structures_layer.GetFeatureCount()))
+                last_log_time = time.time()
+
             # Coordinates in map units to pass to viewshed algorithm
             geometry = point.GetGeometryRef()
             viewpoint = (geometry.GetX(), geometry.GetY())

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -524,10 +524,10 @@ def _determine_valid_viewpoints(dem_path, structures_path):
             viewpoint = (item.bounds[0], item.bounds[2])
             metadata = item.object
             ix_viewpoint = int(
-                (viewpoint[0] - dem_gt[0]) / dem_gt[1]) - block_data['xoff']
+                (viewpoint[0] - dem_gt[0]) // dem_gt[1]) - block_data['xoff']
             iy_viewpoint = int(
-                (viewpoint[1] - dem_gt[3]) / dem_gt[5]) - block_data['yoff']
-            if dem_block[ix_viewpoint][iy_viewpoint] == dem_nodata:
+                (viewpoint[1] - dem_gt[3]) // dem_gt[5]) - block_data['yoff']
+            if dem_block[iy_viewpoint][ix_viewpoint] == dem_nodata:
                 LOGGER.info(
                     'Feature %s in layer %s is over nodata; skipping.',
                     point.GetFID(), layer_name)

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -167,7 +167,7 @@ ARGS_SPEC = {
 def execute(args):
     """Run the Scenic Quality Model.
 
-    Parameters:
+    Args:
         args['workspace_dir'] (string): (required) output directory for
             intermediate, temporary, and final files.
         args['results_suffix'] (string): (optional) string to append to any
@@ -464,7 +464,7 @@ def _clip_vector(shape_to_clip_path, binding_shape_path, output_path):
     Uses gdal.Layer.Clip() to clip a vector, where the output Layer
     inherits the projection and fields from the original.
 
-    Parameters:
+    Args:
         shape_to_clip_path (string): a path to a vector on disk. This is
             the Layer to clip. Must have same spatial reference as
             'binding_shape_path'.
@@ -514,7 +514,7 @@ def _clip_vector(shape_to_clip_path, binding_shape_path, output_path):
 def _sum_valuation_rasters(dem_path, valuation_filepaths, target_path):
     """Sum up all valuation rasters.
 
-    Parameters:
+    Args:
         dem_path (string): A path to the DEM.  Must perfectly overlap all of
             the rasters in ``valuation_filepaths``.
         valuation_filepaths (list of strings): A list of paths to individual
@@ -553,7 +553,7 @@ def _calculate_valuation(visibility_path, viewpoint, weight,
                          valuation_raster_path):
     """Calculate valuation with one of the defined methods.
 
-    Parameters:
+    Args:
         visibility_path (string): The path to a visibility raster for a single
             point.  The visibility raster has pixel values of 0, 1, or nodata.
             This raster must be projected in meters.
@@ -687,7 +687,7 @@ def _calculate_valuation(visibility_path, viewpoint, weight,
 def _viewpoint_within_raster(viewpoint, dem_path):
     """Determine if a viewpoint overlaps a DEM.
 
-    Parameters:
+    Args:
         viewpoint (tuple): A coordinate pair indicating the (x, y) coordinates
             projected in the DEM's coordinate system.
         dem_path (string): The path to a DEM raster on disk.
@@ -709,7 +709,7 @@ def _viewpoint_within_raster(viewpoint, dem_path):
 def _viewpoint_over_nodata(viewpoint, dem_path):
     """Determine if a viewpoint overlaps a nodata value within the DEM.
 
-    Parameters:
+    Args:
         viewpoint (tuple): A coordinate pair indicating the (x, y) coordinates
             projected in the DEM's coordinate system.
         dem_path (string): The path to a DEM raster on disk.
@@ -744,7 +744,7 @@ def _viewpoint_over_nodata(viewpoint, dem_path):
 def _clip_and_mask_dem(dem_path, aoi_path, target_path, working_dir):
     """Clip and mask the DEM to the AOI.
 
-    Parameters:
+    Args:
         dem_path (string): The path to the DEM to use.  Must have the same
             projection as the AOI.
         aoi_path (string): The path to the AOI to use.  Must have the same
@@ -814,7 +814,7 @@ def _count_and_weight_visible_structures(visibility_raster_path_list, weights,
                                          clipped_dem_path, target_path):
     """Count (and weight) the number of visible structures for each pixel.
 
-    Parameters:
+    Args:
         visibility_raster_path_list (list of strings): A list of strings to
             perfectly overlapping visibility rasters.
         weights (list of numbers): A list of numeric weights to apply to each
@@ -887,7 +887,7 @@ def _calculate_visual_quality(source_raster_path, working_dir, target_path):
     Visual quality is based on the nearest-rank method for breaking pixel
     values from the source raster into percentiles.
 
-    Parameters:
+    Args:
         source_raster_path (string): The path to a raster from which
             percentiles should be calculated.  Nodata values and pixel values
             of 0 are ignored.
@@ -962,7 +962,7 @@ def _calculate_visual_quality(source_raster_path, working_dir, target_path):
 def validate(args, limit_to=None):
     """Validate args to ensure they conform to ``execute``'s contract.
 
-    Parameters:
+    Args:
         args (dict): dictionary of key(str)/value pairs where keys and
             values are specified in ``execute`` docstring.
         limit_to (str): (optional) if not None indicates that validation

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -257,8 +257,6 @@ def execute(args):
             processes should be used in parallel processing. -1 indicates
             single process mode, 0 is single process but non-blocking mode,
             and >= 1 is number of processes.
-        args['target_pixel_size'] (list): requested target pixel size in
-            local projection coordinate system.
         args['biophysical_table_lucode_field'] (str): optional, if exists
             use this instead of 'lucode'.
 


### PR DESCRIPTION
This PR addresses an issue of having "too many files open" experienced by a user of our mac binaries who was running Scenic Quality with over 7000 viewpoints and the model was naively passing all 7000+ rasters to a single `raster_calculator` call.

So, this PR updates Scenic Quality to make better, more responsible use of memory and disk I/O when given large numbers of viewpoints.  Updates include:

* A refactor to the main `execute` function.  Previously, the model would iterate through every point in the viewpoints vector on every run through the model.  This looping (which also determines which points are valid viewpoints) has been refactored into a separate task (`_determine_valid_viewpoints`) in the graph to avoid that (potentially expensive) loop.
* Timed progress logging has been added to a few loops that may take some time when operating on many points.
* The task `_count_and_weight_visible_functions` has been refactored to load each block from each visibility raster in sequence rather than passing them all in to a single call to `pygeoprocessing.raster_calculator`.

There's also a bonus change to SDR that removes a bit of the `execute` docstring documenting an args key that was not actually used by the model.

Fixes #171 