### PR TITLE
Bugfix/sdr 129 flow area cap

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,9 +42,9 @@ Unreleased Changes (3.9)
     * ``get_raster_info`` / ``get_vector_info`` keyword ``projection`` to
       ``projection_wkt``.
 * SDR:
-  * Fixing an issue where the LS factor should be capped to 333 m^2 upstream.
-    In previous versions the LS factor was erroniously capped to "333" leading
-    to high export spikes in some pixels.
+  * Fixing an issue where the LS factor should be capped to an upstream area of
+    333^2 m^2. In previous versions the LS factor was erroniously capped to
+    "333" leading to high export spikes in some pixels.
 
 Unreleased Changes
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,6 +41,10 @@ Unreleased Changes (3.9)
     * ``convolve_2d`` keyword ``ignore_nodata`` to ``ignore_nodata_and_edges``.
     * ``get_raster_info`` / ``get_vector_info`` keyword ``projection`` to
       ``projection_wkt``.
+* SDR:
+  * Fixing an issue where the LS factor should be capped to 333 m^2 upstream.
+    In previous versions the LS factor was erroniously capped to "333" leading
+    to high export spikes in some pixels.
 
 Unreleased Changes
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 scipy>=0.16.1,<1.5.0
-Shapely>=1.6.4,<1.7.0
+shapely>=1.6.4,<1.8.0
 pygeoprocessing>=2.0 # pip-only
 taskgraph[niced_processes]>=0.9.1
 psutil>=5.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 scipy>=0.16.1,<1.5.0
