### PR TITLE
Change units in UCM to account for building area and improve handling of CC inputs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,7 +133,7 @@ jobs:
             - name: Run model tests
               shell: bash -l {0}
               run: |
-                  pip install --isolated --upgrade --only-binary natcap.invest --find-links=dist natcap.invest
+                  pip install $(find dist -name "natcap.invest*.whl")
                   make test
 
             - uses: actions/upload-artifact@v1
@@ -187,7 +187,7 @@ jobs:
                   rm -r natcap.invest.egg-info
 
                   # Install natcap.invest from the sdist in dist/
-                  pip install --isolated --find-links=dist natcap.invest
+                  pip install $(find dist -name "natcap.invest*")
 
                   # Model tests should cover model functionality, we just want
                   # to be sure that we can import `natcap.invest` here.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,12 @@
 .. :changelog:
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Urban Cooling
+    * Energy units are now (correctly) expressed in kWh.  They were previously
+      (incorrectly) expressed in kW.
+    * Energy savings calculations now assume that consumption is in units of
+      kWh/degree C/m^2 for each building class.
 
 3.8.7 (2020-07-17)
 ------------------
@@ -13,9 +17,6 @@
 * GLOBIO
     * Fix a bug that mishandled combining infrastructure data when only one
       infrastructure data was present.
