### PR TITLE
Validate coastal vulnerability SLR geometry type

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Unreleased Changes
 * Coastal Vulnerability
     * Improved handling of invalid AOI geometries to avoid crashing and instead
       fix the geometry when possible and skip it otherwise.
+    * Added validation check that shows a warning if the SLR vector is not 
+      a point or multipoint geometry.
 * Urban Cooling
     * Energy units are now (correctly) expressed in kWh.  They were previously
       (incorrectly) expressed in kW.

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2941,6 +2941,19 @@ def validate(args, limit_to=None):
                 (['shelf_contour_vector_path'],
                  'Must be a polyline vector'))
 
+    if ('slr_vector_path' in sufficient_keys and 
+       'slr_vector_path' not in invalid_keys):
+        vector = gdal.OpenEx(args['slr_vector_path'], gdal.OF_VECTOR)
+        layer = vector.GetLayer()
+        # all OGR point/multipoint codes
+        if layer.GetGeomType() not in [
+            ogr.wkbPoint, ogr.wkbMultiPoint,
+            ogr.wkbPointM, ogr.wkbMultiPointM,
+            ogr.wkbPointZM, ogr.wkbMultiPointZM,
+            ogr.wkbPoint25D, ogr.wkbMultiPoint25D]:
+            validation_warnings.append((['slr_vector_path'], 
+                f'Must be a point or multipoint geometry.'))
+
     if ('slr_vector_path' not in invalid_keys and
             'slr_field' not in invalid_keys and
             'slr_vector_path' in sufficient_keys and

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2936,7 +2936,10 @@ def validate(args, limit_to=None):
         layer = vector.GetLayer()
         # linestring codes: https://github.com/OSGeo/gdal/blob/master/gdal/ogr/ogr_core.h
         if layer.GetGeomType() not in [
-                2, 5, 2002, 2005, 3002, 3005, -2147483646, -2147483643]:
+            ogr.wkbLineString, ogr.wkbMultiLineString,
+            ogr.wkbLineStringM, ogr.wkbMultiLineStringM,
+            ogr.wkbLineStringZM, ogr.wkbMultiLineStringZM,
+            ogr.wkbLineString25D, ogr.wkbMultiLineString25D]:
             validation_warnings.append(
                 (['shelf_contour_vector_path'],
                  'Must be a polyline vector'))

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1444,10 +1444,10 @@ class CoastalVulnerabilityValidationTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             for keys, message in warning_messages:
-                print(keys, message)
                 if (keys == ['slr_vector_path'] and
                     message == 'Must be a point or multipoint geometry.'):
                     raise ValueError(warning_messages)
+
 
 def make_slr_vector(slr_point_vector_path, fieldname, shapely_feature, srs):
     """Create an SLR vector with a single point feature.

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1428,6 +1428,26 @@ class CoastalVulnerabilityValidationTests(unittest.TestCase):
                 if 'Value must be one of:' in err_strings:
                     raise ValueError(err_strings)
 
+    def test_check_slr_geometry_type(self):
+        """CV Validate: test catching non-point geometries in SLR input"""
+        gpkg_driver = ogr.GetDriverByName("GPKG")
+        # create a non-point/multipoint geometry
+        polygon_path = os.path.join(self.workspace_dir, 'slr_poly.gpkg')
+        polygon_vector = gpkg_driver.CreateDataSource(polygon_path)
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        polygon_vector.CreateLayer('layer', srs, ogr.wkbPolygon)
+        polygon_vector = None
+
+        args = {'slr_vector_path': polygon_path}
+        warning_messages = coastal_vulnerability.validate(args)
+
+        with self.assertRaises(ValueError):
+            for keys, message in warning_messages:
+                print(keys, message)
+                if (keys == ['slr_vector_path'] and
+                    message == 'Must be a point or multipoint geometry.'):
+                    raise ValueError(warning_messages)
 
 def make_slr_vector(slr_point_vector_path, fieldname, shapely_feature, srs):
     """Create an SLR vector with a single point feature.


### PR DESCRIPTION
Addresses #93 
Added a step to `coastal_vulnerability.validate` that checks that the SLR vector is a point or multipoint geometry, and a corresponding test case.
(Should single point geometries be allowed? User's guide isn't clear on this)
