### PR TITLE
Installing the sdist by its pathname. RE:#221

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -187,7 +187,7 @@ jobs:
                   rm -r natcap.invest.egg-info
 
                   # Install natcap.invest from the sdist in dist/
-                  pip install --isolated --find-links=dist natcap.invest
+                  pip install $(find dist -name "natcap.invest*")
 
                   # Model tests should cover model functionality, we just want
                   # to be sure that we can import `natcap.invest` here.


### PR DESCRIPTION
This PR fixes #221 by addressing a `natcap.invest` installation issue.  The root of the problem was that the parameters passed to `pip` would look for `natcap.invest` distributions in `dist/`, but the most 'recent' build would actually be determined to be on PyPI.  This is ultimately an issue with the versioning of the sdist in this specific build environment.

Instead of expecting our versioning to always be correct, this fix will cause the one and only distribution expected to be in `dist`, a `.tar.gz` or `.zip` file (extension is OS-dependent) to be installed.