-* Urban Cooling
-    * Energy units are now (correctly) expressed in kWh.  They were previously
-      (incorrectly) expressed in kW.
 * Urban Flood Risk
     * The output vector ``flood_risk_service.shp`` now includes a field,
       ``flood_vol`` that is the sum of the modeled flood volume (from

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Unreleased Changes
 * GLOBIO
     * Fix a bug that mishandled combining infrastructure data when only one
       infrastructure data was present.
+* Urban Cooling
+    * Energy units are now (correctly) expressed in kWh.  They were previously
+      (incorrectly) expressed in kW.
 * Urban Flood Risk
     * The output vector ``flood_risk_service.shp`` now includes a field,
       ``flood_vol`` that is the sum of the modeled flood volume (from

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Unreleased Changes
 * Urban Cooling
     * Energy units are now (correctly) expressed in kWh.  They were previously
       (incorrectly) expressed in kW.
-    * Energy savings calculations now assume that consumption is in units of
+    * Energy savings calculations now require that consumption is in units of
       kWh/degree C/m^2 for each building class.
 
 3.8.7 (2020-07-17)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,9 @@ Unreleased Changes
       (incorrectly) expressed in kW.
     * Energy savings calculations now require that consumption is in units of
       kWh/degree C/m^2 for each building class.
+    * Fixing an issue where blank values of the Cooling Coefficient weights
+      (shade, albedo, ETI) would raise an error.  Now, a default value for the
+      coefficient is assumed if any single value is left blank.
 
 3.8.7 (2020-07-17)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 8a108c6fc1df475efc5f173c5236dc19a6ca5fb6
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := d5fbb6e46ac9b841672d5616ff0172de0f5834e7
+GIT_UG_REPO_REV              := d6d19262d99a019220c0cd01ab5489caade2fa66
 
 
 ENV = env

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -303,9 +303,24 @@ def execute(args):
     # cast to float and calculate relative weights
     # Use default weights for shade, albedo, eti if the user didn't provide
     # weights.
-    cc_weight_shade_raw = float(args.get('cc_weight_shade', 0.6))
-    cc_weight_albedo_raw = float(args.get('cc_weight_albedo', 0.2))
-    cc_weight_eti_raw = float(args.get('cc_weight_eti', 0.2))
+    # TypeError when float(None)
+    # ValueError when float('')
+    # KeyError when the parameter is not present in the args dict.
+    try:
+        cc_weight_shade_raw = float(args['cc_weight_shade'])
+    except (ValueError, TypeError, KeyError):
+        cc_weight_shade_raw = 0.6
+
+    try:
+        cc_weight_albedo_raw = float(args['cc_weight_albedo'])
+    except (ValueError, TypeError, KeyError):
+        cc_weight_albedo_raw = 0.2
+
+    try:
+        cc_weight_eti_raw = float(args['cc_weight_eti'])
+    except (ValueError, TypeError, KeyError):
+        cc_weight_eti_raw = 0.2
+
     t_ref_raw = float(args['t_ref'])
     uhi_max_raw = float(args['uhi_max'])
     cc_weight_sum = sum(

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -177,7 +177,7 @@ ARGS_SPEC = {
             },
             "about": (
                 "A CSV table containing information on energy consumption "
-                "for various types of buildings, in kWh/degC/m^2."
+                "for various types of buildings, in kWh/deg C/m^2."
             ),
         },
         "cc_method": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -177,7 +177,7 @@ ARGS_SPEC = {
             },
             "about": (
                 "A CSV table containing information on energy consumption "
-                "for various types of buildings, in kW/degC."
+                "for various types of buildings, in kWh/degC."
             ),
         },
         "cc_method": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -246,7 +246,8 @@ def execute(args):
         args['results_suffix'] (string): (optional) string to append to any
             output file names
         args['t_ref'] (str/float): reference air temperature.
-        args['lulc_raster_path'] (str): path to landcover raster.
+        args['lulc_raster_path'] (str): path to landcover raster.  This raster
+            must be in a linearly-projected CRS.
         args['ref_eto_raster_path'] (str): path to evapotranspiration raster.
         args['aoi_vector_path'] (str): path to desired AOI.
         args['biophysical_table_path'] (str): table to map landcover codes to
@@ -924,6 +925,8 @@ def calculate_energy_savings(
         target_building_vector_path (str): path to target vector that
             will contain the additional field 'energy_sav' calculated as
             ``consumption.increase(b) * ((T_(air,MAX)  - T_(air,i)))``.
+            This vector must be in a linearly projected spatial reference
+            system.
 
     Return:
         None.

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -177,7 +177,7 @@ ARGS_SPEC = {
             },
             "about": (
                 "A CSV table containing information on energy consumption "
-                "for various types of buildings, in kWh/degC."
+                "for various types of buildings, in kWh/degC/m^2."
             ),
         },
         "cc_method": {

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -30,18 +30,26 @@ class UCMTests(unittest.TestCase):
             'workspace_dir': os.path.join(self.workspace_dir, 'workspace'),
             'results_suffix': 'test_suffix',
             't_ref': 35.0,
-            't_obs_raster_path': os.path.join(REGRESSION_DATA, "Tair_Sept.tif"),
-            'lulc_raster_path': os.path.join(REGRESSION_DATA, "LULC_SFBA.tif"),
-            'ref_eto_raster_path': os.path.join(REGRESSION_DATA, "ETo_SFBA.tif"),
-            'aoi_vector_path': os.path.join(REGRESSION_DATA, "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
-            'biophysical_table_path': os.path.join(REGRESSION_DATA, "biophysical_table_ucm.csv"),
+            't_obs_raster_path': os.path.join(
+                REGRESSION_DATA, "Tair_Sept.tif"),
+            'lulc_raster_path': os.path.join(
+                REGRESSION_DATA, "LULC_SFBA.tif"),
+            'ref_eto_raster_path': os.path.join(
+                REGRESSION_DATA, "ETo_SFBA.tif"),
+            'aoi_vector_path': os.path.join(
+                REGRESSION_DATA,
+                "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
+            'biophysical_table_path': os.path.join(
+                REGRESSION_DATA, "biophysical_table_ucm.csv"),
             'green_area_cooling_distance': 1000.0,
             'uhi_max': 3,
             'cc_method': 'factors',
             'do_valuation': True,
             't_air_average_radius': "1000.0",
-            'building_vector_path': os.path.join(REGRESSION_DATA, "buildings_clip.gpkg"),
-            'energy_consumption_table_path': os.path.join(REGRESSION_DATA, "Energy.csv"),
+            'building_vector_path': os.path.join(
+                REGRESSION_DATA, "buildings_clip.gpkg"),
+            'energy_consumption_table_path': os.path.join(
+                REGRESSION_DATA, "Energy.csv"),
             'avg_rel_humidity': '30.0',
             'cc_weight_shade': '',  # to trigger default of 0.6
             'cc_weight_albedo': None,  # to trigger default of 0.2
@@ -156,7 +164,8 @@ class UCMTests(unittest.TestCase):
             'ref_eto_raster_path': os.path.join(
                 REGRESSION_DATA, "ETo_SFBA.tif"),
             'aoi_vector_path': os.path.join(
-                REGRESSION_DATA, "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
+                REGRESSION_DATA,
+                "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
             'biophysical_table_path': os.path.join(
                 REGRESSION_DATA, "biophysical_table_ucm.csv"),
             'green_area_cooling_distance': 1000.0,
@@ -209,18 +218,25 @@ class UCMTests(unittest.TestCase):
             'workspace_dir': self.workspace_dir,
             'results_suffix': 'test_suffix',
             't_ref': 35.0,
-            't_obs_raster_path': os.path.join(REGRESSION_DATA, "Tair_Sept.tif"),
+            't_obs_raster_path': os.path.join(
+                REGRESSION_DATA, "Tair_Sept.tif"),
             'lulc_raster_path': os.path.join(REGRESSION_DATA, "LULC_SFBA.tif"),
-            'ref_eto_raster_path': os.path.join(REGRESSION_DATA, "ETo_SFBA.tif"),
-            'aoi_vector_path': os.path.join(REGRESSION_DATA, "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
-            'biophysical_table_path': os.path.join(REGRESSION_DATA, "biophysical_table_ucm.csv"),
+            'ref_eto_raster_path': os.path.join(
+                REGRESSION_DATA, "ETo_SFBA.tif"),
+            'aoi_vector_path': os.path.join(
+                REGRESSION_DATA,
+                "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
+            'biophysical_table_path': os.path.join(
+                REGRESSION_DATA, "biophysical_table_ucm.csv"),
             'green_area_cooling_distance': 1000.0,
             'uhi_max': 3,
             'cc_method': 'factors',
             'do_valuation': True,
             't_air_average_radius': "1000.0",
-            'building_vector_path': os.path.join(REGRESSION_DATA, "buildings_clip.gpkg"),
-            'energy_consumption_table_path': os.path.join(REGRESSION_DATA, "Energy.csv"),
+            'building_vector_path': os.path.join(
+                REGRESSION_DATA, "buildings_clip.gpkg"),
+            'energy_consumption_table_path': os.path.join(
+                REGRESSION_DATA, "Energy.csv"),
             'avg_rel_humidity': '30.0',
             'cc_weight_shade': '0.6',
             'cc_weight_albedo': '0.2',
@@ -228,7 +244,6 @@ class UCMTests(unittest.TestCase):
             'n_workers': -1,
             }
 
-        gpkg_driver = gdal.GetDriverByName('GPKG')
         bad_building_vector_path = os.path.join(
             self.workspace_dir, 'bad_building_vector.gpkg')
 
@@ -257,18 +272,26 @@ class UCMTests(unittest.TestCase):
             'workspace_dir': self.workspace_dir,
             'results_suffix': 'test_suffix',
             't_ref': 35.0,
-            't_obs_raster_path': os.path.join(REGRESSION_DATA, "Tair_Sept.tif"),
-            'lulc_raster_path': os.path.join(REGRESSION_DATA, "LULC_SFBA.tif"),
-            'ref_eto_raster_path': os.path.join(REGRESSION_DATA, "ETo_SFBA.tif"),
-            'aoi_vector_path': os.path.join(REGRESSION_DATA, "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
-            'biophysical_table_path': os.path.join(REGRESSION_DATA, "biophysical_table_ucm.csv"),
+            't_obs_raster_path': os.path.join(
+                REGRESSION_DATA, "Tair_Sept.tif"),
+            'lulc_raster_path': os.path.join(
+                REGRESSION_DATA, "LULC_SFBA.tif"),
+            'ref_eto_raster_path': os.path.join(
+                REGRESSION_DATA, "ETo_SFBA.tif"),
+            'aoi_vector_path': os.path.join(
+                REGRESSION_DATA,
+                "watersheds_clippedDraft_Watersheds_SFEI.gpkg"),
+            'biophysical_table_path': os.path.join(
+                REGRESSION_DATA, "biophysical_table_ucm.csv"),
             'green_area_cooling_distance': 1000.0,
             'uhi_max': 3,
             'cc_method': 'factors',
             'do_valuation': True,
             't_air_average_radius': "1000.0",
-            'building_vector_path': os.path.join(REGRESSION_DATA, "buildings_clip.gpkg"),
-            'energy_consumption_table_path': os.path.join(REGRESSION_DATA, "Energy.csv"),
+            'building_vector_path': os.path.join(
+                REGRESSION_DATA, "buildings_clip.gpkg"),
+            'energy_consumption_table_path': os.path.join(
+                REGRESSION_DATA, "Energy.csv"),
             'avg_rel_humidity': '30.0',
             # Explicitly leaving CC weight parameters out.
             'n_workers': -1,
@@ -285,7 +308,8 @@ class UCMTests(unittest.TestCase):
         args['t_ref'] = 35.0
         args['cc_weight_shade'] = -0.6
         result = natcap.invest.urban_cooling_model.validate(args)
-        self.assertEqual(result[0][1], "Value does not meet condition value > 0")
+        self.assertEqual(
+            result[0][1], "Value does not meet condition value > 0")
 
         args['cc_weight_shade'] = "not a number"
         result = natcap.invest.urban_cooling_model.validate(args)

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -43,9 +43,9 @@ class UCMTests(unittest.TestCase):
             'building_vector_path': os.path.join(REGRESSION_DATA, "buildings_clip.gpkg"),
             'energy_consumption_table_path': os.path.join(REGRESSION_DATA, "Energy.csv"),
             'avg_rel_humidity': '30.0',
-            'cc_weight_shade': '0.6',
-            'cc_weight_albedo': '0.2',
-            'cc_weight_eti': '0.2',
+            'cc_weight_shade': '',  # to trigger default of 0.6
+            'cc_weight_albedo': None,  # to trigger default of 0.2
+            # Purposefully excluding cc_weight_eti to trigger default of 0.2
             'n_workers': -1,
         }
 

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -70,7 +70,7 @@ class UCMTests(unittest.TestCase):
             for key, expected_value in expected_results.items():
                 actual_value = float(results_feature.GetField(key))
                 self.assertAlmostEqual(
-                    actual_value, expected_value,
+                    actual_value, expected_value, places=4,
                     msg='%s should be close to %f, actual: %f' % (
                         key, expected_value, actual_value))
         finally:
@@ -195,7 +195,7 @@ class UCMTests(unittest.TestCase):
             for key, expected_value in expected_results.items():
                 actual_value = float(results_feature.GetField(key))
                 self.assertAlmostEqual(
-                    actual_value, expected_value,
+                    actual_value, expected_value, places=4,
                     msg='%s should be close to %f, actual: %f' % (
                         key, expected_value, actual_value))
         finally:

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -147,9 +147,12 @@ class UCMTests(unittest.TestCase):
                     # When energy_sav is Nonetype
                     n_nonetype += 1
 
-            self.assertAlmostEqual(energy_sav, expected_energy_sav, msg=(
-                '%f should be close to %f' % (
-                    energy_sav, expected_energy_sav)))
+            # These accumulated values are accumulated
+            # and may differ past about 4 decimal places.
+            self.assertAlmostEqual(
+                energy_sav, expected_energy_sav, places=4, msg=(
+                    '%f should be close to %f' % (
+                        energy_sav, expected_energy_sav)))
             self.assertEqual(n_nonetype, 119)
         finally:
             buildings_layer = None

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -104,9 +104,10 @@ class UCMTests(unittest.TestCase):
                     # When energy_sav is NoneType
                     n_nonetype += 1
 
-            self.assertAlmostEqual(energy_sav, expected_energy_sav, msg=(
-                '%f should be close to %f' % (
-                    energy_sav, expected_energy_sav)))
+            self.assertAlmostEqual(
+                energy_sav, expected_energy_sav, places=4, msg=(
+                    '%f should be close to %f' % (
+                        energy_sav, expected_energy_sav)))
             self.assertEqual(n_nonetype, 119)
         finally:
             buildings_layer = None

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -60,7 +60,7 @@ class UCMTests(unittest.TestCase):
             'avg_cc': 0.222150472947109,
             'avg_tmp_v': 37.325275675470998,
             'avg_tmp_an': 2.325275675470998,
-            'avd_eng_cn': 9019.152329608312357,
+            'avd_eng_cn': 3520212.4242880843,
             'avg_wbgt_v': 32.60417266705069,
             'avg_ltls_v': 75.000000000000000,
             'avg_hvls_v': 75.000000000000000,
@@ -79,7 +79,7 @@ class UCMTests(unittest.TestCase):
 
         # Assert that the decimal value of the energy savings value is what we
         # expect.
-        expected_energy_sav = 9361.431821463711
+        expected_energy_sav = 3564033.336855425
         energy_sav = 0.0
         n_nonetype = 0
         stats_vector_path = (
@@ -186,7 +186,7 @@ class UCMTests(unittest.TestCase):
             'avg_cc': 0.428302583240327,
             'avg_tmp_v': 36.60869797039769,
             'avg_tmp_an': 1.608697970397692,
-            'avd_eng_cn': 18787.273592787547,
+            'avd_eng_cn': 7240099.951768191,
             'avg_wbgt_v': 31.91108630952381,
             'avg_ltls_v': 28.744239631336406,
             'avg_hvls_v': 75.000000000000000,

--- a/tests/test_ucm.py
+++ b/tests/test_ucm.py
@@ -77,6 +77,8 @@ class UCMTests(unittest.TestCase):
         try:
             for key, expected_value in expected_results.items():
                 actual_value = float(results_feature.GetField(key))
+                # These accumulated values (esp. avd_eng_cn) are accumulated
+                # and may differ past about 4 decimal places.
                 self.assertAlmostEqual(
                     actual_value, expected_value, places=4,
                     msg='%s should be close to %f, actual: %f' % (
@@ -104,6 +106,8 @@ class UCMTests(unittest.TestCase):
                     # When energy_sav is NoneType
                     n_nonetype += 1
 
+            # Expected energy savings is an accumulated value and may differ
+            # past about 4 decimal places.
             self.assertAlmostEqual(
                 energy_sav, expected_energy_sav, places=4, msg=(
                     '%f should be close to %f' % (
@@ -204,6 +208,8 @@ class UCMTests(unittest.TestCase):
         try:
             for key, expected_value in expected_results.items():
                 actual_value = float(results_feature.GetField(key))
+                # These accumulated values (esp. avd_eng_cn) are accumulated
+                # and may differ past about 4 decimal places.
                 self.assertAlmostEqual(
                     actual_value, expected_value, places=4,
                     msg='%s should be close to %f, actual: %f' % (


### PR DESCRIPTION
This PR updates the Urban Cooling model's energy consumption equation in response to a discussion that's been playing out on the side and in response to a [discussion on the forums](https://community.naturalcapitalproject.org/t/understanding-urban-cooling-energy-consumption-input/1006).

Summary of changes:

* Energy consumption inputs are now considered to be in units of kWh/Degrees C/m^2.  This requires that we include the building footprint area (in m^2) in the energy consumption calculations. (see #138)
  * The UG has been updated (and repo rev updated here) to include the above unit change
  * Tests updated to reflect the above unit change
* The model now very explicitly handles cases where the user does not provide an input value for the cooling coefficient inputs.  Cases where parameters are `""`, `None` and absent from `args` are all accounted for and default values assumed.  (see #28 )
* In debugging this, it turned out that there was an issue with which version of InVEST was being installed in these tests.  The model tests workflow has been updated to install exactly which file we want to install, rather than relying on pip to find it for us.
* PEP8/pylint updates in `test_ucm.py`.

Fixes #138 , fixes #28 