### PR TITLE
Annual water yield conditional bug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,9 @@
 .. :changelog:
 Unreleased Changes (3.9)
 ------------------------
+* Annual Water Yield:
+    * Fixing bug that limited ``rsupply`` result when ``wyield_mn`` or
+      ``consump_mn`` was 0.
 * General:
   * Deprecating GDAL 2 and adding support for GDAL 3.
   * Adding function in utils.py to handle InVEST coordindate transformations.

--- a/src/natcap/invest/hydropower/hydropower_water_yield.py
+++ b/src/natcap/invest/hydropower/hydropower_water_yield.py
@@ -833,7 +833,6 @@ def fractp_op(
         (awc / precip[valid_mask]) * seasonality_constant) + 1.25
     # Capping to 5.0 to set to upper limit if exceeded
     climate_w[climate_w > 5.0] = 5.0
-    # climate_w = numpy.where(climate_w > 5.0, 5.0, climate_w)
 
     # Compute evapotranspiration partition of the water balance
     aet_p = (
@@ -928,7 +927,7 @@ def compute_watershed_valuation(watershed_results_vector_path, val_dict):
 
         # there won't be a rsupply_vl value if the polygon feature only
         # covers nodata raster values, so check before doing math.
-        if rsupply_vl:
+        if rsupply_vl is not None:
             # Get the valuation parameters for watershed 'ws_id'
             val_row = val_dict[ws_id]
 
@@ -1000,7 +999,7 @@ def compute_rsupply_volume(watershed_results_vector_path):
         # Calculate realized supply
         # these values won't exist if the polygon feature only
         # covers nodata raster values, so check before doing math.
-        if wyield_mn and consump_mn:
+        if wyield_mn is not None and consump_mn is not None:
             rsupply_vol = wyield - consump_vol
             rsupply_mn = wyield_mn - consump_mn
 
@@ -1045,7 +1044,7 @@ def compute_water_yield_volume(watershed_results_vector_path):
         wyield_mn = feat.GetField('wyield_mn')
         # there won't be a wyield_mn value if the polygon feature only
         # covers nodata raster values, so check before doing math.
-        if wyield_mn:
+        if wyield_mn is not None:
             geom = feat.GetGeometryRef()
             # Calculate water yield volume,
             # 1000 is for converting the mm of wyield to meters


### PR DESCRIPTION
This PR fixes a bug related to a conditional check that should have been guarding against `None` but instead was guarding against any non-true returning value. This came up in a User Forum post which is linked in the issue: #332 . Ultimately, this fix now allows for a demand table where all demand values are 0.

Closes #332 