### PR TITLE
Fix UFRM nodata handling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,8 @@ Unreleased Changes
       workspace.
     * Fixed a bug in the flood volume (``Q_m3.tif``) calculations that was
       producing incorrect values in all cases.
+    * Fixed a bug where input rasters with nodata values of 0 were not handled
+      properly.
 
 3.8.6 (2020-07-03)
 ------------------

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -677,7 +677,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result = numpy.empty_like(q_pi_array)
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=numpy.bool)
-    if q_pi_nodata:
+    if isinstance(q_pi_nodata, (int, float)):
         valid_mask[:] = ~numpy.isclose(q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
@@ -702,7 +702,7 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
 
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=numpy.bool)
-    if s_max_nodata:
+    if isinstance(s_max_nodata, (int, float)):
         non_nodata_mask[:] = ~numpy.isclose(s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
@@ -731,7 +731,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     result[:] = result_nodata
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
-    if cn_nodata:
+    if isinstance(cn_nodata, (int, float)):
         valid_mask[:] &= ~numpy.isclose(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -677,7 +677,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result = numpy.empty_like(q_pi_array)
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=numpy.bool)
-    if isinstance(q_pi_nodata, (int, float)):
+    if q_pi_nodata is not None:
         valid_mask[:] = ~numpy.isclose(q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
@@ -702,7 +702,7 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
 
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=numpy.bool)
-    if isinstance(s_max_nodata, (int, float)):
+    if s_max_nodata is not None:
         non_nodata_mask[:] = ~numpy.isclose(s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
@@ -731,7 +731,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     result[:] = result_nodata
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
-    if isinstance(cn_nodata, (int, float)):
+    if cn_nodata is not None:
         valid_mask[:] &= ~numpy.isclose(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
@@ -759,9 +759,9 @@ def _lu_to_cn_op(
     result = numpy.empty_like(lucode_array, dtype=numpy.float32)
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=numpy.bool)
-    if isinstance(lucode_nodata, (int, float)):
+    if lucode_nodata is not None:
         valid_mask[:] &= ~numpy.isclose(lucode_array, lucode_nodata)
-    if isinstance(soil_type_nodata, (int, float)):
+    if soil_type_nodata is not None:
         valid_mask[:] &= ~numpy.isclose(soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -759,9 +759,9 @@ def _lu_to_cn_op(
     result = numpy.empty_like(lucode_array, dtype=numpy.float32)
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=numpy.bool)
-    if lucode_nodata:
+    if isinstance(lucode_nodata, (int, float)):
         valid_mask[:] &= ~numpy.isclose(lucode_array, lucode_nodata)
-    if soil_type_nodata:
+    if isinstance(soil_type_nodata, (int, float)):
         valid_mask[:] &= ~numpy.isclose(soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover


### PR DESCRIPTION
This PR fixes a bug where input rasters with nodata of 0 were not properly being masked and causing downstream side-effects. 

Closes issue #185 