### PR TITLE
NDR and SWY sample data bugs

### DIFF
--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -883,7 +883,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
 
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~numpy.isclose(raster_block, base_nodata)
+            valid_mask = ~numpy.isclose(array, base_nodata)
         result[valid_mask] = array[valid_mask]
         if value_mean != 0:
             result[valid_mask] /= value_mean

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1004,14 +1004,16 @@ def _calculate_curve_number_raster(
     lulc_to_soil = {}
     lulc_nodata = pygeoprocessing.get_raster_info(
         lulc_raster_path)['nodata'][0]
+
+    lucodes = list(biophysical_table)
+    if lulc_nodata is not None:
+        lucodes.append(lulc_nodata)
+
     for soil_id, soil_column in map_soil_type_to_header.items():
         lulc_to_soil[soil_id] = {
             'lulc_values': [],
             'cn_values': []
         }
-        lucodes = list(biophysical_table)
-        if lulc_nodata is not None:
-            lucodes.append(lulc_nodata)
 
         for lucode in sorted(lucodes):
             if lucode != lulc_nodata:
@@ -1033,7 +1035,7 @@ def _calculate_curve_number_raster(
                         dtype=numpy.float32))
 
     # Use set of table lucodes in cn_op
-    lucodes_set = set(list(biophysical_table))
+    lucodes_set = set(lucodes)
 
     def cn_op(lulc_array, soil_group_array):
         """Map lulc code and soil to a curve number."""

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -62,44 +62,44 @@ class NDRTests(unittest.TestCase):
         """
         from natcap.invest.ndr import ndr
 
-        float64_raster_path = os.path.join(self.workspace_dir,
-                                           'float64_raster.tif')
+        raster_xsize = 512
+        raster_ysize = 512
+        float64_raster_path = os.path.join(
+            self.workspace_dir, 'float64_raster.tif')
         driver = gdal.GetDriverByName('GTiff')
-        raster = driver.Create(float64_raster_path,
-                               4,  # xsize
-                               4,  # ysize
-                               1,  # n_bands
-                               gdal.GDT_Float64)
+        raster = driver.Create(
+            float64_raster_path, raster_xsize, raster_ysize, 1,
+            gdal.GDT_Float64)
         source_nodata = -1.797693e+308  # taken from user's data
         band = raster.GetRasterBand(1)
         band.SetNoDataValue(source_nodata)
-        source_array = numpy.empty((4, 4), dtype=numpy.float64)
-        source_array[0:2][:] = 5.5  # Something, anything.
-        source_array[2:][:] = source_nodata
+        source_array = numpy.empty(
+            (raster_xsize, raster_ysize), dtype=numpy.float64)
+        source_array[0:256][:] = 5.5  # Something, anything.
+        source_array[256:][:] = source_nodata
         band.WriteArray(source_array)
         band = None
         raster = None
         driver = None
 
-        normalized_raster_path = os.path.join(self.workspace_dir,
-                                              'normalized.tif')
+        normalized_raster_path = os.path.join(
+            self.workspace_dir, 'normalized.tif')
         ndr._normalize_raster((float64_raster_path, 1), normalized_raster_path)
 
         normalized_raster_nodata = pygeoprocessing.get_raster_info(
             normalized_raster_path)['nodata'][0]
 
         normalized_array = gdal.OpenEx(normalized_raster_path).ReadAsArray()
-        expected_array = numpy.array(
-            [[1., 1., 1., 1.],
-             [1., 1., 1., 1.],
-             [normalized_raster_nodata]*4,
-             [normalized_raster_nodata]*4], dtype=numpy.float32)
+        expected_array = numpy.empty(
+            (raster_xsize, raster_ysize), dtype=numpy.float32)
+        expected_array[0:256][:] = 1.
+        expected_array[256:][:] = normalized_raster_nodata
 
         # Assert that the output values match the target nodata value
         self.assertEqual(
-            8,  # Nodata pixels
-            numpy.count_nonzero(numpy.isclose(normalized_array,
-                                              normalized_raster_nodata)))
+            131072,  # Nodata pixels
+            numpy.count_nonzero(
+                numpy.isclose(normalized_array, normalized_raster_nodata)))
 
         numpy.testing.assert_allclose(
             normalized_array, expected_array, rtol=0, atol=1e-6)

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -62,8 +62,8 @@ class NDRTests(unittest.TestCase):
         """
         from natcap.invest.ndr import ndr
 
