### PR TITLE
SWY precision mismatch caused -inf

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -82,6 +82,9 @@ Unreleased Changes (3.9)
       value. Now, the decay does not ignore those nodata edges causing values
       on the edges to decay more quickly. The area of study should have
       adequate boundaries to account for these edge effects.
+* Seasonal Water Yield
+    * Fixed a bug where precip or eto rasters of ``GDT_Float64`` with values
+      greater than 32-bit would overflow to ``-inf``.
 * SDR:
   * Fixing an issue where the LS factor should be capped to an upstream area of
     333^2 m^2. In previous versions the LS factor was erroniously capped to

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
@@ -417,7 +417,7 @@ cpdef calculate_local_recharge(
     cdef int xi, yi, xj, yj, flow_dir_j, p_ij_base
     cdef int win_xsize, win_ysize, n_dir
     cdef int raster_x_size, raster_y_size
-    cdef float pet_m, p_m, qf_m, et0_m, aet_i, p_i, qf_i, l_i, l_avail_i
+    cdef double pet_m, p_m, qf_m, et0_m, aet_i, p_i, qf_i, l_i, l_avail_i
     cdef float qf_nodata, kc_nodata
 
     cdef int j_neighbor_end_index, mfd_dir_sum

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -679,7 +679,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         new_raster = None
         driver = None
 
-        # set precip nodata values to something extremely small
+        # set precip nodata values to a large, negative 64bit value.
         nodata = numpy.finfo(numpy.float64).min
         precip_nodata_dir = os.path.join(
             self.workspace_dir, 'precip_nodata_dir')

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -142,8 +142,8 @@ def make_eto_rasters(eto_dir_path):
     """
     size = 100
     for month in range(1, 13):
-        eto_raster_path = os.path.join(eto_dir_path,
-                                       'eto' + str(month) + '.tif')
+        eto_raster_path = os.path.join(
+            eto_dir_path, 'eto' + str(month) + '.tif')
         eto_array = numpy.full((size, size), month, dtype=numpy.int32)
         make_raster_from_array(eto_array, eto_raster_path)
 
@@ -159,8 +159,8 @@ def make_precip_rasters(precip_dir_path):
     """
     size = 100
     for month in range(1, 13):
-        precip_raster_path = os.path.join(precip_dir_path,
-                                          'precip_mm_' + str(month) + '.tif')
+        precip_raster_path = os.path.join(
+            precip_dir_path, 'precip_mm_' + str(month) + '.tif')
         precip_array = numpy.full((size, size), month + 10, dtype=numpy.int32)
         make_raster_from_array(precip_array, precip_raster_path)
 
@@ -649,6 +649,78 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             os.path.join(args['workspace_dir'], 'aggregated_results_swy.shp'),
             agg_results_csv_path)
 
