### PR TITLE
Fix InVEST crash related to Qt bindings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,11 @@
 .. :changelog:
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* General
+    * Fixed an issue where some users would be unable to launch InVEST binaries
+      on Windows.  This crash was due to a configuration issue in
+      ``PySide2==5.15.0`` that will be fixed in a future release of PySide2.
 * GLOBIO
     * Fix a bug that mishandled combining infrastructure data when only one
       infrastructure data was present.

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -10,4 +10,4 @@
 qtpy>1.3  # pip-only
 qtawesome  # pip-only
 requests
-PySide2  # pip-only
+PySide2!=5.15.0  # pip-only


### PR DESCRIPTION
This PR fixes #217 by preventing a buggy version of `PySide2` from being installed ([details about the bug here](https://github.com/natcap/invest/issues/217#issuecomment-656867754)).