### PR TITLE
Make SWY output filename consistent with NDR, SDR

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,7 @@ Unreleased Changes
 * HRA
     * Raise ValueError if habitat or stressor inputs are not projected.
 * Seasonal Water Yield
-    * Updated output file name from aggregate_results.shp to aggregate_results_swy.shp
+    * Updated output file name from aggregated_results.shp to aggregated_results_swy.shp
       for consistency with NDR and SDR
 
 3.8.7 (2020-07-17)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,8 @@ Unreleased Changes
       coefficient is assumed if any single value is left blank.
 * HRA
     * Raise ValueError if habitat or stressor inputs are not projected.
+* Seasonal Water Yield
+    * Updated output file name from aggregate_results.shp to aggregate_results_swy.shp for consistency
 
 3.8.7 (2020-07-17)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,8 @@ Unreleased Changes
 * HRA
     * Raise ValueError if habitat or stressor inputs are not projected.
 * Seasonal Water Yield
-    * Updated output file name from aggregate_results.shp to aggregate_results_swy.shp for consistency
+    * Updated output file name from aggregate_results.shp to aggregate_results_swy.shp
+      for consistency with NDR and SDR
 
 3.8.7 (2020-07-17)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 8a108c6fc1df475efc5f173c5236dc19a6ca5fb6
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := d6d19262d99a019220c0cd01ab5489caade2fa66
+GIT_UG_REPO_REV              := 25732693ef4139d77bb2ae6847366208b0e16e87
 
 
 ENV = env

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -253,7 +253,7 @@ ARGS_SPEC = {
 
 
 _OUTPUT_BASE_FILES = {
-    'aggregate_vector_path': 'aggregated_results.shp',
+    'aggregate_vector_path': 'aggregated_results_swy.shp',
     'annual_precip_path': 'P.tif',
     'cn_path': 'CN.tif',
     'l_avail_path': 'L_avail.tif',

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -739,7 +739,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path, climate_zones=True)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], 'aggregated_results_cz.shp'),
+            os.path.join(args['workspace_dir'], 'aggregated_results_swy_cz.shp'),
             agg_results_csv_path)
 
     def test_user_recharge(self):

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -13,7 +13,6 @@ import pygeoprocessing.testing
 REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data',
     'seasonal_water_yield')
-AGGREGATED_RESULTS_FILENAME = 'aggregated_results_swy.shp'
 
 
 def make_simple_shp(base_shp_path, origin):
@@ -452,7 +451,7 @@ class SeasonalWaterYieldUnusualDataTests(unittest.TestCase):
         l_path = os.path.join(self.workspace_dir, 'L.tif')
         make_recharge_raster(l_path)
         aggregate_vector_path = os.path.join(self.workspace_dir,
-                                             AGGREGATED_RESULTS_FILENAME)
+                                             'aggregated_results_swy.shp')
         make_simple_shp(aggregate_vector_path, (1180000.0, 690000.0))
         seasonal_water_yield._aggregate_recharge(aoi_path, l_path, l_path,
                                                  aggregate_vector_path)
@@ -650,7 +649,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
+            os.path.join(args['workspace_dir'], 'aggregated_results_swy.shp'),
             agg_results_csv_path)
 
     def test_bad_biophysical_table(self):
@@ -702,7 +701,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
+            os.path.join(args['workspace_dir'], 'aggregated_results_swy.shp'),
             agg_results_csv_path)
 
     def test_climate_zones_regression(self):
@@ -770,7 +769,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path, recharge=True)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
+            os.path.join(args['workspace_dir'], 'aggregated_results_swy.shp'),
             agg_results_csv_path)
 
     @staticmethod

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -13,6 +13,7 @@ import pygeoprocessing.testing
 REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data',
     'seasonal_water_yield')
+AGGREGATED_RESULTS_FILENAME = 'aggregated_results_swy.shp'
 
 
 def make_simple_shp(base_shp_path, origin):
@@ -279,7 +280,7 @@ def make_agg_results_csv(result_csv_path,
                          climate_zones=False,
                          recharge=False,
                          vector_exists=False):
-    """Make csv file that has the expected aggregated_results.shp table.
+    """Make csv file that has the expected aggregated_results_swy.shp table.
 
     The csv table is in the form of fid,vri_sum,qb_val per line.
 
@@ -451,7 +452,7 @@ class SeasonalWaterYieldUnusualDataTests(unittest.TestCase):
         l_path = os.path.join(self.workspace_dir, 'L.tif')
         make_recharge_raster(l_path)
         aggregate_vector_path = os.path.join(self.workspace_dir,
-                                             'aggregated_results.shp')
+                                             AGGREGATED_RESULTS_FILENAME)
         make_simple_shp(aggregate_vector_path, (1180000.0, 690000.0))
         seasonal_water_yield._aggregate_recharge(aoi_path, l_path, l_path,
                                                  aggregate_vector_path)
@@ -649,7 +650,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], 'aggregated_results.shp'),
+            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
             agg_results_csv_path)
 
     def test_bad_biophysical_table(self):
@@ -701,7 +702,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], 'aggregated_results.shp'),
+            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
             agg_results_csv_path)
 
     def test_climate_zones_regression(self):
@@ -769,7 +770,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         make_agg_results_csv(agg_results_csv_path, recharge=True)
 
         SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
-            os.path.join(args['workspace_dir'], 'aggregated_results.shp'),
+            os.path.join(args['workspace_dir'], AGGREGATED_RESULTS_FILENAME),
             agg_results_csv_path)
 
     @staticmethod
@@ -782,7 +783,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             result_vector_path (string): path to the summary shapefile
                 produced by the SWY model.
             agg_results_path (string): path to a csv file that has the
-                expected aggregated_results.shp table in the form of
+                expected aggregated_results_swy.shp table in the form of
                 fid,vri_sum,qb_val per line
 
         Returns:
@@ -792,7 +793,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             AssertionError if any files are missing or results are out of
             range by `tolerance_places`
         """
-        # we expect a file called 'aggregated_results.shp'
+        # we expect a file called 'aggregated_results_swy.shp'
         result_vector = gdal.OpenEx(result_vector_path, gdal.OF_VECTOR)
         result_layer = result_vector.GetLayer()
 


### PR DESCRIPTION
Changed aggregate_results.shp to aggregate_results_swy.shp for consistency with output file naming in NDR and SDR models.
Addresses natcap/invest#70

In the test file, `aggregated_results.shp` was mentioned 4 times, so I replaced those mentions with a new variable set to the new filename. Let me know if this is overkill/doesn't deserve a global variable.