### PR TITLE
Capping scipy requirement for build issues. RE:#180

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Pyro4==4.77  # pip-only
 pandas>=1.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
-scipy>=0.16.1
+scipy>=0.16.1,<1.5.0
 Shapely>=1.6.4,<1.7.0
 pygeoprocessing>=1.9.2,<2.0  # pip-only
 taskgraph[niced_processes]>=0.9.1


### PR DESCRIPTION
This PR temporarily resolves the build issues noted in #180 by capping the allowed versions of scipy until we have a chance to dig deeper into this.

I'll leave #180 open so we can remember to look into this later.