### PR TITLE
Restoring bugfix releases on a schedule

### DIFF
--- a/.github/workflows/auto-pr-from-master-into-releases.yml
+++ b/.github/workflows/auto-pr-from-master-into-releases.yml
@@ -69,6 +69,7 @@ jobs:
                           --base $GITHUB_REPOSITORY:$RELEASE_BRANCH \
                           --reviewer "$PR_USERNAME" \
                           --assign "$PR_USERNAME" \
+                          --labels "auto" \
                           --file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
                   done
 

--- a/.github/workflows/auto-release-bugfix.yml
+++ b/.github/workflows/auto-release-bugfix.yml
@@ -1,8 +1,8 @@
 name: Automated Bugfix Release
 on:
-    #schedule:
-        # 9am PST on Friday of each week
-        #- cron: '0 17 * * 5'
+    schedule:
+        # 11am PST on Friday of each week
+        - cron: '0 18 * * 5'
 
 jobs:
     create-bugfix-release:
@@ -171,6 +171,7 @@ jobs:
                           --head $GITHUB_REPOSITORY:$TARGET_BRANCH \
                           --reviewer $RELEASE_MANAGER \
                           --assign $RELEASE_MANAGER \
+                          --labels "auto" \
                           --file $PRMSG
                   fi
 

--- a/ci/master-release-pr-body.md
+++ b/ci/master-release-pr-body.md
@@ -1,4 +1,4 @@
-AUTO: merge $SOURCE_BRANCH into $RELEASE_BRANCH
+Merge $SOURCE_BRANCH into $RELEASE_BRANCH
 
 This PR was automatically generated in response to a push to `master`,
 and is a chance to review any changes that will be included in the release

--- a/ci/release/bugfix-autorelease-branch-pr-body.md
+++ b/ci/release/bugfix-autorelease-branch-pr-body.md
@@ -1,4 +1,4 @@
-Auto: Release $BUGFIX_VERSION and merge into $SOURCE_BRANCH
+Release $BUGFIX_VERSION and merge into $SOURCE_BRANCH
 
 # Release $BUGFIX_VERSION
 


### PR DESCRIPTION
This PR restores the automated releases, but also bumps the time to 11am Pacific (so there isn't as much of a rush on reviewing this PR) and adds an 'auto' tag instead of prefixing the PR title with `AUTO:`.  I did the same tagging on the automated merges from `master` --> `release/*`.