+    def test_base_regression_nodata_inf(self):
+        """SWY base regression test on sample data with really small nodata.
+
+        Executes SWY in default mode and checks that the output files are
+        generated and that the aggregate shapefile fields are the same as the
+        regression case.
+        """
+        from natcap.invest.seasonal_water_yield import seasonal_water_yield
+
+        # use predefined directory so test can clean up files during teardown
+        args = SeasonalWaterYieldRegressionTests.generate_base_args(
+            self.workspace_dir)
+
+        # Ensure the model can pass when a nodata value is not defined.
+        size = 100
+        lulc_array = numpy.zeros((size, size), dtype=numpy.int8)
+        lulc_array[size // 2:, :] = 1
+
+        driver = gdal.GetDriverByName('GTiff')
+        new_raster = driver.Create(
+            args['lulc_raster_path'], lulc_array.shape[0],
+            lulc_array.shape[1], 1, gdal.GDT_Byte)
+        band = new_raster.GetRasterBand(1)
+        band.WriteArray(lulc_array)
+        geotransform = [1180000, 1, 0, 690000, 0, -1]
+        new_raster.SetGeoTransform(geotransform)
+        band = None
+        new_raster = None
+        driver = None
+
+        # set precip nodata values to something extremely small
+        nodata = numpy.finfo(numpy.float64).min
+        precip_nodata_dir = os.path.join(
+            self.workspace_dir, 'precip_nodata_dir')
+        os.makedirs(precip_nodata_dir)
+        size = 100
+        for month in range(1, 13):
+            precip_raster_path = os.path.join(
+                precip_nodata_dir, 'precip_mm_' + str(month) + '.tif')
+            precip_array = numpy.full(
+                (size, size), month + 10, dtype=numpy.float64)
+            precip_array[size - 1, :] = nodata
+
+            srs = osr.SpatialReference()
+            srs.ImportFromEPSG(26910)  # UTM Zone 10N
+            project_wkt = srs.ExportToWkt()
+
+            # Each pixel is 1x1 m
+            pygeoprocessing.numpy_array_to_raster(
+                precip_array, nodata, (1, -1), (1180000, 690000), project_wkt,
+                precip_raster_path)
+
+        args['precip_dir'] = precip_nodata_dir
+
+        # make args explicit that this is a base run of SWY
+        args['user_defined_climate_zones'] = False
+        args['user_defined_local_recharge'] = False
+        args['monthly_alpha'] = False
+        args['results_suffix'] = ''
+
+        seasonal_water_yield.execute(args)
+
+        # generate aggregated results csv table for assertion
+        agg_results_csv_path = os.path.join(
+            args['workspace_dir'], 'agg_results_base.csv')
+        with open(agg_results_csv_path, 'w') as open_table:
+            open_table.write('0,1.0,50.076062\n')
+
+        SeasonalWaterYieldRegressionTests._assert_regression_results_equal(
+            os.path.join(args['workspace_dir'], 'aggregated_results_swy.shp'),
+            agg_results_csv_path)
+
     def test_bad_biophysical_table(self):
         """SWY bad biophysical table with non-numerical values."""
         from natcap.invest.seasonal_water_yield import seasonal_water_yield
@@ -769,8 +841,8 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         # reclassifying
         lulc_array[0][1] = lulc_info['nodata'][0]
         pygeoprocessing.numpy_array_to_raster(
-            lulc_array, lulc_info['nodata'][0], lulc_info['pixel_size'], 
-            (lulc_info['geotransform'][0], lulc_info['geotransform'][3]), 
+            lulc_array, lulc_info['nodata'][0], lulc_info['pixel_size'],
+            (lulc_info['geotransform'][0], lulc_info['geotransform'][3]),
             lulc_info['projection_wkt'], lulc_new_path)
 
         lulc_array = None
@@ -869,10 +941,10 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
 
         # set up tiny raster arrays to test
         precip_array = numpy.array([
-            [10, 10], 
+            [10, 10],
             [10, 10]], dtype=numpy.float32)
         lulc_array = numpy.array([
-            [1, 1], 
+            [1, 1],
             [2, 2]], dtype=numpy.float32)
         cn_array = numpy.array([
             [40, 40],
@@ -881,10 +953,10 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             [15, 15],
             [2.5, 2.5]], dtype=numpy.float32)
         n_events_array = numpy.array([
-            [10, 10], 
+            [10, 10],
             [1, 1]], dtype=numpy.float32)
         stream_mask = numpy.array([
-            [0, 0], 
+            [0, 0],
             [0, 0]], dtype=numpy.float32)
 
         expected_quickflow_array = numpy.array([
@@ -919,7 +991,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
 
         # save the quickflow results raster to quickflow.tif
         seasonal_water_yield._calculate_monthly_quick_flow(
-            precip_path, lulc_path, cn_path, n_events_path, stream_path, 
+            precip_path, lulc_path, cn_path, n_events_path, stream_path,
             si_path, output_path)
         # read the raster output back in to a numpy array
         quickflow_array = pygeoprocessing.raster_to_numpy_array(output_path)
@@ -933,10 +1005,10 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
 
         # set up tiny raster arrays to test
         precip_array = numpy.array([
-            [10, 10], 
+            [10, 10],
             [10, 10]], dtype=numpy.float32)
         et0_array = numpy.array([
-            [100, 100], 
+            [100, 100],
             [200, 200]], dtype=numpy.float32)
         quickflow_array = numpy.array([
             [-4.8e-36, -4.822e-36],
@@ -948,7 +1020,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             [1, 1],
             [1, 1]], dtype=numpy.float32)
         stream_mask = numpy.array([
-            [0, 0], 
+            [0, 0],
             [0, 0]], dtype=numpy.float32)
 
         precip_path = os.path.join(self.workspace_dir, 'precip.tif')
@@ -978,11 +1050,11 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
                 array, -1, (1, -1), (1180000, 690000), project_wkt, path)
 
         # arbitrary values for alpha, beta, gamma, etc.
-        # not verifying the output, just making sure there are no errors 
+        # not verifying the output, just making sure there are no errors
         seasonal_water_yield_core.calculate_local_recharge(
             [precip_path for i in range(12)], [et0_path for i in range(12)],
-            [quickflow_path for i in range(12)], flow_dir_path, 
-            [kc_path for i in range(12)], {i: 0.5 for i in range(12)}, 0.5, 
+            [quickflow_path for i in range(12)], flow_dir_path,
+            [kc_path for i in range(12)], {i: 0.5 for i in range(12)}, 0.5,
             0.5, stream_path, 'target_li_path.tif', 'target_li_avail_path.tif',
             'target_l_sum_avail_path.tif', 'target_aet_path.tif')
 


### PR DESCRIPTION
The PR fixes a bug in SWY where a 64-bit precip or eto raster with values (typically nodata set to `numpy.finfo(numpy.float64).min` ) outside 32-bit precision would cause `-inf` values that would sneak there where through the model calculations without throwing an error. The problem was the cython module using `float` instead of `double` for the precip and eto pixel variables and the precip / eto rasters basically coming in to that module from the user input. Normally in our workflow, by the time we've reached a Cython module the inputs have been handled by pygeoprocessing and usually set as Float32 with a reasonable nodata value. 

I did add a test that uses Float64 precip rasters and confirmed the test failed before this fix.

The issue is documented here: #331 

I scanned around the other cython modules we have in InVEST and it did not look like this was a possible problem in any of those.

Closes #331