-        raster_xsize = 512
-        raster_ysize = 512
+        raster_xsize = 1124 
+        raster_ysize = 512 
         float64_raster_path = os.path.join(
             self.workspace_dir, 'float64_raster.tif')
         driver = gdal.GetDriverByName('GTiff')
@@ -74,7 +74,7 @@ class NDRTests(unittest.TestCase):
         band = raster.GetRasterBand(1)
         band.SetNoDataValue(source_nodata)
         source_array = numpy.empty(
-            (raster_xsize, raster_ysize), dtype=numpy.float64)
+            (raster_ysize, raster_xsize), dtype=numpy.float64)
         source_array[0:256][:] = 5.5  # Something, anything.
         source_array[256:][:] = source_nodata
         band.WriteArray(source_array)
@@ -91,13 +91,13 @@ class NDRTests(unittest.TestCase):
 
         normalized_array = gdal.OpenEx(normalized_raster_path).ReadAsArray()
         expected_array = numpy.empty(
-            (raster_xsize, raster_ysize), dtype=numpy.float32)
+            (raster_ysize, raster_xsize), dtype=numpy.float32)
         expected_array[0:256][:] = 1.
         expected_array[256:][:] = normalized_raster_nodata
 
         # Assert that the output values match the target nodata value
         self.assertEqual(
-            131072,  # Nodata pixels
+            287744,  # Nodata pixels
             numpy.count_nonzero(
                 numpy.isclose(normalized_array, normalized_raster_nodata)))
 

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -90,7 +90,7 @@ def make_lulc_raster(lulc_ras_path):
         None.
     """
     size = 100
-    lulc_array = numpy.zeros((size, size), dtype=numpy.int8)
+    lulc_array = numpy.zeros((size, size), dtype=numpy.int16)
     lulc_array[size // 2:, :] = 1
     make_raster_from_array(lulc_array, lulc_ras_path)
 
@@ -764,7 +764,10 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         lulc_new_path = os.path.join(self.workspace_dir, 'lulc_new.tif')
         lulc_info = pygeoprocessing.get_raster_info(args['lulc_raster_path'])
         lulc_array = gdal.OpenEx(args['lulc_raster_path']).ReadAsArray()
-        lulc_array[0][0] = 2
+        lulc_array[0][0] = 321
+        # set a nodata value to make sure nodatas are handled correctly when
+        # reclassifying
+        lulc_array[0][1] = lulc_info['nodata'][0]
         pygeoprocessing.numpy_array_to_raster(
             lulc_array, lulc_info['nodata'][0], lulc_info['pixel_size'], 
             (lulc_info['geotransform'][0], lulc_info['geotransform'][3]), 
@@ -777,7 +780,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             seasonal_water_yield.execute(args)
         self.assertTrue(
             ("The missing values found in the LULC raster but not the"
-             " table are: [2]") in str(context.exception))
+             " table are: [321]") in str(context.exception))
 
     def test_user_recharge(self):
         """SWY user recharge regression test on sample data.


### PR DESCRIPTION
This PR fixes bugs in NDR and SWY that were exposed when testing the installer for PR #314 . 

The NDR bug was related to referencing the wrong the numpy array in a `raster_calculator` op. 

The SWY bug was related to not handling nodata values correctly when reclassifying a raster against a value map.

The issues are defined in detail here #321 

Since these bugs were introduced under the `release/3.9` branch I don't believe there needs to be any mention in HISTORY.

Fixes #321 