### PR TITLE
Making the Rec PUD calculations more tolerant to imperfect AOIs

### DIFF
--- a/src/natcap/invest/recreation/recmodel_server.py
+++ b/src/natcap/invest/recreation/recmodel_server.py
@@ -687,49 +687,54 @@ def _calc_poly_pud(
     LOGGER.info('local qt load took %.2fs', time.time() - start_time)
 
     aoi_vector = gdal.OpenEx(aoi_path, gdal.OF_VECTOR)
-    aoi_layer = aoi_vector.GetLayer()
+    if aoi_vector:
+        aoi_layer = aoi_vector.GetLayer()
 
-    for poly_id in iter(poly_test_queue.get, 'STOP'):
-        poly_feat = aoi_layer.GetFeature(poly_id)
-        poly_geom = poly_feat.GetGeometryRef()
-        poly_wkt = poly_geom.ExportToWkt()
-        try:
-            shapely_polygon = shapely.wkt.loads(poly_wkt)
-        except Exception:  # pylint: disable=broad-except
-            # We often get weird corrupt data, this lets us tolerate it
-            LOGGER.warn('error parsing poly, skipping')
-            continue
+        for poly_id in iter(poly_test_queue.get, 'STOP'):
+            try:
+                poly_feat = aoi_layer.GetFeature(poly_id)
+                poly_geom = poly_feat.GetGeometryRef()
+                poly_wkt = poly_geom.ExportToWkt()
+            except AttributeError as error:
+                LOGGER.warning('skipping feature that raised: %s', str(error))
+                continue
+            try:
+                shapely_polygon = shapely.wkt.loads(poly_wkt)
+            except Exception:  # pylint: disable=broad-except
+                # We often get weird corrupt data, this lets us tolerate it
+                LOGGER.warning('error parsing poly, skipping')
+                continue
 
-        poly_points = local_qt.get_intersecting_points_in_polygon(
-            shapely_polygon)
-        pud_set = set()
-        pud_monthly_set = collections.defaultdict(set)
+            poly_points = local_qt.get_intersecting_points_in_polygon(
+                shapely_polygon)
+            pud_set = set()
+            pud_monthly_set = collections.defaultdict(set)
 
-        for point_datetime, user_hash, _, _ in poly_points:
-            if date_range[0] <= point_datetime <= date_range[1]:
-                timetuple = point_datetime.tolist().timetuple()
+            for point_datetime, user_hash, _, _ in poly_points:
+                if date_range[0] <= point_datetime <= date_range[1]:
+                    timetuple = point_datetime.tolist().timetuple()
 
-                year = str(timetuple.tm_year)
-                month = str(timetuple.tm_mon)
-                day = str(timetuple.tm_mday)
-                pud_hash = str(user_hash) + '%s-%s-%s' % (year, month, day)
-                pud_set.add(pud_hash)
-                pud_monthly_set[month].add(pud_hash)
-                pud_monthly_set["%s-%s" % (year, month)].add(pud_hash)
+                    year = str(timetuple.tm_year)
+                    month = str(timetuple.tm_mon)
+                    day = str(timetuple.tm_mday)
+                    pud_hash = str(user_hash) + '%s-%s-%s' % (year, month, day)
+                    pud_set.add(pud_hash)
+                    pud_monthly_set[month].add(pud_hash)
+                    pud_monthly_set["%s-%s" % (year, month)].add(pud_hash)
 
-        # calculate the number of years and months between the max/min dates
-        # index 0 is annual and 1-12 are the months
-        pud_averages = [0.0] * 13
-        n_years = (
-            date_range[1].tolist().timetuple().tm_year -
-            date_range[0].tolist().timetuple().tm_year + 1)
-        pud_averages[0] = len(pud_set) / float(n_years)
-        for month_id in range(1, 13):
-            monthly_pud_set = pud_monthly_set[str(month_id)]
-            pud_averages[month_id] = (
-                len(monthly_pud_set) / float(n_years))
+            # calculate the number of years and months between the max/min dates
+            # index 0 is annual and 1-12 are the months
+            pud_averages = [0.0] * 13
+            n_years = (
+                date_range[1].tolist().timetuple().tm_year -
+                date_range[0].tolist().timetuple().tm_year + 1)
+            pud_averages[0] = len(pud_set) / float(n_years)
+            for month_id in range(1, 13):
+                monthly_pud_set = pud_monthly_set[str(month_id)]
+                pud_averages[month_id] = (
+                    len(monthly_pud_set) / float(n_years))
 
-        pud_poly_feature_queue.put((poly_id, pud_averages, pud_monthly_set))
+            pud_poly_feature_queue.put((poly_id, pud_averages, pud_monthly_set))
     pud_poly_feature_queue.put('STOP')
     aoi_layer = None
     gdal.Dataset.__swig_destroy__(aoi_vector)

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -405,7 +405,7 @@ class TestRecServer(unittest.TestCase):
             numpy.datetime64('2005-01-01'),
             numpy.datetime64('2014-12-31'))
 
