### PR TITLE
CV: handle invalid geometry in AOI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,11 @@
 .. :changelog:
 
 ..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Coastal Vulnerability
+    * Improved handling of invalid geometries in the AOI layer by fixing them
+      when possible and skipping them when not.  
 
 3.8.7 (2020-07-17)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,8 @@
 .. :changelog:
 
 ..
-Unreleased Changes
-------------------
-* Coastal Vulnerability
-    * Improved handling of invalid geometries in the AOI layer by fixing them
-      when possible and skipping them when not.  
+  Unreleased Changes
+  ------------------
 
 3.8.7 (2020-07-17)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,11 @@
 .. :changelog:
 
 ..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Coastal Vulnerability
+    * Improved handling of invalid AOI geometries to avoid crashing and instead
+      fix the geometry when possible and skip it otherwise.
 
 3.8.7 (2020-07-17)
 ------------------

--- a/exe/hooks/hook-scipy.py
+++ b/exe/hooks/hook-scipy.py
@@ -1,0 +1,5 @@
+# encoding=UTF-8
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+datas = collect_data_files('scipy')
+hiddenimports = collect_submodules('scipy')

--- a/exe/hooks/hook-scipy.py
+++ b/exe/hooks/hook-scipy.py
@@ -1,5 +1,0 @@
-# encoding=UTF-8
-from PyInstaller.utils.hooks import collect_submodules, collect_data_files
-
-datas = collect_data_files('scipy')
-hiddenimports = collect_submodules('scipy')

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -267,8 +267,8 @@ def execute(args):
             The radius in meters around each shore point in which to compute
             the population density.
         args['slr_vector_path'] (string): (optional) path to point vector
-            containing the field `args['slr_field']`.
-        args['slr_field'] (string): name of a field in `args['slr_vector_path']`
+            containing the field ``args['slr_field']``.
+        args['slr_field'] (string): name of a field in ``args['slr_vector_path']``
             containing numeric values.
         args['n_workers'] (int): (optional) The number of worker processes to
             use for processing this model.  If omitted, computation will take
@@ -581,7 +581,7 @@ def execute(args):
     # For now this is outside the task graph to make sure we always
     # re-calculate final exposure. Some of the intermediate variables
     # are in files only referenced within tuples within
-    # `exposure_variables_path_list`, so it would require some
+    # ``exposure_variables_path_list``, so it would require some
     # re-factoring to make all those files considered by taskgraph.
     target_exposure_vector_path = os.path.join(
         output_dir, 'coastal_exposure%s.gpkg' % file_suffix)
