### PR TITLE
Handle non projected inputs nicely in HRA

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,8 @@
 ..
   Unreleased Changes
   ------------------
+* HRA
+    * Raise ValueError if habitat or stressor inputs are not projected.
 
 3.8.7 (2020-07-17)
 ------------------

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -179,17 +179,17 @@ ARGS_SPEC = {
 def execute(args):
     """InVEST Habitat Risk Assessment (HRA) Model.
 
-    Parameters:
+    Args:
         args['workspace_dir'] (str): a path to the output workspace folder.
             It will overwrite any files that exist if the path already exists.
         args['results_suffix'] (str): a string appended to each output file
             path. (optional)
         args['info_table_path'] (str): a path to the CSV or Excel file that
-            contains the name of the habitat (H) or stressor (s) on the ``NAME``
-            column that matches the names in criteria_table_path. Each H/S has
-            its corresponding vector or raster path on the ``PATH`` column. The
-            ``STRESSOR BUFFER (meters)`` column should have a buffer value if
-            the ``TYPE`` column is a stressor.
+            contains the name of the habitat (H) or stressor (s) on the
+            ``NAME`` column that matches the names in criteria_table_path.
+            Each H/S has its corresponding vector or raster path on the
+            ``PATH`` column. The ``STRESSOR BUFFER (meters)`` column should
+            have a buffer value if the ``TYPE`` column is a stressor.
         args['criteria_table_path'] (str): a path to the CSV or Excel file that
             contains the set of criteria ranking of each stressor on each
             habitat.
@@ -214,7 +214,8 @@ def execute(args):
             place in the current process. (optional)
         args['visualize_outputs'] (bool): if True, create output GeoJSONs and
             save them in a visualization_outputs folder, so users can visualize
-            results on the web app. Default to True if not specified. (optional)
+            results on the web app. Default to True if not specified.
+            (optional)
 
     Returns:
         None.
@@ -284,7 +285,6 @@ def execute(args):
         target_sr = osr.SpatialReference()
         if target_sr_wkt:
             target_sr.ImportFromWkt(target_sr_wkt)
-
         if not target_sr.IsProjected():
             raise ValueError(
                 'The AOI vector file %s is provided but not projected.' %
@@ -425,7 +425,8 @@ def execute(args):
 
                 # If it's a spatial criteria vector, burn the values from the
                 # ``rating`` attribute
-                rasterize_kwargs['option_list'] = ["ATTRIBUTE=" + _RATING_FIELD]
+                rasterize_kwargs['option_list'] = [
+                    "ATTRIBUTE=" + _RATING_FIELD]
                 rasterize_nodata = _TARGET_NODATA_FLT
                 rasterize_pixel_type = _TARGET_PIXEL_FLT
 
@@ -531,7 +532,8 @@ def execute(args):
             task_graph.add_task(
                 func=_calc_habitat_recovery,
                 args=(habitat_raster_path, habitat_recovery_df, max_rating),
-                target_path_list=[recovery_raster_path, recovery_num_raster_path],
+                target_path_list=[
+                    recovery_raster_path, recovery_num_raster_path],
                 task_name='calculate_%s_recovery' % habitat,
                 dependent_task_list=[align_and_resize_rasters_task]))
 
@@ -601,7 +603,8 @@ def execute(args):
             pair_e_raster_path, pair_c_raster_path, \
                 target_pair_risk_raster_path = [
                     habitat_stressor_overlap_df.loc[path] for path in
-                    ['E_RASTER_PATH', 'C_RASTER_PATH', 'PAIR_RISK_RASTER_PATH']]
+                    ['E_RASTER_PATH', 'C_RASTER_PATH',
+                     'PAIR_RISK_RASTER_PATH']]
             pair_risk_calculation_list = [
                 (pair_e_raster_path, 1), (pair_c_raster_path, 1),
                 ((max_rating, 'raw')), (args['risk_eq'], 'raw')]
@@ -839,7 +842,8 @@ def execute(args):
 
     task_graph.add_task(
         func=_zonal_stats_to_csv,
-        args=(overlap_df, habitats_info_df, region_list, target_stats_csv_path),
+        args=(
+            overlap_df, habitats_info_df, region_list, target_stats_csv_path),
         target_path_list=[target_stats_csv_path],
         task_name='zonal_stats_to_csv',
         dependent_task_list=zonal_stats_dependent_tasks)
@@ -930,7 +934,7 @@ def _raster_to_geojson(
     So a GPKG serves as intermediate storage for the polygonized projected
     features.
 
-    Parameters:
+    Args:
         base_raster_path (str): the raster that needs to be turned into a
             GeoJSON file.
         target_geojson_path (str): the desired path for the new GeoJSON.
@@ -994,7 +998,7 @@ def _calc_and_pickle_zonal_stats(
     Clip the score raster with the bounding box of zonal raster first, so
     we only look at blocks that intersect.
 
-    Parameters:
+    Args:
         score_raster_path (str): a path to the E/C/risk score raster to be
             analyzed.
         zonal_raster_path (str): a path to the zonal raster with 1s
@@ -1115,7 +1119,7 @@ def _zonal_stats_to_csv(
         overlap_df, info_df, region_list, target_stats_csv_path):
     """Unpickle zonal stats from files and concatenate the dataframe into CSV.
 
-    Parameters:
+    Args:
         overlap_df (dataframe): a multi-index dataframe with exposure and
             consequence raster paths, as well as pickle path columns for
             getting zonal statistics dictionary from.
@@ -1218,7 +1222,7 @@ def _create_rasters_from_geometries(
     Pixel value of 1 on the target rasters indicates the existence of the
     geometry collection, and everywhere else is nodata.
 
-    Parameters:
+    Args:
         geom_pickle_path (str): a path to a tuple of pickled
             geom_sets_by_field, a list of shapely geometry objects in Well
             Known Binary (WKB) format, and target spatial reference in Well
@@ -1332,7 +1336,7 @@ def _get_vector_geometries_by_field(
         base_vector_path, field_name, target_geom_pickle_path):
     """Get a dictionary of field values with list of geometries from a vector.
 
-    Parameters:
+    Args:
         base_vector_path (str): a path to the vector the get geometry
             collections based on the given field name.
         field_name (str): the field name used to aggregate the geometries
@@ -1381,7 +1385,7 @@ def _get_vector_geometries_by_field(
 def _has_field_name(base_vector_path, field_name):
     """Check if the vector attribute table has the designated field name.
 
-    Parameters:
+    Args:
         base_vector_path (str): a path to the vector to check the field name
             with.
         field_name (str): the field name to be inspected.
@@ -1408,7 +1412,7 @@ def _ecosystem_risk_op(habitat_count_arr, *hab_risk_arrays):
 
     Divide the total risk by the number of habitats on each pixel.
 
-    Parameters:
+    Args:
         habitat_count_arr (array): an integer array with each pixel indicating
             the number of habitats existing on that pixel.
         *hab_risk_arrays: a list of arrays representing reclassified risk
@@ -1448,7 +1452,7 @@ def _reclassify_ecosystem_risk_op(ecosystem_risk_arr, max_rating):
     Note: If 3*(risk/max rating) == 0, it will remain 0, meaning that there's
     no stressor on the ecosystem.
 
-    Parameters:
+    Args:
         ecosystem_risk_arr (array): an average risk score calculated by
             dividing the cumulative habitat risks by the habitat count in
             that pixel.
@@ -1476,7 +1480,7 @@ def _reclassify_ecosystem_risk_op(ecosystem_risk_arr, max_rating):
 def _count_habitats_op(*habitat_arrays):
     """Adding pixel values together from multiple arrays.
 
-    Parameters:
+    Args:
         *habitat_arrays: a list of arrays with 1s and 0s values.
 
     Returns:
@@ -1509,10 +1513,11 @@ def _reclassify_risk_op(risk_arr, max_rating):
     Note: If risk == 0, it will remain 0, meaning that there's no
     stressor on that habitat.
 
-    Parameters:
+    Args:
         risk_arr (array): an array of cumulative risk scores from all stressors
         max_rating (float): the maximum possible risk score used for
             reclassifying the risk score into 0 to 3 on each pixel.
+
     Returns:
         reclass_arr (array): an integer array of reclassified risk scores for a
             certain habitat. The values are discrete on the array.
@@ -1535,7 +1540,7 @@ def _tot_risk_op(habitat_arr, *pair_risk_arrays):
     The risk score is calculated by summing up all the risk scores on each
     valid pixel of the habitat.
 
-    Parameters:
+    Args:
         habitat_arr (array): an integer habitat array where 1's indicates
             habitat existence and 0's non-existence.
         *pair_risk_arrays: a list of individual risk float arrays from each
@@ -1569,7 +1574,7 @@ def _pair_risk_op(exposure_arr, consequence_arr, max_rating, risk_eq):
     Euclidean risk equation: R = sqrt((E-1)^2 + (C-1)^2)
     Multiplicative risk equation: R = E * C
 
-    Parameters:
+    Args:
         exosure_arr (array): a float array with total exposure scores.
         consequence_arr (array): a float array with total consequence scores.
         max_rating (float): a number representing the highest potential value
@@ -1630,7 +1635,7 @@ def _total_exposure_op(habitat_arr, *num_denom_list):
     the total numerator by the total denominator on habitat pixels, to get
     the final exposure or consequence score.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         *num_denom_list (list): if exists, it's a list of numerator float
@@ -1688,7 +1693,7 @@ def _total_consequence_op(
     respectively, then divide the total numerator by the total denominator on
     habitat pixels, to get the final consequence score.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         recov_num_arr (array): a float array of the numerator score from
@@ -1748,7 +1753,7 @@ def _pair_exposure_op(
     function will only calculate the score on pixels where both habitat
     and stressor (including buffer zone) exist.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         stressor_dist_arr (array): a stressor distance float array where pixel
@@ -1800,7 +1805,7 @@ def _pair_consequence_op(
     function will only calculate the score on pixels where both habitat
     and stressor (including buffer zone) exist.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         stressor_dist_arr (array): a stressor distance float array where pixel
@@ -1859,7 +1864,7 @@ def _pair_criteria_num_op(
     and stressor (including buffer zone) exist. A spatial criteria will be
     added if spatial_explicit_arr_const is provided.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1s indicates habitat
             existence and 0s non-existence.
         stressor_dist_arr (array): a stressor distance float array where pixel
@@ -1936,7 +1941,7 @@ def _calc_pair_criteria_score(
         recov_params=None):
     """Calculate exposure or consequence scores for a habitat-stressor pair.
 
-    Parameters:
+    Args:
         habitat_stressor_overlap_df (dataframe): a dataframe that has
             information on stressor and habitat overlap property.
         habitat_raster_path (str): a path to the habitat raster where 0's
@@ -2026,7 +2031,7 @@ def _tot_recovery_op(habitat_arr, num_arr, denom, max_rating):
     If 1 < score <= 2, reclassify it to 2.
     If 2 < score <= 3, reclassify it to 3.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         num_arr (array): a float array of the numerator score for recovery
@@ -2063,7 +2068,7 @@ def _recovery_num_op(habitat_arr, num, *spatial_explicit_arr_const):
     This function will only calculate the score on pixels where habitat exists,
     and use a spatial criteria if spatial_explicit_arr_const is provided.
 
-    Parameters:
+    Args:
         habitat_arr (array): a habitat integer array where 1's indicates
             habitat existence and 0's non-existence.
         num (float): a cumulative value pre-calculated based on the criteria
@@ -2106,7 +2111,7 @@ def _calc_habitat_recovery(
         habitat_raster_path, habitat_recovery_df, max_rating):
     """Calculate habitat raster recovery potential based on recovery scores.
 
-    Parameters:
+    Args:
         habitat_raster_path (str): a path to the habitat raster where 0's
             indicate no habitat and 1's indicate habitat existence. 1's will be
             used for calculating recovery potential output raster.
@@ -2164,7 +2169,7 @@ def _append_spatial_raster_row(info_df, recovery_df, overlap_df,
                                spatial_file_dir, output_dir, suffix_end):
     """Append spatial raster to NAME, PATH, and TYPE column of info_df.
 
-    Parameters:
+    Args:
         info_df (dataframe): the dataframe to append spatial raster information
             to.
         recovery_df (dataframe): the dataframe that has the spatial raster
@@ -2231,7 +2236,7 @@ def _append_spatial_raster_row(info_df, recovery_df, overlap_df,
 def _to_abspath(base_path, dir_path):
     """Return an absolute path within dir_path if the given path is relative.
 
-    Parameters:
+    Args:
         base_path (str): a path to the file to be examined.
         dir_path (str): a path to the directory which will be used to create
             absolute file paths.
@@ -2260,7 +2265,7 @@ def _label_raster(path):
 
     If the provided path is a relative path, join it with the dir_path provide.
 
-    Parameters:
+    Args:
         path (str): a path to the file to be opened with GDAL.
 
     Returns:
@@ -2288,7 +2293,7 @@ def _label_raster(path):
 def _generate_raster_path(row, dir_path, suffix_front, suffix_end):
     """Generate a raster file path with suffixes in dir_path.
 
-    Parameters:
+    Args:
         row (pandas.Series): a row on the dataframe to get path value from.
         dir_path (str): a path to the folder which raster paths will be
             created based on.
@@ -2321,7 +2326,7 @@ def _generate_raster_path(row, dir_path, suffix_front, suffix_end):
 def _generate_vector_path(row, dir_path, suffix_front, suffix_end):
     """Generate a vector file path with suffixes in dir_path for vector types.
 
-    Parameters:
+    Args:
         row (pandas.Series): a row on the dataframe to get path value from.
         dir_path (str): a path to the folder which vector paths will be
             created based on.
@@ -2347,7 +2352,7 @@ def _generate_vector_path(row, dir_path, suffix_front, suffix_end):
 def _generate_pickle_path(row, dir_path, suffix_front, suffix_end):
     """Generate a pickle file path with suffixes in dir_path for habitat types.
 
-    Parameters:
+    Args:
         row (pandas.Series): a row on the dataframe to get path value from.
         dir_path (str): a path to the folder which raster paths will be
             created based on.
@@ -2372,7 +2377,7 @@ def _generate_pickle_path(row, dir_path, suffix_front, suffix_end):
 def _label_linear_unit(row):
     """Get linear unit from path, and keep track of paths w/o projection.
 
-    Parameters:
+    Args:
         row (pandas.Series): a row on the dataframe to get path value from.
 
     Returns:
@@ -2381,6 +2386,7 @@ def _label_linear_unit(row):
 
     Raises:
         ValueError if any of the file's spatial reference is missing.
+        ValueError if any of the file's are not linearly projected.
 
     """
     if row['IS_RASTER']:
@@ -2397,8 +2403,12 @@ def _label_linear_unit(row):
         vector = None
 
     if not spat_ref:
-        raise ValueError('The following layer does not have a projection: %s' %
-                         row['PATH'])
+        raise ValueError(
+            f"The following layer does not have a projection: {row['PATH']}")
+    elif not spat_ref.IsProjected():
+        raise ValueError(
+            "The following layer is not projected in linear units:"
+            f"{row['PATH']}")
     else:
         return float(spat_ref.GetLinearUnits())
 
@@ -2410,7 +2420,7 @@ def _get_info_dataframe(base_info_table_path, file_preprocessing_dir,
     Add new columns that provide file information and target file paths of each
     given habitat or stressors to the dataframe.
 
-    Parameters:
+    Args:
         base_info_table_path (str): a path to the CSV or excel file that
             contains the path and buffer information.
         file_preprocessing_dir (str): a path to the folder where simplified
@@ -2550,7 +2560,7 @@ def _get_info_dataframe(base_info_table_path, file_preprocessing_dir,
 def _get_criteria_dataframe(base_criteria_table_path):
     """Get validated criteria dataframe from a criteria table.
 
-    Parameters:
+    Args:
         base_criteria_table_path (str): a path to the CSV or Excel file with
             habitat and stressor criteria ratings.
 
@@ -2615,7 +2625,7 @@ def _get_attributes_from_df(criteria_df, habitat_names, stressor_names):
 
     Get the info from the criteria dataframe.
 
-    Parameters:
+    Args:
         criteria_df (dataframe): a validated dataframe with required
             fields in it.
         habitat_names (list): a list of habitat names obtained from info table.
@@ -2710,7 +2720,7 @@ def _validate_rating(
         rating, max_rating, criteria_name, habitat, stressor=None):
     """Validate rating value, which should range between 1 to maximum rating.
 
-    Parameters:
+    Args:
         rating (str): a string of either digit or file path. If it's a digit,
             it should range between 1 to maximum rating.
         max_rating (float): a number representing the highest value that
@@ -2763,7 +2773,7 @@ def _validate_rating(
 def _validate_dq_weight(dq, weight, habitat, stressor=None):
     """Check if DQ and Weight column values are numbers.
 
-    Parameters:
+    Args:
         dq (str): a string representing the value of data quality score.
         weight (str): a string representing the value of weight score.
         habitat (str): the name of the habitat where the score is from.
@@ -2807,7 +2817,7 @@ def _get_overlap_dataframe(criteria_df, habitat_names, stressor_attributes,
     spatially explicit criteria scores will be added to the score calculation
     later on.
 
-    Parameters:
+    Args:
         criteria_df (dataframe): a validated dataframe with required fields.
         habitat_names (list): a list of habitat names used as dataframe index.
         stressor_attributes (dict): a dictionary with stressor names as keys,
@@ -2979,7 +2989,7 @@ def _get_recovery_dataframe(criteria_df, habitat_names, resilience_attributes,
     numerator, denominator, spatially explicit criteria dict, score raster
     path, and numerator raster path.
 
-    Parameters:
+    Args:
         criteria_df (dataframe): a validated dataframe with required
             fields.
         habitat_names (list): a list of habitat names used as dataframe index.
@@ -3056,7 +3066,8 @@ def _get_recovery_dataframe(criteria_df, habitat_names, resilience_attributes,
                         habitat + '_' + resilience_attr] = [rating, dq, weight]
 
                 # Add 1/(dq*w) to the denominator
-                recovery_df.loc[habitat, 'R_DENOM'] += 1/float(dq)/float(weight)
+                recovery_df.loc[habitat, 'R_DENOM'] += (
+                    1/float(dq)/float(weight))
 
             i += 3  # Jump to next habitat
         else:
@@ -3074,7 +3085,7 @@ def _simplify_geometry(
     See https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem
     for the math prove.
 
-    Parameters:
+    Args:
         base_vector_path (string): path to base vector.
         tolerance (float): all new vertices in the geometry will be within
             this distance (in units of the vector's projection).
@@ -3140,7 +3151,7 @@ def _simplify_geometry(
 
         # If simplify doesn't work, fall back to the original geometry
         else:
-            # Still using the target_feature here because the preserve_field 
+            # Still using the target_feature here because the preserve_field
             # option altered the layer defn between base and target.
             target_feature.SetGeometry(base_geometry)
             target_simplified_layer.CreateFeature(target_feature)
@@ -3157,7 +3168,7 @@ def _simplify_geometry(
 def validate(args, limit_to=None):
     """Validate args to ensure they conform to ``execute``'s contract.
 
-    Parameters:
+    Args:
         args (dict): dictionary of key(str)/value pairs where keys and
             values are specified in ``execute`` docstring.
         limit_to (str): (optional) if not None indicates that validation

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -2385,8 +2385,8 @@ def _label_linear_unit(row):
             to transform them to meters
 
     Raises:
-        ValueError if any of the file's spatial reference is missing.
-        ValueError if any of the file's are not linearly projected.
+        ValueError if any of the file's spatial reference is missing or if 
+            any of the file's are not linearly projected.
 
     """
     if row['IS_RASTER']:
@@ -2402,13 +2402,10 @@ def _label_linear_unit(row):
         layer = None
         vector = None
 
-    if not spat_ref:
+    if not spat_ref or not spat_ref.IsProjected():
         raise ValueError(
-            f"The following layer does not have a projection: {row['PATH']}")
-    elif not spat_ref.IsProjected():
-        raise ValueError(
-            "The following layer is not projected in linear units:"
-            f"{row['PATH']}")
+            "The following layer does not have a spatial reference or is not"
+            f"projected (in linear units): {row['PATH']}")
     else:
         return float(spat_ref.GetLinearUnits())
 

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -744,7 +744,7 @@ class HraUnitTests(unittest.TestCase):
             1E-6)
 
     def test_simplify_geometry_points(self):
-        """HRA: test _simplify_geometry does't alter geometry given points."""
+        """HRA: test _simplify_geometry does not alter point geometries."""
         from natcap.invest.hra import _simplify_geometry
 
         srs = osr.SpatialReference()
@@ -965,8 +965,8 @@ class HraRegressionTests(unittest.TestCase):
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
-    def test_layer_no_projection(self):
-        """HRA: testing habitats and stressors without projection."""
+    def test_layer_without_spatial_ref(self):
+        """HRA: test habitats and stressors w/out spatial references."""
         import natcap.invest.hra
 
         args = HraRegressionTests.generate_base_args(self.workspace_dir)
@@ -982,12 +982,12 @@ class HraRegressionTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             natcap.invest.hra.execute(args)
 
-        expected_message = 'The following layer does not have a projection'
+        expected_message = "The following layer does not have a spatial"
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
-    def test_layer_geographic(self):
-        """HRA: testing habitats and stressors that are not projected."""
+    def test_non_projected_layers(self):
+        """HRA: test habitat and stressor layers that are not projected."""
         import natcap.invest.hra
 
         args = HraRegressionTests.generate_base_args(self.workspace_dir)
@@ -1024,8 +1024,7 @@ class HraRegressionTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             natcap.invest.hra.execute(args)
 
-        expected_message = ("The following layer is not projected in linear"
-                            " units:")
+        expected_message = "The following layer does not have a spatial"
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -23,7 +23,7 @@ EPSG_CODE = 26910
 def _make_simple_vector(target_vector_path, projected=True):
     """Make a 10x10 ogr rectangular geometry shapefile.
 
-    Parameters:
+    Args:
         target_vector_path (str): path to the output shapefile.
 
         projected (bool): if true, define projection information for the vector
@@ -71,7 +71,7 @@ def _make_simple_vector(target_vector_path, projected=True):
 def _make_rating_vector(target_vector_path):
     """Make a 10x10 ogr rectangular geometry shapefile with `rating` field.
 
-    Parameters:
+    Args:
         target_vector_path (str): path to the output shapefile.
 
     Returns:
@@ -121,7 +121,7 @@ def _make_rating_vector(target_vector_path):
 def _make_aoi_vector(target_vector_path, projected=True, subregion_field=True):
     """Make a 20x20 ogr rectangular geometry shapefile with `rating` field.
 
-    Parameters:
+    Args:
         target_vector_path (str): path to the output shapefile.
 
         projected (bool): if true, define projection information for the vector
@@ -179,7 +179,7 @@ def _make_aoi_vector(target_vector_path, projected=True, subregion_field=True):
 def _make_raster_from_array(base_array, target_raster_path, projected=True):
     """Make a raster from an array on a designated path.
 
-    Parameters:
+    Args:
         array (numpy.ndarray): the 2D array for making the raster.
 
         raster_path (str): path to the output raster.
@@ -210,7 +210,7 @@ def _make_info_csv(info_table_path, workspace_dir, missing_columns=False,
                    projected=True, rel_path=False):
     """Make a synthesized information csv on the designated path.
 
-    Parameters:
+    Args:
         info_table_path (str): path to the csv with information on habitats and
             stressors.
 
@@ -218,8 +218,8 @@ def _make_info_csv(info_table_path, workspace_dir, missing_columns=False,
 
         missing_columns (bool): if true, write wrong column headers to the CSV.
 
-        wrong_layer_type (bool): if true, write a type different from `habitat` or
-            `stressor`.
+        wrong_layer_type (bool): if true, write a type different from
+            ``habitat`` or ``stressor``.
 
         wrong_buffer_value (bool): if true, write a string to the buffer column
 
@@ -283,7 +283,8 @@ def _make_info_csv(info_table_path, workspace_dir, missing_columns=False,
             if projected:
                 _make_raster_from_array(array, abs_raster_path, projected=True)
             else:
-                _make_raster_from_array(array, abs_raster_path, projected=False)
+                _make_raster_from_array(
+                    array, abs_raster_path, projected=False)
 
             if rel_path:
                 rel_raster_path = os.path.relpath(
@@ -311,7 +312,7 @@ def _make_criteria_csv(
         rel_path=False):
     """Make a synthesized information CSV on the designated path.
 
-    Parameters:
+    Args:
 
         info_table_path (str): path to the CSV or Excel file with information
             on habitats and stressors.
@@ -380,9 +381,11 @@ def _make_criteria_csv(
         if rel_path:
             rel_rating_raster_path = os.path.relpath(
                 abs_rating_raster_path, workspace_dir)
-            table.write('"criteria 1",'+rel_rating_raster_path+',2,2,3,2,2,C\n')
+            table.write(
+                '"criteria 1",'+rel_rating_raster_path+',2,2,3,2,2,C\n')
         else:
-            table.write('"criteria 1",'+abs_rating_raster_path+',2,2,3,2,2,C\n')
+            table.write(
+                '"criteria 1",'+abs_rating_raster_path+',2,2,3,2,2,C\n')
         table.write('"criteria 2",0,2,2,1,2,2,C\n')
 
         if missing_index:
@@ -397,9 +400,11 @@ def _make_criteria_csv(
         if rel_path:
             rel_rating_vector_path = os.path.relpath(
                 abs_rating_vector_path, workspace_dir)
-            table.write('"criteria 3",2,2,2,'+rel_rating_vector_path+',2,2,C\n')
+            table.write(
+                '"criteria 3",2,2,2,'+rel_rating_vector_path+',2,2,C\n')
         else:
-            table.write('"criteria 3",2,2,2,'+abs_rating_vector_path+',2,2,C\n')
+            table.write(
+                '"criteria 3",2,2,2,'+abs_rating_vector_path+',2,2,C\n')
         table.write('"criteria 4",1,2,2,0,2,2,E\n')
 
         if missing_layer_names:
@@ -428,7 +433,7 @@ class HraUnitTests(unittest.TestCase):
     """Unit tests for the Wind Energy module."""
 
     def setUp(self):
-        """Overriding setUp function to create temporary workspace directory."""
+        """Overriding setUp function to create temp workspace directory."""
         # this lets us delete the workspace after its done no matter the
         # the rest result
         self.workspace_dir = tempfile.mkdtemp()
@@ -439,7 +444,8 @@ class HraUnitTests(unittest.TestCase):
 
     def test_missing_criteria_header(self):
         """HRA: exception raised when missing criteria from criteria CSV."""
-        from natcap.invest.hra import _get_criteria_dataframe, _get_overlap_dataframe
+        from natcap.invest.hra import _get_criteria_dataframe
+        from natcap.invest.hra import _get_overlap_dataframe
 
         # Create a criteria CSV that misses a criteria type
         bad_criteria_table_path = os.path.join(
@@ -461,7 +467,8 @@ class HraUnitTests(unittest.TestCase):
 
     def test_unknown_criteria_from_criteria_csv(self):
         """HRA: exception raised with unknown criteria from criteria CSV."""
-        from natcap.invest.hra import _get_criteria_dataframe, _get_attributes_from_df
+        from natcap.invest.hra import _get_criteria_dataframe
+        from natcap.invest.hra import _get_attributes_from_df
 
         # Create a criteria CSV that has a criteria row that shows up before
         # any stressors
@@ -480,7 +487,7 @@ class HraUnitTests(unittest.TestCase):
         self.assertTrue(expected_message in actual_message, actual_message)
 
     def test_missing_index_from_criteria_csv(self):
-        """HRA: correct error message when missing indexes from criteria CSV."""
+        """HRA: correct error msg when missing indexes from criteria CSV."""
         from natcap.invest.hra import _get_criteria_dataframe
 
         # Use a criteria CSV that misses two indexes
@@ -500,7 +507,7 @@ class HraUnitTests(unittest.TestCase):
             expected_message in actual_message, actual_message)
 
     def test_missing_criteria_header_from_criteria_csv(self):
-        """HRA: correct error message when missing indexes from criteria CSV."""
+        """HRA: correct error msg when missing indexes from criteria CSV."""
         from natcap.invest.hra import _get_criteria_dataframe
 
         # Use a criteria CSV that misses two indexes
@@ -536,7 +543,8 @@ class HraUnitTests(unittest.TestCase):
         copied_criteria_excel_path = os.path.join(
             self.workspace_dir, 'criteria_excel.xlsx')
         shutil.copyfile(criteria_excel_path, copied_criteria_excel_path)
-        out_df = _get_criteria_dataframe(copied_criteria_excel_path).astype(str)
+        out_df = _get_criteria_dataframe(
+                    copied_criteria_excel_path).astype(str)
 
         self.assertTrue(
             out_df.equals(expected_df),
@@ -634,7 +642,8 @@ class HraUnitTests(unittest.TestCase):
 
     def test_wrong_criteria_type_type(self):
         """HRA: exception raised when type is not C or E from criteria CSV."""
-        from natcap.invest.hra import _get_criteria_dataframe, _get_overlap_dataframe
+        from natcap.invest.hra import _get_criteria_dataframe
+        from natcap.invest.hra import _get_overlap_dataframe
 
         # Use a criteria CSV that's missing a criteria type
         bad_criteria_table_path = os.path.join(
@@ -657,7 +666,8 @@ class HraUnitTests(unittest.TestCase):
 
     def test_wrong_weight_from_criteria_csv(self):
         """HRA: exception raised when weight is not a number from CSV."""
-        from natcap.invest.hra import _get_criteria_dataframe, _get_overlap_dataframe
+        from natcap.invest.hra import _get_criteria_dataframe
+        from natcap.invest.hra import _get_overlap_dataframe
 
         # Use a criteria CSV that's missing a criteria type
         bad_criteria_table_path = os.path.join(
@@ -680,7 +690,8 @@ class HraUnitTests(unittest.TestCase):
 
     def test_large_rating_from_criteria_csv(self):
         """HRA: exception raised when rating is larger than maximum rating."""
-        from natcap.invest.hra import _get_criteria_dataframe, _get_overlap_dataframe
+        from natcap.invest.hra import _get_criteria_dataframe
+        from natcap.invest.hra import _get_overlap_dataframe
 
         # Use a criteria CSV that's missing a criteria type
         bad_criteria_table_path = os.path.join(
@@ -733,7 +744,7 @@ class HraUnitTests(unittest.TestCase):
             1E-6)
 
     def test_simplify_geometry_points(self):
-        """HRA: test _simplify_geometry does not alter geometry given points."""
+        """HRA: test _simplify_geometry does't alter geometry given points."""
         from natcap.invest.hra import _simplify_geometry
 
         srs = osr.SpatialReference()
@@ -794,7 +805,7 @@ class HraRegressionTests(unittest.TestCase):
 
     @staticmethod
     def generate_base_args(workspace_dir):
-        """Generate args dict that is consistent across all regression tests."""
+        """Generate args dict that's consistent across all regression tests."""
         args = {
             'workspace_dir': workspace_dir,
             'results_suffix': '',
@@ -812,7 +823,7 @@ class HraRegressionTests(unittest.TestCase):
         return args
 
     def test_hra_regression_euclidean_linear(self):
-        """HRA: regression testing synthetic data with linear, euclidean eqn."""
+        """HRA: regression testing synthetic data w/ linear, euclidean eqn."""
         import natcap.invest.hra
 
         args = HraRegressionTests.generate_base_args(self.workspace_dir)
@@ -840,7 +851,8 @@ class HraRegressionTests(unittest.TestCase):
 
         # Assert rasters are equal
         output_raster_paths = [
-            os.path.join(args['workspace_dir'], 'outputs', raster_name + '.tif')
+            os.path.join(
+                args['workspace_dir'], 'outputs', raster_name + '.tif')
             for raster_name in output_rasters]
         expected_raster_paths = [os.path.join(
             TEST_DATA, raster_name + '_euc_lin.tif') for raster_name in
@@ -963,13 +975,57 @@ class HraRegressionTests(unittest.TestCase):
 
         # Make unprojected files and write their filepaths to info csv.
         bad_info_table_path = os.path.join(self.workspace_dir, 'bad_info.csv')
-        _make_info_csv(bad_info_table_path, self.workspace_dir, projected=False)
+        _make_info_csv(
+            bad_info_table_path, self.workspace_dir, projected=False)
         args['info_table_path'] = bad_info_table_path
 
         with self.assertRaises(ValueError) as cm:
             natcap.invest.hra.execute(args)
 
         expected_message = 'The following layer does not have a projection'
+        actual_message = str(cm.exception)
+        self.assertTrue(expected_message in actual_message, actual_message)
+
+    def test_layer_geographic(self):
+        """HRA: testing habitats and stressors that are not projected."""
+        import natcap.invest.hra
+
+        args = HraRegressionTests.generate_base_args(self.workspace_dir)
+        _make_criteria_csv(args['criteria_table_path'], self.workspace_dir)
+        _make_aoi_vector(args['aoi_vector_path'])
+
+        # Make projected files and write their filepaths to info csv.
+        info_table_path = os.path.join(self.workspace_dir, 'info.csv')
+        _make_info_csv(
+            info_table_path, self.workspace_dir, projected=True,
+            rel_path=False)
+
+        # create geographic spatial reference
+        wgs84_srs = osr.SpatialReference()
+        wgs84_srs.ImportFromEPSG(4326)
+        wgs84_wkt = wgs84_srs.ExportToWkt()
+        # move created habitat vector to a sub directory so the reprojected
+        # file can be saved where the csv PATH expects it
+        tmp_out = os.path.join(self.workspace_dir, 'tmp_move')
+        os.mkdir(tmp_out)
+        for filename in os.listdir(self.workspace_dir):
+            if filename.startswith("habitat_0"):
+                shutil.move(
+                    os.path.join(self.workspace_dir, filename),
+                    os.path.join(tmp_out, filename))
+        habitat_path = os.path.join(tmp_out, 'habitat_0.shp')
+        habitat_wgs84_path = os.path.join(self.workspace_dir, 'habitat_0.shp')
+        # reproject habitat layer to geographic
+        pygeoprocessing.reproject_vector(
+            habitat_path, wgs84_wkt, habitat_wgs84_path)
+
+        args['info_table_path'] = info_table_path
+
+        with self.assertRaises(ValueError) as cm:
+            natcap.invest.hra.execute(args)
+
+        expected_message = ("The following layer is not projected in linear"
+                            " units:")
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
@@ -1079,7 +1135,7 @@ class HraRegressionTests(unittest.TestCase):
         self.assertTrue(expected_error in validation_error_list)
 
     def test_validate_negative_resolution(self):
-        """HRA: testing validation with negative value in resolution in args."""
+        """HRA: testing validation w/ negative value in resolution in args."""
         import natcap.invest.hra
 
         args = HraRegressionTests.generate_base_args(self.workspace_dir)
@@ -1094,7 +1150,7 @@ class HraRegressionTests(unittest.TestCase):
     def _assert_vectors_equal(a_vector_path, b_vector_path, precision=6):
         """Assert that geometries in two vectors are equal, order-insensitive.
 
-        Parameters:
+        Args:
             a_vector_path (str): a path to a valid OGR vector.
             b_vector_path (str): a path to a valid OGR vector.
 


### PR DESCRIPTION
This PR fixes a bug in HRA where habitat and stressor inputs were not checked to see if they were projected. The model uses the projected AOI as the base but does not reproject geographic inputs before using them in an operation. Now if spatial inputs are not projected a ValueError is raised with an error message. The users guide has been updated to reflect these inputs should be projected. Added a test to validate the proper error is raised.

Closes #79 