### PR TITLE
Bugfix/cv shore points memory

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -60,6 +60,8 @@ Unreleased Changes (3.9)
       the suffix if any, and its one layer now is renamed from
       'missing_geomorphology' to be the same as the file name
       (including suffix).
+    * Fixed a memory bug that occurred during shore point interpolation when
+      dealing with very large landmass vectors.
 * Delineateit
     * The layer in the 'preprocessed_geometries.gpkg' output is renamed from
       'verified_geometries' to be the same as the file name (including suffix).

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -701,21 +701,24 @@ def interpolate_shore_points(
             if intersected_shapely_geom.type == 'LineString':
                 lines_in_aoi_list.append(intersected_shapely_geom)
             elif intersected_shapely_geom.type == 'MultiLineString':
+                intersected_geom_len = len(intersected_shapely_geom)
+                # Iterator to limit the number of shapely geometries that get
+                # loaded in a list comprehension. This has caused a memory
+                # error on large landmass vectors
+                linestring_chunks = [
+                    x for x in range(0, intersected_geom_len, 10000)]
 
-                intersected_shapely_geom_length = len(intersected_shapely_geom_length)
-                
-                linestring_chunks = [x for x in range(0, intersected_shapely_geom_length, 1000)]
-                
                 for idx, chunk in enumerate(linestring_chunks):
-                    if idx < len(linestring_chunks)-1:
+                    if idx < len(linestring_chunks) - 1:
                         shapely_geom_explode = [
                             shapely.geometry.LineString(x)
-                            for x in intersected_shapely_geom[chunk:linestring_chunks[idx+1]]]
+                            for x in intersected_shapely_geom[
+                                chunk:linestring_chunks[idx + 1]]]
                     else:
                         shapely_geom_explode = [
                             shapely.geometry.LineString(x)
                             for x in intersected_shapely_geom[idx:]]
-                    LOGGER.debug(f"exploding shore points: {idx} of {len(linestring_chunk)}")
+
                     lines_in_aoi_list.extend(shapely_geom_explode)
             else:
                 # intersection could generate a point geom
@@ -2052,7 +2055,7 @@ def calculate_habitat_rank(
 
 def calculate_geomorphology_exposure(
         geomorphology_vector_path, geomorphology_fill_value,
-        base_shore_point_vector_path, model_resolution, target_pickle_path, 
+        base_shore_point_vector_path, model_resolution, target_pickle_path,
         target_missing_data_path):
     """Join geomorphology ranks to shore points by proximity.
 
@@ -2072,7 +2075,7 @@ def calculate_geomorphology_exposure(
         target_pickle_path (string): path to pickle file storing dict
             keyed by point fid.
         target_missing_data_path (string): path to create point vector showing
-            which points received the geomorphology fill value because no 
+            which points received the geomorphology fill value because no
             geomorphology segments were found within the search radius.
 
     Returns:
@@ -2985,7 +2988,7 @@ def validate(args, limit_to=None):
                 (['shelf_contour_vector_path'],
                  'Must be a polyline vector'))
 
-    if ('slr_vector_path' in sufficient_keys and 
+    if ('slr_vector_path' in sufficient_keys and
        'slr_vector_path' not in invalid_keys):
         vector = gdal.OpenEx(args['slr_vector_path'], gdal.OF_VECTOR)
         layer = vector.GetLayer()
@@ -2995,7 +2998,7 @@ def validate(args, limit_to=None):
             ogr.wkbPointM, ogr.wkbMultiPointM,
             ogr.wkbPointZM, ogr.wkbMultiPointZM,
             ogr.wkbPoint25D, ogr.wkbMultiPoint25D]:
-            validation_warnings.append((['slr_vector_path'], 
+            validation_warnings.append((['slr_vector_path'],
                 f'Must be a point or multipoint geometry.'))
 
     if ('slr_vector_path' not in invalid_keys and

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -701,10 +701,22 @@ def interpolate_shore_points(
             if intersected_shapely_geom.type == 'LineString':
                 lines_in_aoi_list.append(intersected_shapely_geom)
             elif intersected_shapely_geom.type == 'MultiLineString':
-                shapely_geom_explode = [
-                    shapely.geometry.LineString(x)
-                    for x in intersected_shapely_geom]
-                lines_in_aoi_list.extend(shapely_geom_explode)
+
+                intersected_shapely_geom_length = len(intersected_shapely_geom_length)
+                
+                linestring_chunks = [x for x in range(0, intersected_shapely_geom_length, 1000)]
+                
+                for idx, chunk in enumerate(linestring_chunks):
+                    if idx < len(linestring_chunks)-1:
+                        shapely_geom_explode = [
+                            shapely.geometry.LineString(x)
+                            for x in intersected_shapely_geom[chunk:linestring_chunks[idx+1]]]
+                    else:
+                        shapely_geom_explode = [
+                            shapely.geometry.LineString(x)
+                            for x in intersected_shapely_geom[idx:]]
+                    LOGGER.debug(f"exploding shore points: {idx} of {len(linestring_chunk)}")
+                    lines_in_aoi_list.extend(shapely_geom_explode)
             else:
                 # intersection could generate a point geom
                 # or if somehow the intersection is empty,


### PR DESCRIPTION
This PR patches a memory bug during shore points interpolation. Given a very large landmass the list comprehension that would convert `multilinestring` geometries to `linestring` geometries would bust. The solution here chunks through the multiline geometries in 10,000 chunks. 10,000 is an arbitrary number that I found worked and seemed reasonable? I couldn't think of a better metric to help decide on this number. 

This bug was brought to our attention via a user: https://community.naturalcapitalproject.org/t/coastal-vulnerability-memory-error-and-managing-very-large-aois/1430/11

The memory error was reproducible on 32-bit version of InVEST but not 64-bit versions. I tested the solution here on 32-bit version to ensure it fixed this specific memory bug with the users data.

Fixes #352