### PR TITLE
Merging Crop Production bugfix and testing updates for GDAL 3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,12 @@ Unreleased Changes (3.9)
     * ``get_raster_info`` / ``get_vector_info`` keyword ``projection`` to
       ``projection_wkt``.
 
+Unreleased Changes
+------------------
+* Crop Production
+    * Fixed critical bug in crop regression that caused incorrect yields in
+      all cases.
+
 3.8.5 (2020-06-26)
 ------------------
 * General
@@ -54,14 +60,6 @@ Unreleased Changes (3.9)
       dictionary.
     * Remove ``warn_if_missing`` argument from ``utils.build_lookup_from_csv``
       and warning by default.
-* Urban Flood Risk Mitigation
-    * Fixed an issue where the output vector ``flood_risk_service.shp`` would
-      only be created when the built infrastructure vector was provided.  Now,
-      the ``flood_risk_service.shp`` vector is always created, but the fields
-      created differ depending on whether the built infrastructure input is
-      present during the model run.
-    * Fixed an issue where the model would crash if an infrastructure geometry
-      were invalid or absent.  Such features are now skipped.
 * Scenic Quality
     * Fixing an issue in Scenic Quality where the creation of the weighted sum
       of visibility rasters could cause "Too Many Open Files" errors and/or
@@ -73,6 +71,14 @@ Unreleased Changes (3.9)
 * SDR:
     * Removed the unused parameter ``args['target_pixel_size']`` from the SDR
       ``execute`` docstring.
+* Urban Flood Risk Mitigation
+    * Fixed an issue where the output vector ``flood_risk_service.shp`` would
+      only be created when the built infrastructure vector was provided.  Now,
+      the ``flood_risk_service.shp`` vector is always created, but the fields
+      created differ depending on whether the built infrastructure input is
+      present during the model run.
+    * Fixed an issue where the model would crash if an infrastructure geometry
+      were invalid or absent.  Such features are now skipped.
 
 3.8.4 (2020-06-05)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := a280ef2cf79b7a794ebb3e8678ca27cbe37d1f5b
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 8a108c6fc1df475efc5f173c5236dc19a6ca5fb6
+GIT_TEST_DATA_REPO_REV      := 9d40692e216605df65bbf2f5d2a0943ff40c6970
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := a280ef2cf79b7a794ebb3e8678ca27cbe37d1f5b
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 8913471ecc1b91b6d9f10b5c20976ac1a5858c5f
+GIT_TEST_DATA_REPO_REV      := 8a108c6fc1df475efc5f173c5236dc19a6ca5fb6
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -572,7 +572,7 @@ def execute(args):
     LOGGER.info("Generating report table")
     result_table_path = os.path.join(
         output_dir, 'result_table%s.csv' % file_suffix)
-    tabulate_results_task = task_graph.add_task(
+    _ = task_graph.add_task(
         func=tabulate_regression_results,
         args=(nutrient_table,
               crop_to_landcover_table, pixel_area_ha,
@@ -590,7 +590,7 @@ def execute(args):
             output_dir, _AGGREGATE_VECTOR_FILE_PATTERN % (file_suffix))
         aggregate_results_table_path = os.path.join(
             output_dir, _AGGREGATE_TABLE_FILE_PATTERN % file_suffix)
-        aggregate_results_task = task_graph.add_task(
+        _ = task_graph.add_task(
             func=aggregate_regression_results_to_polygons,
             args=(args['aggregate_polygon_path'],
                   target_aggregate_vector_path,
@@ -612,18 +612,18 @@ def _x_yield_op(
     """Calc generalized yield op, Ymax*(1-b_NP*exp(-cN * N_GC)).
 
     The regression model has identical mathematical equations for
-    the nitrogen, phosporous, and potassium.  The only difference is
-    the scalars in the equation (fertizlization rate and pixel area).
+    the nitrogen, phosphorous, and potassium.  The only difference is
+    the scalars in the equation (fertilization rate and pixel area).
     """
     result = numpy.empty(b_x.shape, dtype=numpy.float32)
     result[:] = _NODATA_YIELD
     valid_mask = (
         (b_x != _NODATA_YIELD) & (c_x != _NODATA_YIELD) &
         (lulc_array == crop_lucode))
-    result[valid_mask] = y_max[valid_mask] * (
+    result[valid_mask] = pixel_area_ha * y_max[valid_mask] * (
         1 - b_x[valid_mask] * numpy.exp(
-            -c_x[valid_mask] * fert_rate) *
-        pixel_area_ha)
+            -c_x[valid_mask] * fert_rate))
+
     return result
 
 
@@ -706,7 +706,7 @@ def tabulate_regression_results(
         landcover_raster_path (string): path to landcover raster
         landcover_nodata (float): landcover raster nodata value
         output_dir (string): the file path to the output workspace.
-        file_suffix (string): string to appened to any output filenames.
+        file_suffix (string): string to append to any output filenames.
         target_table_path (string): path to 'result_table.csv' in the output
             workspace
 
@@ -808,7 +808,7 @@ def aggregate_regression_results_to_polygons(
         nutrient_table (dict): a lookup of nutrient values by crop in the
             form of nutrient_table[<crop>][<nutrient>].
         output_dir (string): the file path to the output workspace.
-        file_suffix (string): string to appened to any output filenames.
+        file_suffix (string): string to append to any output filenames.
         target_aggregate_table_path (string): path to 'aggregate_results.csv'
             in the output workspace
 


### PR DESCRIPTION
This PR resolves a conflict when merging `master` into `release/3.9` for Crop Production bugfix changes which required updating tests under GDAL 2. The tests failed under the `release` branch because GDAL 3 has slight spatial differences that affect the CSV results from crop production outputs. 

The bitbucket `invest-test-data` PR lives here: https://bitbucket.org/natcap/invest-test-data/pull-requests/13/updating-crop-tests-for-gdal-3/diff

The prior InVEST PRs this fixes for history are:
- https://github.com/natcap/invest/pull/193
- https://github.com/natcap/invest/pull/195
- https://github.com/natcap/invest/pull/196
- https://github.com/natcap/invest/pull/197