### PR TITLE
Remove duplicate validation calls

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -55,6 +55,8 @@ Unreleased Changes (3.9)
       messages from the model execution will show up when you run the script.
     * InVEST is now a 64-bit binary built against Python 3.7.
     * Adding Python 3.8 support for InVEST testing.
+    * Stop running validation extra times when model inputs autofill, saving
+      a small but noticeable amount of time in launching a model.
 * Coastal Vulnerability
     * 'shore_points_missing_geomorphology.gpkg' output file name now includes
       the suffix if any, and its one layer now is renamed from

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -1165,6 +1165,7 @@ class InVESTModel(QtWidgets.QMainWindow):
             localdoc (string): The filename of the user's guide chapter for
                 this model.
         """
+
         QtWidgets.QMainWindow.__init__(self)
         self.label = label
         self.target = target
@@ -1851,16 +1852,7 @@ class InVESTModel(QtWidgets.QMainWindow):
         def _validate(new_value):
             # We want to validate the whole form; discard the individual value
             self.validate(block=False)
-
-        self.validate(block=False)
-        for input_obj in self.inputs:
-            input_obj.value_changed.connect(_validate)
-            try:
-                input_obj.validity_changed.connect(_validate)
-            except AttributeError:
-                # Not all inputs can have validity (e.g. Container, dropdown)
-                pass
-
+        
         # Set up quickrun options if we're doing a quickrun
         if quickrun:
             @QtCore.Slot()
@@ -1907,6 +1899,15 @@ class InVESTModel(QtWidgets.QMainWindow):
         self.show()
         self.raise_()  # raise window to top of stack.
         self.validate(block=False)  # initial validation for the model
+
+        for input_obj in self.inputs:
+            input_obj.value_changed.connect(_validate)
+            try:
+                input_obj.validity_changed.connect(_validate)
+            except AttributeError:
+                # Not all inputs can have validity (e.g. Container, dropdown)
+                pass
+
 
     def close(self, prompt=True):
         """Close the window.


### PR DESCRIPTION
While experimenting with early logging from the UI before the model run logfile is created, I noticed `model.validate` was being called a lot of times. The last run args are loaded after `connect`ing args changes to `validate`. So validation was being called once for each arg when it gets autofilled. 
Getting rid of this duplication made the `invest run` command noticeably faster for me.