### PR TITLE
Timeout functions that read files in validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -27,6 +27,10 @@ Unreleased Changes
 * Recreation
     * Validate values in the type column of predictor tables early in execution. Raise
       a ValueError if a type value isn't valid (leading/trailing whitespace is okay).
+* Validation
+    * Set a timeout on validation functions that open a file. This will raise an error to
+      prevent the UI from hanging if a file has to be downloaded from Google Drive File
+      Stream or a similar service.
 
 3.8.7 (2020-07-17)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,9 +36,8 @@ Unreleased Changes
     * Validate values in the type column of predictor tables early in execution. Raise
       a ValueError if a type value isn't valid (leading/trailing whitespace is okay).
 * Validation
-    * Set a timeout on validation functions that open a file. This will raise an error to
-      prevent the UI from hanging if a file has to be downloaded from Google Drive File
-      Stream or a similar service.
+    * Set a 5-second timeout on validation functions that access a file. This will raise 
+      a warning and prevent validation from slowing down the UI too much.
 
 3.8.7 (2020-07-17)
 ------------------

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -1836,7 +1836,9 @@ class InVESTModel(QtWidgets.QMainWindow):
             # We want to validate the whole form; discard the individual value
             self.validate(block=False)
 
+        print('validating...')
         self.validate(block=False)
+        print('done validating.')
         for input_obj in self.inputs:
             input_obj.value_changed.connect(_validate)
             try:
@@ -1888,6 +1890,7 @@ class InVESTModel(QtWidgets.QMainWindow):
         if not self.window_title.filename:
             self.load_lastrun()
 
+        
         self.show()
         self.raise_()  # raise window to top of stack.
         self.validate(block=False)  # initial validation for the model

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -1836,9 +1836,7 @@ class InVESTModel(QtWidgets.QMainWindow):
             # We want to validate the whole form; discard the individual value
             self.validate(block=False)
 
-        print('validating...')
         self.validate(block=False)
-        print('done validating.')
         for input_obj in self.inputs:
             input_obj.value_changed.connect(_validate)
             try:
@@ -1890,7 +1888,6 @@ class InVESTModel(QtWidgets.QMainWindow):
         if not self.window_title.filename:
             self.load_lastrun()
 
-        
         self.show()
         self.raise_()  # raise window to top of stack.
         self.validate(block=False)  # initial validation for the model

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -292,6 +292,7 @@ def check_raster(filepath, projected=False, projection_units=None):
         A string error message if an error was found.  ``None`` otherwise.
 
     """
+    print('starting check_raster...')
     file_warning = check_file(filepath, permissions='r')
     if file_warning:
         return file_warning
@@ -312,6 +313,7 @@ def check_raster(filepath, projected=False, projection_units=None):
         return projection_warning
 
     gdal_dataset = None
+    print('check_raster finished.')
     return None
 
 

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -667,7 +667,6 @@ def validate(args, spec, spatial_overlap_opts=None):
         found, an empty list is returned.
 
     """
-    print('in validation.validate')
     validation_warnings = []
 
     # step 1: check absolute requirement

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -628,7 +628,10 @@ def timeout(func, *args, timeout=5, **kwargs):
     thread.join(timeout=timeout)
 
     if thread.is_alive():
-        raise RuntimeError('File checking thread timed out.')
+        return ('Validation of this file timed out. If this file is stored in '
+               'a file-streaming service, it may be taking too long to '
+               'download. Try storing it locally.')
+
     else:
         LOGGER.info('File checking thread completed.')
         # get any warning messages returned from the thread
@@ -804,14 +807,8 @@ def validate(args, spec, spatial_overlap_opts=None):
             LOGGER.exception(
                 'Error when validating key %s with value %s',
                 key, args[key])
-            if str(ex) == 'File checking thread timed out.':
-                warning_msg = ('Validation of this file timed out. If this '
-                    'file is stored in a file-streaming service, it may be '
-                    'taking too long to download. Try storing it locally.')
-            else:
-                warning_msg = 'An unexpected error occurred in validation'
             validation_warnings.append(
-                ([key], warning_msg))
+                ([key], 'An unexpected error occurred in validation'))
     # step 5: check spatial overlap if applicable
     if spatial_overlap_opts:
         spatial_keys = set(spatial_overlap_opts['spatial_keys'])

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -11,6 +11,7 @@ import functools
 import importlib
 import queue
 import signal
+import warnings
 
 import pygeoprocessing
 import pandas
@@ -610,9 +611,11 @@ def timeout(func, *args, timeout=5, **kwargs):
             Defaults to 5.
 
     Returns:
-        None
+        A string warning message if the thread completed in time and returned
+        warnings, ``None`` otherwise.
 
     Raises:
