### PR TITLE
HQ: make validation treat empty string args as non-existent.

### DIFF
--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -291,11 +291,11 @@ def execute(args):
     threat_values_task_lookup = {}
     LOGGER.info("Validate threat rasters and collect unique LULC codes")
     # compile all the threat rasters associated with the land cover
-    for lulc_key, lulc_args in (('_c', 'lulc_cur_path'),
-                                ('_f', 'lulc_fut_path'),
-                                ('_b', 'lulc_bas_path')):
-        if lulc_args in args:
-            lulc_path = args[lulc_args]
+    for lulc_key, lulc_arg in (('_c', 'lulc_cur_path'),
+                               ('_f', 'lulc_fut_path'),
+                               ('_b', 'lulc_bas_path')):
+        if lulc_arg in args and args[lulc_arg] != '':
+            lulc_path = args[lulc_arg]
             lulc_path_dict[lulc_key] = lulc_path
             # save land cover paths in a list for alignment and resize
             lulc_and_threat_raster_list.append(lulc_path)
@@ -1084,10 +1084,10 @@ def validate(args, limit_to=None):
         duplicate_paths = []
         threat_path_list = []
         bad_threat_columns = []
-        for lulc_key, lulc_args in (('_c', 'lulc_cur_path'),
-                                    ('_f', 'lulc_fut_path'),
-                                    ('_b', 'lulc_bas_path')):
-            if lulc_args in args:
+        for lulc_key, lulc_arg in (('_c', 'lulc_cur_path'),
+                                   ('_f', 'lulc_fut_path'),
+                                   ('_b', 'lulc_bas_path')):
+            if lulc_arg in args and args[lulc_arg] != '':
                 # for each threat given in the CSV file try opening the
                 # associated raster which should be found in
                 # threat_raster_folder


### PR DESCRIPTION
Here's a quick PR to make validation in HQ compliant to an args dict that has empty strings for arg values. I think the pattern of checking for the key `and` checking that the value is not an empty string is common across invest. 

Datastacks like this are common if they're saved from the invest UI:

```
{
    "args": {
        "access_vector_path": "C:\\Users\\dmf\\projects\\forum\\hq_neg\\Aree_protette_clip.shp",
        "half_saturation_constant": 0.5,
        "lulc_bas_path": "",
        "lulc_cur_path": "C:\\Users\\dmf\\projects\\forum\\hq_neg\\LULC2.tif",
        "lulc_fut_path": "",
        "n_workers": "-1",
        "results_suffix": "",
        "sensitivity_table_path": "C:\\Users\\dmf\\projects\\forum\\hq_neg\\Sensitivity_39.csv",
        "threat_raster_folder": "C:\\Users\\dmf\\projects\\forum\\hq_neg",
        "threats_table_path": "C:\\Users\\dmf\\projects\\forum\\hq_neg\\Threats_39.csv",
        "workspace_dir": "C:\\Users\\dmf\\projects\\forum\\hq_neg\\run"
    },
    "invest_version": "3.8.9",
    "model_name": "natcap.invest.habitat_quality"
}
```

I didn't note this in HISTORY because it's based on the unreleased 3.9 branch.