### PR TITLE
Allow extra args keys in validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,11 @@
 
 ..
 ..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Hydropower
+    * Fixed bug that prevented validation from ever passing for this model.
+      Validation will allow extra keys in addition to those in the ARGS_SPEC.
 
 3.8.8 (2020-09-04)
 ------------------

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -787,7 +787,13 @@ def validate(args, spec, spatial_overlap_opts=None):
     invalid_keys = set()
     sufficient_keys = set(args.keys()).difference(insufficient_keys)
     for key in sufficient_keys.difference(excluded_keys):
-        parameter_spec = spec[key]
+        # Extra args that don't exist in the ARGS_SPEC are okay
+        # we don't need to try to validate them
+        try:
+            parameter_spec = spec[key]
+        except KeyError:
+            LOGGER.debug(f'Provided key {key} does not exist in ARGS_SPEC')
+            continue
         # If no validation options specified, assume defaults.
         try:
             validation_options = parameter_spec['validation_options']

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1218,7 +1218,7 @@ class TestValidationFromSpec(unittest.TestCase):
                 'required': True
             }
         }
-        message = 'Provided key b does not exist in ARGS_SPEC'
+        message = 'DEBUG:natcap.invest.validation:Provided key b does not exist in ARGS_SPEC'
         
         with self.assertLogs('natcap.invest.validation', level='DEBUG') as cm:
             validation.validate(args, spec)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1204,3 +1204,21 @@ class TestValidationFromSpec(unittest.TestCase):
         self.assertTrue('Bounding boxes do not intersect' in
                         validation_warnings[0][1])
         self.assertEqual(set(args.keys()), set(validation_warnings[0][0]))
+
+    def test_allow_extra_keys(self):
+        """Including extra keys in args that aren't in ARGS_SPEC should work"""
+        from natcap.invest import validation
+
+        args = {'a': 'a', 'b': 'b'}
+        spec = {
+            'a': {
+                'type': 'freestyle_string',
+                'name': 'a',
+                'about': 'a freestyle string',
+                'required': True
+            }
+        }
+
+        with self.assertLogs('natcap.invest.validation', level='DEBUG') as cm:
+            validation.validate(args, spec)
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1218,7 +1218,9 @@ class TestValidationFromSpec(unittest.TestCase):
                 'required': True
             }
         }
-
+        message = 'Provided key b does not exist in ARGS_SPEC'
+        
         with self.assertLogs('natcap.invest.validation', level='DEBUG') as cm:
             validation.validate(args, spec)
+        self.assertTrue(message in cm.output)
 


### PR DESCRIPTION
Fixes #305 
Put the key lookup in a try/except to be consistent with other error handling