### PR TITLE
fixes #308 - error when calculating runoff volume

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,16 +1,17 @@
 .. :changelog:
 
-..
-..
-  Unreleased Changes
-  ------------------
+
+Unreleased Changes
+------------------
+* Fixed incorrect calculation of total quickflow volume in Urban Flood
+  Mitigation.
 
 3.8.8 (2020-09-04)
 ------------------
 * Coastal Vulnerability
     * Improved handling of invalid AOI geometries to avoid crashing and instead
       fix the geometry when possible and skip it otherwise.
-    * Added validation check that shows a warning if the SLR vector is not 
+    * Added validation check that shows a warning if the SLR vector is not
       a point or multipoint geometry.
 * Urban Cooling
     * Energy units are now (correctly) expressed in kWh.  They were previously
@@ -30,7 +31,7 @@
 * Datastack
     * Saved datastack archives now use helpful identifying names for spatial input folders
 * Validation
-    * Fixed bug that caused fields activated by a checkbox to make validation fail, 
+    * Fixed bug that caused fields activated by a checkbox to make validation fail,
       even when the checkbox was unchecked.
 * General
     * Input table column headers are now insensitive to leading/trailing whitespace in
@@ -42,7 +43,7 @@
     * Validate values in the type column of predictor tables early in execution. Raise
       a ValueError if a type value isn't valid (leading/trailing whitespace is okay).
 * Validation
-    * Set a 5-second timeout on validation functions that access a file. This will raise 
+    * Set a 5-second timeout on validation functions that access a file. This will raise
       a warning and prevent validation from slowing down the UI too much.
 
 3.8.7 (2020-07-17)

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -306,8 +306,7 @@ def execute(args):
     flood_vol_task = task_graph.add_task(
         func=pygeoprocessing.raster_calculator,
         args=(
-            [(float(args['rainfall_depth']), 'raw'),
-             (q_pi_raster_path, 1), (q_pi_nodata, 'raw'),
+            [(q_pi_raster_path, 1), (q_pi_nodata, 'raw'),
              (pixel_area, 'raw'), (flood_vol_nodata, 'raw')],
             _flood_vol_op, flood_vol_raster_path, gdal.GDT_Float32,
             flood_vol_nodata),
@@ -612,7 +611,7 @@ def _calculate_damage_to_infrastructure_in_aoi(
 
 
 def _flood_vol_op(
-        rainfall_depth, q_pi_array, q_pi_nodata, pixel_area, target_nodata):
+        q_pi_array, q_pi_nodata, pixel_area, target_nodata):
     """Calculate vol of flood water.
 
     Parmeters:
@@ -629,9 +628,9 @@ def _flood_vol_op(
     result = numpy.empty(q_pi_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     valid_mask = q_pi_array != q_pi_nodata
-    # 0.001 converts mm (rainfall depth) to m (pixel area units)
+    # 0.001 converts mm (quickflow) to m (pixel area units)
     result[valid_mask] = (
-        q_pi_array[valid_mask] * rainfall_depth * pixel_area * 0.001)
+        q_pi_array[valid_mask] * pixel_area * 0.001)
     return result
 
 

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -74,7 +74,7 @@ class UFRMTests(unittest.TestCase):
                 ('serv.blt', 13253546667257.65),
                 ('rnf_rt_idx', 0.70387527942),
                 ('rnf_rt_m3', 70870.4765625),
-                ('flood_vol', 1192625.75)):
+                ('flood_vol', 29815.640625)):
             result_val = result_feature.GetField(fieldname)
             places_to_round = (
                 int(round(numpy.log(expected_value)/numpy.log(10)))-6)
@@ -119,7 +119,7 @@ class UFRMTests(unittest.TestCase):
         for fieldname, expected_value in (
                 ('rnf_rt_idx', 0.70387527942),
                 ('rnf_rt_m3', 70870.4765625),
-                ('flood_vol', 1192625.75)):
+                ('flood_vol', 29815.640625)):
             result_val = result_feature.GetField(fieldname)
             places_to_round = (
                 int(round(numpy.log(expected_value)/numpy.log(10)))-6)


### PR DESCRIPTION
Fixes an issue stemming from an incorrect calculation of total quickflow volume. I was nonsensically multiplying quickflow runoff with the precipitation depth. Removed that, updated tests, and history.