+        ``RuntimeWarning`` if the thread does not complete in time.
     """
     # use a queue to share the return value from the file checking thread
     # the target function puts the return value from `func` into shared memory
@@ -626,9 +629,11 @@ def timeout(func, *args, timeout=5, **kwargs):
     thread.join(timeout=timeout)
 
     if thread.is_alive():
-        return ('Validation of this file timed out. If this file is stored in '
-               'a file-streaming service, it may be taking too long to '
-               'download. Try storing it locally.')
+        # first arg to `check_csv`, `check_raster`, `check_vector` is the path
+        warnings.warn(f'Validation of file {args[0]} timed out. If this file '
+            'is stored in a file streaming service, it may be taking a long '
+            'time to download. Try storing it locally instead.')
+        return None
 
     else:
         LOGGER.info('File checking thread completed.')

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -526,7 +526,7 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
         # use sep=None, engine='python' to infer what the separator is
         dataframe = pandas.read_csv(
             filepath, sep=None, engine='python', encoding=encoding)
-    except Exception as e:
+    except Exception:
         if excel_ok:
             try:
                 dataframe = pandas.read_excel(filepath)
@@ -614,8 +614,6 @@ def timeout(func, *args, timeout=5, **kwargs):
 
     Raises:
     """
-
-
     # use a queue to share the return value from the file checking thread
     # the target function puts the return value from `func` into shared memory
     message_queue = queue.Queue()
@@ -638,7 +636,7 @@ def timeout(func, *args, timeout=5, **kwargs):
         return message_queue.get()
 
 
-# checks that open a file could potentially take a long time
+# opening a file could take a long time if it's in a file streaming service
 # to prevent the UI from hanging due to slow validation,
 # set a timeout for these functions.
 _VALIDATION_FUNCS = {
@@ -803,7 +801,7 @@ def validate(args, spec, spatial_overlap_opts=None):
             if warning_msg:
                 validation_warnings.append(([key], warning_msg))
                 invalid_keys.add(key)
-        except Exception as ex:
+        except Exception:
             LOGGER.exception(
                 'Error when validating key %s with value %s',
                 key, args[key])

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -10,7 +10,6 @@ import threading
 import functools
 import importlib
 import queue
-import signal
 import warnings
 
 import pygeoprocessing
@@ -935,6 +934,7 @@ def invest_validator(validate_func):
                 if args_value not in ('', None):
                     input_type = args_key_spec['type']
                     validator_func = _VALIDATION_FUNCS[input_type]
+
 
                     try:
                         validation_options = (

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -640,15 +640,15 @@ def timeout(func, *args, timeout=5, **kwargs):
         return message_queue.get()
 
 
-# opening a file could take a long time if it's in a file streaming service
+# accessing a file could take a long time if it's in a file streaming service
 # to prevent the UI from hanging due to slow validation,
 # set a timeout for these functions.
 _VALIDATION_FUNCS = {
     'boolean': check_boolean,
     'csv': functools.partial(timeout, check_csv),
-    'file': check_file,
-    'folder': check_directory,
-    'directory': check_directory,
+    'file': functools.partial(timeout, check_file),
+    'folder': functools.partial(timeout, check_directory),
+    'directory': functools.partial(timeout, check_directory),
     'freestyle_string': check_freestyle_string,
     'number': check_number,
     'option_string': check_option_string,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -219,10 +219,10 @@ class ValidatorTest(unittest.TestCase):
         def func():
             time.sleep(10)
 
-        # this will raise an error if the timeout is exceeded
+        # this will return a warning if the timeout is exceeded
         # timeout defaults to 5 seconds so this should fail
-        with self.assertRaises(RuntimeError):
-            validation.timeout(func)
+        msg = 'Validation of this file timed out'
+        self.assertTrue(msg in validation.timeout(func))
 
 
 class DirectoryValidation(unittest.TestCase):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import os
 import shutil
 import string
+import time
 
 from osgeo import gdal, osr, ogr
 import pandas
@@ -198,6 +199,30 @@ class ValidatorTest(unittest.TestCase):
         self.assertTrue(validation_errors[0][0] == ['n_workers'])
         self.assertTrue('could not be interpreted as a number'
                         in validation_errors[0][1])
+
+    def test_timeout_succeed(self):
+        from natcap.invest import validation
+
+        # both args and the kwarg should be passed to the function
+        def func(arg1, arg2, kwarg=None):
+            self.assertEqual(kwarg, 'kwarg')
+            time.sleep(1)
+
+        # this will raise an error if the timeout is exceeded
+        # timeout defaults to 5 seconds so this should pass
+        validation.timeout(func, 'arg1', 'arg2', kwarg='kwarg')
+
+    def test_timeout_fail(self):
+        from natcap.invest import validation
+
+        # both args and the kwarg should be passed to the function
+        def func():
+            time.sleep(10)
+
+        # this will raise an error if the timeout is exceeded
+        # timeout defaults to 5 seconds so this should fail
+        with self.assertRaises(RuntimeError):
+            validation.timeout(func)
 
 
 class DirectoryValidation(unittest.TestCase):


### PR DESCRIPTION
Addresses #261 

Using `threading` to set a timeout on functions that open a file. These could potentially be slowed down by Google File Stream-like services if the file has to be downloaded.

Note: I had a really hard time trying to replicate the issue with Google File Stream. Using a 2GB file on my google drive, it seemed to stay available locally no matter what I did. I tried limiting the download speed using the File Stream setting to be sure it would take a noticeable amount of time to download. Even after uninstalling, clearing the cache, and reinstalling, the file would show up almost instantly.