-        aoi_vector_path = 'aoi.gpkg'
+        aoi_vector_path = os.path.join(self.workspace_dir, 'aoi.gpkg')
         gpkg_driver = gdal.GetDriverByName('GPKG')
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
@@ -414,32 +414,33 @@ class TestRecServer(unittest.TestCase):
         target_layer = target_vector.CreateLayer(
             'target_layer', srs, ogr.wkbUnknown)
 
-        target_layer.StartTransaction()
+        # Testing with an AOI of 2 features, one is missing Geometry.
         input_geom_list = [
             None,
             ogr.CreateGeometryFromWkt(
                 'POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))')]
+        poly_test_queue = queue.Queue()
+        poly_test_queue.put(1)  # gpkg FIDs start at 1
+        poly_test_queue.put(2)
+        target_layer.StartTransaction()
         for geometry in input_geom_list:
             feature = ogr.Feature(target_layer.GetLayerDefn())
             feature.SetGeometry(geometry)
             target_layer.CreateFeature(feature)
         target_layer.CommitTransaction()
-
+        poly_test_queue.put('STOP')
         target_layer = None
         target_vector = None
 
-        poly_test_queue = queue.Queue()
-        poly_test_queue.put(0)
-        poly_test_queue.put('STOP')
         pud_poly_feature_queue = queue.Queue()
         recmodel_server._calc_poly_pud(
             recreation_server.qt_pickle_filename,
             aoi_vector_path, date_range, poly_test_queue,
             pud_poly_feature_queue)
 
-        # assert annual average PUD is the same as regression
+        # assert PUD was calculated for the one good AOI feature.
         self.assertEqual(
-            83.2, pud_poly_feature_queue.get()[1][0])
+            0.0, pud_poly_feature_queue.get()[1][0])
 
     def test_local_calc_existing_cached(self):
         """Recreation local PUD calculation on existing quadtree."""

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -17,6 +17,8 @@ import Pyro4
 import numpy
 import pandas
 from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
 import taskgraph
 
 from natcap.invest import utils
@@ -386,6 +388,54 @@ class TestRecServer(unittest.TestCase):
             recreation_server.qt_pickle_filename,
             os.path.join(SAMPLE_DATA, 'test_aoi_for_subset.shp'),
             date_range, poly_test_queue, pud_poly_feature_queue)
+
+        # assert annual average PUD is the same as regression
+        self.assertEqual(
+            83.2, pud_poly_feature_queue.get()[1][0])
+
+    def test_local_calc_poly_pud_bad_aoi(self):
+        """Recreation test PUD calculation with missing AOI features."""
+        from natcap.invest.recreation import recmodel_server
+
+        recreation_server = recmodel_server.RecModel(
+            self.resampled_data_path,
+            2005, 2014, os.path.join(self.workspace_dir, 'server_cache'))
+
+        date_range = (
+            numpy.datetime64('2005-01-01'),
+            numpy.datetime64('2014-12-31'))
+
+        aoi_vector_path = 'aoi.gpkg'
+        gpkg_driver = gdal.GetDriverByName('GPKG')
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
+        target_vector = gpkg_driver.Create(
+            aoi_vector_path, 0, 0, 0, gdal.GDT_Unknown)
+        target_layer = target_vector.CreateLayer(
+            'target_layer', srs, ogr.wkbUnknown)
+
+        target_layer.StartTransaction()
+        input_geom_list = [
+            None,
+            ogr.CreateGeometryFromWkt(
+                'POLYGON ((1 1, 1 0, 0 0, 0 1, 1 1))')]
+        for geometry in input_geom_list:
+            feature = ogr.Feature(target_layer.GetLayerDefn())
+            feature.SetGeometry(geometry)
+            target_layer.CreateFeature(feature)
+        target_layer.CommitTransaction()
+
+        target_layer = None
+        target_vector = None
+
+        poly_test_queue = queue.Queue()
+        poly_test_queue.put(0)
+        poly_test_queue.put('STOP')
+        pud_poly_feature_queue = queue.Queue()
+        recmodel_server._calc_poly_pud(
+            recreation_server.qt_pickle_filename,
+            aoi_vector_path, date_range, poly_test_queue,
+            pud_poly_feature_queue)
 
         # assert annual average PUD is the same as regression
         self.assertEqual(


### PR DESCRIPTION
This PR adds a test and some error-handling to the PUD calculation. If an AOI has features with missing geometry, we skip over them rather than crashing on gdal `AttributeErrors`. 

This is important because when the server-side process did crash, no feedback got back to the client. Now the user will still get their PUD results, but with empty attribute information for any features that have missing/corrupt geometry. 

I double-checked the client-side `_build_regression` function and confirmed that missing PUD values for some features are handled appropriately already, by excluding those features from the least-squares regression.

After this PR is merged we should update the version of invest we have running on the VM. For now, I did already patch and re-install the `recmodel_server.py` module on the VM with the fix we have here, but it would be good to properly clone and install `natcap:release/3.9` .

This fixes #304 