@@ -898,7 +898,7 @@ def interpolate_sealevelrise_points(
     Args:
         base_shore_point_vector_path (string): path to point vector
         slr_points_vector_path (string): path to point vector containing
-            the field `slr_fieldname`.
+            the field ``slr_fieldname``.
         slr_fieldname (string): name of a field containing numeric values
         target_pickle_path (string): path to pickle file storing dict
             keyed by point fid.
@@ -1013,7 +1013,7 @@ def calculate_wind_exposure(
             bounds of line geometries.
         landmass_lines_pickle_path (string): path to pickle
             storing list of shapely line geometries. List index must match
-            index of `landmass_line_rtree_path`.
+            index of ``landmass_line_rtree_path``.
         bathymetry_raster_path (string): path to bathymetry raster that has
             already had positive pixel values clamped to 0.
         workspace_dir (string): path to a directory for intermediate files
@@ -1021,7 +1021,7 @@ def calculate_wind_exposure(
         max_fetch_distance (float): maximum fetch distance for a ray in
             meters.
         target_shore_point_vector_path (string): path to target point file,
-            will be a copy of `base_shore_point_vector_path`'s geometry with
+            will be a copy of ``base_shore_point_vector_path``'s geometry with
             an 'REI' (relative exposure index) field added.
         target_wind_exposure_pickle_path (string): path to pickle file storing
             dict keyed by shore point fid, with wind exposure values.
@@ -1787,7 +1787,7 @@ def _schedule_habitat_tasks(
                 each shore point.
         working_dir (string): path to a directory for intermediate files
         file_suffix (string): to be appended to output filenames
-        task_graph (Taskgraph): the graph that was initialized in `execute`
+        task_graph (Taskgraph): the graph that was initialized in ``execute``
 
     Returns:
         list of task objects
@@ -2033,7 +2033,7 @@ def calculate_geomorphology_exposure(
 
     Args:
         geomorphology_vector_path (string): path to polyline vector
-            with an integer attribute named `RANK` that contains values
+            with an integer attribute named ``RANK`` that contains values
             in (1, 2, 3, 4, 5).
         geomorphology_fill_value (int): integer in (1, 2, 3, 4, 5).
         base_shore_point_vector_path (string): path to point vector
@@ -2330,7 +2330,7 @@ def _geometric_mean(array):
     """Calculate a geometric mean of numpy array of floats.
 
     Returns:
-        float, unless array contains a `nan`, then returns `nan`.
+        float, unless array contains a ``nan``, then returns ``nan``.
 
     """
     return numpy.prod(array)**(1./len(array))
@@ -2339,8 +2339,8 @@ def _geometric_mean(array):
 def _bin_values_to_percentiles(base_values_dict, invert_values=False):
     """Bin continuous values into percentile categories.
 
-    `nan` should be ignored when calculating percentiles, and features
-    with a `nan` value should get a `nan` rank as well.
+    ``nan`` should be ignored when calculating percentiles, and features
+    with a ``nan`` value should get a ``nan`` rank as well.
 
     Args:
         base_values_dict (dictionary): values are numeric
@@ -2704,18 +2704,18 @@ def polygon_to_lines(geometry):
 def _ogr_to_geometry_list(vector_path):
     """Convert an OGR type with one layer to a list of shapely geometry.
 
-    Iterates through the features in the `vector_path`'s first layer and
-    converts them to `shapely` geometry objects.  If the objects are not
+    Iterates through the features in the ``vector_path``'s first layer and
+    converts them to ``shapely`` geometry objects.  If the objects are not
     valid geometry, an attempt is made to buffer the object by 0 units
     before adding to the list. If the object cannot be loaded by shapely
     at all, it is left out of the list.
 
     Parameters:
-        vector_path (string): path to an OGR datasource
+        vector_path (string): path to an OGR vector
 
     Returns:
         list of shapely geometry objects representing the features in the
-        `vector_path` layer.
+        ``vector_path`` layer.
 
     """
     vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
@@ -2844,18 +2844,18 @@ def _copy_point_vector_geom_to_gpkg(
 
 
 def _sanitize_path(base_path, raw_path):
-    """Return `raw_path` if absolute, or make absolute relative to `base_path`."""
+    """Return ``raw_path`` if absolute, or make absolute relative to ``base_path``."""
     if os.path.isabs(raw_path):
         return raw_path
     return os.path.join(os.path.dirname(base_path), raw_path)
 
 
 def _make_logger_callback(message, logger):
-    """Build a timed logger callback that prints `message` replaced.
+    """Build a timed logger callback that prints ``message`` replaced.
 
     Args:
         message (string): a string that expects a %f replacement variable for
-            `proportion_complete`.
+            ``proportion_complete``.
 
     Returns:
         Function with signature:

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -622,40 +622,7 @@ def prepare_landmass_line_index(
     """
     LOGGER.info("preparing landmass geometry")
     # Get shapely geometries from landmass
-    landmass_polygon_shapely_list = []
-    landmass_polygon_vector = gdal.OpenEx(
-        landmass_vector_path, gdal.OF_VECTOR | gdal.GA_Update)
-    landmass_polygon_layer = landmass_polygon_vector.GetLayer()
-    for feature in landmass_polygon_layer:
-        geometry = feature.GetGeometryRef()
-        # In my experience a geometry that can't be loaded by shapely
-        # is also a geometry that can't be fixed with the buffer(0) trick,
-        # so just skip it.
-        try:
-            shapely_geometry = shapely.wkb.loads(
-                geometry.ExportToWkb())
-        except shapely.errors.WKBReadingError:
-            LOGGER.warning(
-                "landmass FID:%d is excluded, probably due to invalid geometry"
-                " in %s" % (feature.GetFID(), landmass_vector_path))
-            continue
-        # Only check and fix geometries that were loaded successully.
-        if shapely_geometry.is_valid:
-            landmass_polygon_shapely_list.append(shapely_geometry)
-        else:
-            shapely_geometry = shapely_geometry.buffer(0)
-            if shapely_geometry.is_valid:
-                landmass_polygon_shapely_list.append(shapely_geometry)
-            else:
-                # Given the earlier checks, it might well be impossible to
-                # get here, but it feels best to include the else block anyway.
-                LOGGER.warning(
-                    'landmass FID:%d is excluded due to invalid geometry',
-                    feature.GetFID())
-        geometry = None
-        feature = None
-    landmass_polygon_layer = None
-    landmass_polygon_vector = None
+    landmass_polygon_shapely_list = _ogr_to_geometry_list(landmass_vector_path)
     landmass_shapely = shapely.ops.cascaded_union(
         landmass_polygon_shapely_list)
     landmass_polygon_shapely_list = None
@@ -710,16 +677,9 @@ def interpolate_shore_points(
     aoi_spatial_reference = osr.SpatialReference()
     aoi_spatial_reference.ImportFromWkt(aoi_vector_info['projection'])
 
-    aoi_vector = gdal.OpenEx(aoi_vector_path, gdal.OF_VECTOR)
-    aoi_layer = aoi_vector.GetLayer()
-    aoi_shapely_list = []
-    for feature in aoi_layer:
-        geom = feature.GetGeometryRef()
-        aoi_shapely_list.append(shapely.wkb.loads(geom.ExportToWkb()))
+    aoi_shapely_list = _ogr_to_geometry_list(aoi_vector_path)
     aoi_shapely = shapely.ops.cascaded_union(aoi_shapely_list)
     aoi_shapely_prepped = shapely.prepared.prep(aoi_shapely)
-    aoi_vector = None
-    aoi_layer = None
 
     with open(landmass_lines_pickle_path, 'rb') as lines_pickle_file:
         shapely_line_list = pickle.load(lines_pickle_file)
@@ -2515,24 +2475,7 @@ def clip_and_project_vector(
             str(layer_name), base_spatial_reference, ogr.wkbMultiPolygon))
     clipped_defn = clipped_layer.GetLayerDefn()
 
-    base_vector = gdal.OpenEx(
-        base_vector_path, gdal.OF_VECTOR | gdal.GA_ReadOnly)
-    base_layer = base_vector.GetLayer()
-    for feature in base_layer:
-        geometry = feature.GetGeometryRef()
-        # In my experience a geometry that can't be loaded by shapely
-        # is also a geometry that can't be fixed with the buffer(0) trick,
-        # so just skip it.
-        try:
-            shapely_geometry = shapely.wkb.loads(
-                geometry.ExportToWkb())
-        except shapely.errors.WKBReadingError:
-            LOGGER.warning(
-                "Couldn't load a feature in %s", base_vector_path)
-            continue
-        # Only check and fix geometries that can be loaded.
-        if not shapely_geometry.is_valid:
-            shapely_geometry = shapely_geometry.buffer(0)
+    for shapely_geometry in _ogr_to_geometry_list(base_vector_path):
         if base_srs_clipping_box_shapely.intersects(shapely_geometry):
             intersection_shapely = base_srs_clipping_box_shapely.intersection(
                 shapely_geometry)
@@ -2548,8 +2491,6 @@ def clip_and_project_vector(
     clipped_layer.SyncToDisk()
     clipped_layer = None
     clipped_vector = None
-    base_vector = None
-    base_layer = None
 
     pygeoprocessing.reproject_vector(
         tmp_vector_path, target_srs_wkt, target_vector_path,
@@ -2758,6 +2699,47 @@ def polygon_to_lines(geometry):
         line_list.append(shapely.geometry.LineString([
             previous_point, starting_point]))
     return line_list
+
+
+def _ogr_to_geometry_list(vector_path):
+    """Convert an OGR type with one layer to a list of shapely geometry.
+
+    Iterates through the features in the `vector_path`'s first layer and
+    converts them to `shapely` geometry objects.  If the objects are not
+    valid geometry, an attempt is made to buffer the object by 0 units
+    before adding to the list. If the object cannot be loaded by shapely
+    at all, it is left out of the list.
+
+    Parameters:
+        vector_path (string): path to an OGR datasource
+
+    Returns:
+        list of shapely geometry objects representing the features in the
+        `vector_path` layer.
+
+    """
+    vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
+    layer = vector.GetLayer()
+    geometry_list = []
+    for feature in layer:
+        feature_geometry = feature.GetGeometryRef()
+        try:
+            shapely_geometry = shapely.wkb.loads(
+                feature_geometry.ExportToWkb())
+        except shapely.errors.WKBReadingError:
+            # In my experience a geometry that can't be loaded by shapely
+            # is also a geometry that can't be fixed with the buffer(0) trick,
+            # so just skip it.
+            LOGGER.warning(
+                f'Could not load feature {feature.GetFID()} of {vector_path}')
+            continue
+        if not shapely_geometry.is_valid:
+            shapely_geometry = shapely_geometry.buffer(0)
+        geometry_list.append(shapely_geometry)
+        feature_geometry = None
+    layer = None
+    vector = None
+    return geometry_list
 
 
 def _copy_vector_to_csv(base_vector_path, target_csv_path):

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -102,7 +102,7 @@ ARGS_SPEC = {
             "type": "boolean",
             "required": False,
             "about": (
-                "If true the polygon vector in `args['aoi_path']` should be "
+                "If true the polygon vector in ``args['aoi_path']`` should be "
                 "gridded into a new vector and the recreation model should "
                 "be executed on that"),
             "name": "Grid the AOI"
@@ -216,13 +216,13 @@ def execute(args):
             is the inclusive upper bound to consider points in the PUD and
             regression.
         args['grid_aoi'] (boolean): if true the polygon vector in
-            `args['aoi_path']` should be gridded into a new vector and the
+            ``args['aoi_path']`` should be gridded into a new vector and the
             recreation model should be executed on that
         args['grid_type'] (string): optional, but must exist if
             args['grid_aoi'] is True.  Is one of 'hexagon' or 'square' and
             indicates the style of gridding.
         args['cell_size'] (string/float): optional, but must exist if
-            `args['grid_aoi']` is True.  Indicates the cell size of square
+            ``args['grid_aoi']`` is True.  Indicates the cell size of square
             pixels and the width of the horizontal axis for the hexagonal
             cells.
         args['compute_regression'] (boolean): if True, then process the
@@ -256,7 +256,7 @@ def execute(args):
         args['scenario_predictor_table_path'] (string): (optional) if
             present runs the scenario mode of the recreation model with the
             datasets described in the table on this path.  Field headers
-            are identical to `args['predictor_table_path']` and ids in the
+            are identical to ``args['predictor_table_path']`` and ids in the
             table are required to be identical to the predictor list.
         args['results_suffix'] (string): optional, if exists is appended to
             any output file paths.
@@ -531,10 +531,10 @@ def _grid_vector(vector_path, grid_type, cell_size, out_grid_vector_path):
         vector_path (string): path to an OGR compatible polygon vector type
         grid_type (string): one of "square" or "hexagon"
         cell_size (float): dimensions of the grid cell in the projected units
-            of `vector_path`; if "square" then this indicates the side length,
+            of ``vector_path``; if "square" then this indicates the side length,
             if "hexagon" indicates the width of the horizontal axis.
         out_grid_vector_path (string): path to the output ESRI shapefile
-            vector that contains a gridded version of `vector_path`, this file
+            vector that contains a gridded version of ``vector_path``, this file
             should not exist before this call
 
     Returns:
@@ -639,7 +639,7 @@ def _schedule_predictor_data_processing(
 
     Build a shapefile with geometry from the response vector, and tabular
     data from aggregate metrics of spatial predictor datasets in
-    `predictor_table_path`.
+    ``predictor_table_path``.
 
     Parameters:
         response_vector_path (string): path to a single layer polygon vector.
@@ -650,7 +650,7 @@ def _schedule_predictor_data_processing(
         predictor_table_path (string): path to a CSV file with three columns
             'id', 'path' and 'type'.  'id' is the unique ID for that predictor
             and must be less than 10 characters long. 'path' indicates the
-            full or relative path to the `predictor_table_path` table for the
+            full or relative path to the ``predictor_table_path`` table for the
             spatial predictor dataset. 'type' is one of:
                 'point_count': count # of points per response polygon
                 'point_nearest_distance': distance from nearest point to the
@@ -666,7 +666,7 @@ def _schedule_predictor_data_processing(
                 'raster_mean': average of predictor raster under the
                     response polygon
         out_predictor_vector_path (string): path to a copy of
-            `response_vector_path` with a column for each id in
+            ``response_vector_path`` with a column for each id in
             predictor_table_path. Overwritten if exists.
         working_dir (string): path to an intermediate directory to store json
             files with geoprocessing results.
@@ -770,7 +770,7 @@ def _json_to_shp_table(
     Parameters:
         response_vector_path (string): Path to the response vector polygon
             shapefile.
-        predictor_vector_path (string): a copy of `response_vector_path`.
+        predictor_vector_path (string): a copy of ``response_vector_path``.
             One field will be added for each json file, and all other
             fields will be deleted.
         predictor_json_list (list): list of json filenames, one for each
@@ -842,7 +842,7 @@ def _raster_sum_mean(
         op_mode (string): either 'mean' or 'sum'.
         response_vector_path (string): path to response polygons
         predictor_target_path (string): path to json file to store result,
-            which is a dictionary mapping feature IDs from `response_vector_path`
+            which is a dictionary mapping feature IDs from ``response_vector_path``
             to values of the raster under the polygon.
 
     Returns:
@@ -889,8 +889,8 @@ def _polygon_area(
         predictor_target_path):
     """Calculate polygon area overlap.
 
-    Calculates the amount of projected area overlap from `polygon_vector_path`
-    with `response_polygons_lookup`.
+    Calculates the amount of projected area overlap from ``polygon_vector_path``
+    with ``response_polygons_lookup``.
 
     Parameters:
         mode (string): one of 'area' or 'percent'.  How this is set affects
@@ -903,7 +903,7 @@ def _polygon_area(
             object.
         predictor_target_path (string): path to json file to store result,
             which is a dictionary mapping feature IDs from
-            `response_polygons_lookup` to polygon area coverage.
+            ``response_polygons_lookup`` to polygon area coverage.
 
     Returns:
         None
@@ -962,7 +962,7 @@ def _line_intersect_length(
             object.
         predictor_target_path (string): path to json file to store result,
             which is a dictionary mapping feature IDs from
-            `response_polygons_lookup` to line intersect length.
+            ``response_polygons_lookup`` to line intersect length.
 
     Returns:
         None
@@ -1012,7 +1012,7 @@ def _point_nearest_distance(
             object.
         predictor_target_path (string): path to json file to store result,
             which is a dictionary mapping feature IDs from
-            `response_polygons_lookup` to distance to nearest point.
+            ``response_polygons_lookup`` to distance to nearest point.
 
     Returns:
         None
@@ -1054,7 +1054,7 @@ def _point_count(
             object.
         predictor_target_path (string): path to json file to store result,
             which is a dictionary mapping feature IDs from
-            `response_polygons_lookup` to number of points in that polygon.
+            ``response_polygons_lookup`` to number of points in that polygon.
 
     Returns:
         None
@@ -1087,17 +1087,17 @@ def _point_count(
 def _ogr_to_geometry_list(vector_path):
     """Convert an OGR type with one layer to a list of shapely geometry.
 
-    Iterates through the features in the `vector_path`'s first layer and
-    converts them to `shapely` geometry objects.  if the objects are not
+    Iterates through the features in the ``vector_path``'s first layer and
+    converts them to ``shapely`` geometry objects.  if the objects are not
     valid geometry, an attempt is made to buffer the object by 0 units
     before adding to the list.
 
     Parameters:
-        vector_path (string): path to an OGR datasource
+        vector_path (string): path to an OGR vector
 
     Returns:
         list of shapely geometry objects representing the features in the
-        `vector_path` layer.
+        ``vector_path`` layer.
 
     """
     vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
@@ -1188,22 +1188,22 @@ def _build_regression(
     """Multiple least-squares regression with log-transformed response.
 
     The regression is built such that each feature in the single layer vector
-    pointed to by `predictor_vector_path` corresponds to one data point.
-    `response_id` is the response variable to be log-transformed, and is found
-    in `response_vector_path`. Predictor variables are found in
-    `predictor_vector_path` and are not transformed. Features with incomplete
+    pointed to by ``predictor_vector_path`` corresponds to one data point.
+    ``response_id`` is the response variable to be log-transformed, and is found
+    in ``response_vector_path``. Predictor variables are found in
+    ``predictor_vector_path`` and are not transformed. Features with incomplete
     data are dropped prior to computing the regression.
 
     Parameters:
         response_vector_path (string): path to polygon vector with PUD
-            results, in particular a field named with the `response_id`.
+            results, in particular a field named with the ``response_id``.
         predictor_vector_path (string): path to a shapefile that contains
             only the fields to be used as predictor variables.
-        response_id (string): field ID in `response_vector_path` whose
+        response_id (string): field ID in ``response_vector_path`` whose
             values correspond to the regression response variable.
 
     Asserts:
-        `response_vector_path` and `predictor_vector_path` have an equal
+        ``response_vector_path`` and ``predictor_vector_path`` have an equal
         number of features.
 
     Returns:
@@ -1503,18 +1503,18 @@ def _validate_same_projection(base_vector_path, table_path):
 
 
 def delay_op(last_time, time_delay, func):
-    """Execute `func` if last_time + time_delay >= current time.
+    """Execute ``func`` if last_time + time_delay >= current time.
 
     Parameters:
-        last_time (float): last time in seconds that `func` was triggered
+        last_time (float): last time in seconds that ``func`` was triggered
         time_delay (float): time to wait in seconds since last_time before
-            triggering `func`
+            triggering ``func``
         func (function): parameterless function to invoke if
          current_time >= last_time + time_delay
 
     Returns:
-        If `func` was triggered, return the time which it was triggered in
-        seconds, otherwise return `last_time`.
+        If ``func`` was triggered, return the time which it was triggered in
+        seconds, otherwise return ``last_time``.
 
     """
     if time.time() - last_time > time_delay:
@@ -1524,7 +1524,7 @@ def delay_op(last_time, time_delay, func):
 
 
 def _sanitize_path(base_path, raw_path):
-    """Return `path` if absolute, or make absolute local to `base_path`."""
+    """Return ``path`` if absolute, or make absolute local to ``base_path``."""
     if os.path.isabs(raw_path):
         return raw_path
     else:  # assume relative path w.r.t. the response table
@@ -1533,15 +1533,15 @@ def _sanitize_path(base_path, raw_path):
 
 @validation.invest_validator
 def validate(args, limit_to=None):
-    """Validate args to ensure they conform to `execute`'s contract.
+    """Validate args to ensure they conform to ``execute``'s contract.
 
     Parameters:
         args (dict): dictionary of key(str)/value pairs where keys and
-            values are specified in `execute` docstring.
+            values are specified in ``execute`` docstring.
         limit_to (str): (optional) if not None indicates that validation
             should only occur on the args[limit_to] value. The intent that
             individual key validation could be significantly less expensive
-            than validating the entire `args` dictionary.
+            than validating the entire ``args`` dictionary.
 
     Returns:
         list of ([invalid key_a, invalid_keyb, ...], 'warning/error message')

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1057,6 +1057,46 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         n_points = layer.GetFeatureCount()
         self.assertTrue(n_points == 6)
 
+    def test_aoi_invalid_geometry(self):
+        """CV: test shore point creation with invalid geom in AOI."""
+        args = CoastalVulnerabilityTests.generate_base_args(self.workspace_dir)
+        aoi_path = os.path.join(self.workspace_dir, 'aoi.gpkg')
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)  # UTM Zone 10N
+        wkt = srs.ExportToWkt()
+        _ = make_vector_of_invalid_geoms(aoi_path)
+
+        # In this test, it won't matter if the landmass intersects the AOI.
+        landmass_path = os.path.join(
+            self.workspace_dir, 'landmass.geojson')
+        sampledata.create_vector_on_disk(
+            [Polygon([(-100, -100), (100, -100), (100, 100), (-100, 100), (-100, -100)])],
+            wkt, filename=landmass_path)
+
+        args['aoi_vector_path'] = aoi_path
+        args['landmass_vector_path'] = landmass_path
+        args['model_resolution'] = 100
+
+        polygon_pickle = os.path.join(
+            self.workspace_dir, 'polygon.pickle')
+        lines_pickle = os.path.join(
+            self.workspace_dir, 'lines.pickle')
+        lines_rtree = os.path.join(
+            self.workspace_dir, 'rtree.dat')
+        target_vector_path = os.path.join(
+            self.workspace_dir, 'shore_points.gpkg')
+
+        coastal_vulnerability.prepare_landmass_line_index(
+            args['landmass_vector_path'], polygon_pickle,
+            lines_pickle, lines_rtree)
+
+        # Getting to the RuntimeError for zero shore points means
+        # all the invalid geometries in the AOI were handled.
+        with self.assertRaises(RuntimeError):
+            coastal_vulnerability.interpolate_shore_points(
+                args['aoi_vector_path'], lines_pickle,
+                args['model_resolution'], target_vector_path)
+
     def test_no_wwiii_coverage(self):
         """CV: test exception when shore points are outside max wwiii distance."""
         args = CoastalVulnerabilityTests.generate_base_args(self.workspace_dir)


### PR DESCRIPTION
This PR fixes a bug where CV would crash on invalid geometry in the AOI. That's a bug because we could easily fix that geometry on the fly instead of crashing, as is already done in other CV operations.

It turned out there were three places in CV where the same vector processing and geometry checking were happening in order to get OGR geometries into shapely data structures. So that's now abstracted into a new function `_ogr_to_geometry_list`. That function is borrowed nearly verbatim from `recmodel_client.py`. 

Fixes #239 