-shapely>=1.6.4,<1.8.0
+Shapely>=1.6.4,<1.7.0
 pygeoprocessing>=2.0 # pip-only
 taskgraph[niced_processes]>=0.9.1
 psutil>=5.6.6

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -807,7 +807,7 @@ def _calculate_ls_factor(
         # from McCool paper: "as a final check against excessively long slope
         # length calculations ... cap of 333m"
         # from Rafa, this should really be the upstream area capped to
-        # "333m^2" because McCool is 1D
+        # "333^2 m^2" because McCool is 1D
         contributing_area[contributing_area > 333**2] = 333**2
 
         ls_prime_factor = (

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -804,15 +804,17 @@ def _calculate_ls_factor(
             beta[big_slope_mask] / (1 + beta[big_slope_mask]))
         m_exp[~big_slope_mask] = m_table[m_indexes]
 
+        # from McCool paper: "as a final check against excessively long slope
+        # length calculations ... cap of 333m"
+        # from Rafa, this should really be the upstream area capped to
+        # "333m^2" because McCool is 1D
+        contributing_area[contributing_area > 333**2] = 333**2
+
         ls_prime_factor = (
             ((contributing_area + cell_area)**(m_exp+1) -
              contributing_area ** (m_exp+1)) /
             ((cell_size ** (m_exp + 2)) * (avg_aspect[valid_mask]**m_exp) *
              (22.13**m_exp)))
-
-        # from McCool paper: "as a final check against excessively long slope
-        # length calculations ... cap of 333m"
-        ls_prime_factor[ls_prime_factor > 333] = 333
 
         result[valid_mask] = ls_prime_factor * slope_factor
         return result

--- a/tests/test_sdr.py
+++ b/tests/test_sdr.py
@@ -26,15 +26,12 @@ def assert_expected_results_in_vector(expected_results, vector_path):
     watershed_results_vector = None
     watershed_results_layer = None
     watershed_results_feature = None
-    try:
-        for key in expected_results:
-            numpy.testing.assert_approx_equal(
-                actual_results[key], expected_results[key], significant=6)
-    except AssertionError:
-        print(
-            f'expected results: {expected_results}, '
-            f'actual_results: {actual_results}')
-        raise
+    for key in expected_results:
+        numpy.testing.assert_approx_equal(
+            actual_results[key], expected_results[key], significant=6,
+            err_msg=(
+                f'actual_results: {actual_results}, '
+                f'expected_results: {expected_results}'))
 
 
 class SDRTests(unittest.TestCase):

--- a/tests/test_sdr.py
+++ b/tests/test_sdr.py
@@ -26,18 +26,15 @@ def assert_expected_results_in_vector(expected_results, vector_path):
     watershed_results_vector = None
     watershed_results_layer = None
     watershed_results_feature = None
-    for key in expected_results:
-        # numpy.testing.assert_almost_equal(
-        #     expected_results[key], actual_results[key], decimal=6)
-
-        # In order to pass with GDAL<2.3 and GDAL>2.3:
-        # asserting equality to 5 significant figures instead of 6 decimal
-        # places. GDAL 2.3 introduced new warping behavior yielding different
-        # pixel values when also using a smoothing interpolation method.
-        # Surprisingly, these differences are not washed out by an
-        # aggregation such as zonal statistics.
-        numpy.testing.assert_approx_equal(
-            actual_results[key], expected_results[key], significant=2)
+    try:
+        for key in expected_results:
+            numpy.testing.assert_approx_equal(
+                actual_results[key], expected_results[key], significant=6)
+    except AssertionError:
+        print(
+            f'expected results: {expected_results}, '
+            f'actual_results: {actual_results}')
+        raise
 
 
 class SDRTests(unittest.TestCase):

--- a/tests/test_sdr.py
+++ b/tests/test_sdr.py
@@ -213,11 +213,12 @@ class SDRTests(unittest.TestCase):
         args['watersheds_path'] = target_watersheds_path
         sdr.execute(args)
         expected_results = {
-            'usle_tot': 12.69931602478,
-            'sed_retent': 402704.96875,
-            'sed_export': 0.7930983305,
-            'sed_dep': 8.58807754517,
+            'usle_tot': 12.04494380951,
+            'sed_retent': 367660.25,
+            'sed_export': 0.71140885353,
+            'sed_dep': 7.84880876541,
         }
+
         vector_path = os.path.join(
             args['workspace_dir'], 'watershed_results_sdr.shp')
         assert_expected_results_in_vector(expected_results, vector_path)
@@ -263,10 +264,11 @@ class SDRTests(unittest.TestCase):
 
         sdr.execute(args)
         expected_results = {
-            'sed_retent': 402704.96875,
-            'sed_export': 0.7930983305,
-            'usle_tot': 12.69931602478,
+            'sed_retent': 367660.25,
+            'sed_export': 0.71140885353,
+            'usle_tot': 12.04494380951,
         }
+
         vector_path = os.path.join(
             args['workspace_dir'], 'watershed_results_sdr.shp')
         # make args explicit that this is a base run of SWY
@@ -286,10 +288,11 @@ class SDRTests(unittest.TestCase):
         sdr.execute(args)
 
         expected_results = {
-            'sed_retent': 345797.375,
-            'sed_export': 0.63070225716,
-            'usle_tot': 11.46732711792,
+            'sed_retent': 335578.875,
+            'sed_export': 0.60814452171,
+            'usle_tot': 11.43409824371,
         }
+
         vector_path = os.path.join(
             args['workspace_dir'], 'watershed_results_sdr.shp')
         assert_expected_results_in_vector(expected_results, vector_path)
@@ -310,10 +313,11 @@ class SDRTests(unittest.TestCase):
         sdr.execute(args)
 
         expected_results = {
-            'sed_retent': 436809.59375,
-            'sed_export': 0.94600570202,
-            'usle_tot': 11.59875869751,
+            'sed_retent': 414067.65625,
+            'sed_export': 0.88248616457,
+            'usle_tot': 11.37281990051,
         }
+
         vector_path = os.path.join(
             args['workspace_dir'], 'watershed_results_sdr.shp')
         assert_expected_results_in_vector(expected_results, vector_path)


### PR DESCRIPTION
This PR fixes a design error bug in SDR where the upstream area to the LS factor should be capped to 333m^2, previously the LS factor itself was capped to 333m. This fixes an issue where there were the occasional high spikes of SDR pixel export.

In turn this creates differences in the expected output of SDR. These are all refelected in the "expected output" components of the test suite.

Also increased the the amount of significant digits from 2 to 6 when testing against expected results.