### PR TITLE
Validate recreation predictor types

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,9 @@ Unreleased Changes
 * General
     * Input table column headers are now insensitive to leading/trailing whitespace in 
       most places.
+* Recreation
+    * Validate values in the type column of predictor tables early in execution. Raise
+      a ValueError if a type value isn't valid (leading/trailing whitespace is okay).
 
 3.8.7 (2020-07-17)
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Rtree>=0.8.2,!=0.9.1
 scipy>=0.16.1,<1.5.0
 Shapely>=1.6.4,<1.7.0
 pygeoprocessing>=1.9.2,<2.0  # pip-only
-taskgraph[niced_processes]>=0.9.1
+taskgraph[niced_processes]==0.9.1
 psutil>=5.6.6
 chardet>=3.0.4
 xlrd>=1.2.0

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -252,6 +252,8 @@ def execute(args):
                       with the response polygon in projected units of AOI
                     * 'polygon_area': area of the polygon contained within
                       response polygon in projected units of AOI
+                    * 'polygon_percent_coverage': percent (0-100) of area of 
+                      overlap between the predictor and each AOI grid cell.
 
         args['scenario_predictor_table_path'] (string): (optional) if
             present runs the scenario mode of the recreation model with the
@@ -1520,16 +1522,16 @@ def _validate_predictor_types(table_path):
         type, ignoring leading/trailing whitespace.
     """
     df = utils.read_csv_to_dataframe(table_path, to_lower=True)
-    type_list = df['type'].tolist()
-    valid_types = ['raster_mean', 'raster_sum', 'point_count', 
+    # ignore leading/trailing whitespace because it will be removed
+    # when the type values are used
+    type_list = set([type.strip() for type in df['type']])
+    valid_types = set({'raster_mean', 'raster_sum', 'point_count', 
                    'point_nearest_distance', 'line_intersect_length',
-                   'polygon_area_coverage', 'polygon_percent_coverage']
-    for type_value in type_list:
-        # ignore leading/trailing whitespace because it will be removed
-        # when the type values are used
-        if type_value.strip() not in valid_types:
-            raise ValueError(f'The table contains an invalid type value: \
-                {type_value}. The allowed types are: {", ".join(valid_types)}')
+                   'polygon_area_coverage', 'polygon_percent_coverage'})
+    difference = type_list.difference(valid_types)
+    if difference:
+        raise ValueError('The table contains invalid type value(s): '
+            f'{difference}. The allowed types are: {valid_types}')
 
 
 def delay_op(last_time, time_delay, func):

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -1502,6 +1502,31 @@ def _validate_same_projection(base_vector_path, table_path):
             "projection of the base vector")
 
 
+def _validate_predictor_types(table_path):
+    """Validate the type values in a predictor table.
+
+    Args:
+        table_path (string): path to a csv table that has at least
+            the field 'type' 
+
+    Returns:
+        None
+
+    Raises:
+        ValueError if any value in the ``type`` column does not match a valid
+        type, ignoring leading/trailing whitespace.
+    """
+    df = utils.read_csv_to_dataframe(table_path, to_lower=True)
+    type_list = df['type'].tolist()
+    valid_types = ['raster_mean', 'raster_sum', 'point_count', 
+                      'point_nearest_distance', 'line_intersect_length',
+                      'polygon_area_coverage', 'polygon_percent_coverage']
+    for type_value in type_list:
+        if type_value.strip() not in valid_types:
+            raise ValueError(f'The table contains an invalid type value: \
+                {type_value}. The allowed types are: {", ".join(valid_types)}')
+
+
 def delay_op(last_time, time_delay, func):
     """Execute ``func`` if last_time + time_delay >= current time.
 

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -253,7 +253,7 @@ def execute(args):
                     * 'polygon_area': area of the polygon contained within
                       response polygon in projected units of AOI
                     * 'polygon_percent_coverage': percent (0-100) of area of 
-                      overlap between the predictor and each AOI grid cell.
+                      overlap between the predictor and each AOI grid cell
 
         args['scenario_predictor_table_path'] (string): (optional) if
             present runs the scenario mode of the recreation model with the

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -1187,6 +1187,24 @@ class RecreationValidationTests(unittest.TestCase):
             actual_messages.add(error_strings)
         self.assertTrue(expected_message in actual_messages)
 
+    def test_validate_predictor_types(self):
+        """Recreation Validate: assert error on invalid type value"""
+        from natcap.invest.recreation import recmodel_client
+
+        table_path = os.path.join(self.workspace_dir, 'table.csv')
+        with open(table_path, 'w') as file:
+            file.write('id,path,type\n')
+            file.write('1,a,raster_mean \n')  # include trailing whitespace
+
+        bad_table_path = os.path.join(self.workspace_dir, 'bad_table.csv')
+        with open(bad_table_path, 'w') as file:
+            file.write('id,path,type\n')
+            file.write('1,a,raster?mean\n')  # include a typo in the type
+
+        
+
+
+
 
 def _assert_vector_attributes_eq(
         actual_vector_path, expected_vector_path, tolerance_places=3):

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -1244,7 +1244,7 @@ class RecreationValidationTests(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             recmodel_client.execute(args)
-        self.assertTrue('The table contains an invalid type value' in 
+        self.assertTrue('The table contains invalid type value(s)' in 
                         str(cm.exception))
 
 

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -1191,18 +1191,19 @@ class RecreationValidationTests(unittest.TestCase):
         """Recreation Validate: assert error on invalid type value"""
         from natcap.invest.recreation import recmodel_client
 
+        predictor_id = 'dem90m'
         # include trailing whitespace in the type, this should pass
-        raster_path = os.path.join(SAMPLE_DATA, 'nodata_raster.tif')
+        raster_path = os.path.join(SAMPLE_DATA, 'predictors/dem90m_coarse.tif')
         table_path = os.path.join(self.workspace_dir, 'table.csv')
         with open(table_path, 'w') as file:
             file.write('id,path,type\n')
-            file.write(f'a,{raster_path},raster_mean \n')
+            file.write(f'{predictor_id},{raster_path},raster_mean \n')
 
         # include a typo in the type, this should fail
         bad_table_path = os.path.join(self.workspace_dir, 'bad_table.csv')
         with open(bad_table_path, 'w') as file:
             file.write('id,path,type\n')
-            file.write(f'a,{raster_path},raster?mean\n')  
+            file.write(f'{predictor_id},{raster_path},raster?mean\n')
 
         args = {
             'aoi_path': os.path.join(SAMPLE_DATA, 'andros_aoi.shp'),
@@ -1217,6 +1218,13 @@ class RecreationValidationTests(unittest.TestCase):
 
         # there should be no error when the type has trailing whitespace
         recmodel_client.execute(args)
+        output_path = os.path.join(self.workspace_dir, 'regression_coefficients.txt')
+        print('regression_coefficients.txt:')
+
+        # the regression_coefficients.txt output file should contain the
+        # predictor id, meaning it wasn't dropped from the regression
+        with open(output_path, 'r') as output_file:
+            self.assertTrue(predictor_id in ''.join(output_file.readlines()))
 
         # try it again with the table that has a misspelled type
         # it should raise an error


### PR DESCRIPTION
Addresses #263 

As suggested by @davemfish, validating the type values early in `execute()`. Leading/trailing whitespace is ignored. Following the pattern of more complex validation being done in a separate function outside of `validate()` e.g. `_validate_same_id_lengths` and `_validate_same_projection`.