### PR TITLE
Fixing history for GLOBIO

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,9 @@
 ..
   Unreleased Changes
   ------------------
+* GLOBIO
+    * Fix a bug that mishandled combining infrastructure data when only one
+      infrastructure data was present.
 
 3.8.6 (2020-07-03)
 ------------------
@@ -22,9 +25,6 @@
       dictionary.
     * Remove ``warn_if_missing`` argument from ``utils.build_lookup_from_csv``
       and warning by default.
-* GLOBIO
-    * Fix a bug that mishandled combining infrastructure data when only one
-      infrastructure data was present.
 * Scenic Quality
     * Fixing an issue in Scenic Quality where the creation of the weighted sum
       of visibility rasters could cause "Too Many Open Files" errors and/or


### PR DESCRIPTION
A PR involving changes to GLOBIO were merge into master from #186 on 7/7/2020. History indicates those changes came in version 3.8.5, but we've already released 3.8.6 on 7/6/2020! Clearly something went wrong when merging or fixing a conflict. This PR moves those changes to `Unreleased`.


Fixes #207