### PR TITLE
Installer architecture warning for 32-bit machines

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -55,6 +55,8 @@ Unreleased Changes (3.9)
       messages from the model execution will show up when you run the script.
     * InVEST is now a 64-bit binary built against Python 3.7.
     * Adding Python 3.8 support for InVEST testing.
+    * Add warning message to installer for 32-bit computers about installing
+      64-bit software.
 * Coastal Vulnerability
     * 'shore_points_missing_geomorphology.gpkg' output file name now includes
       the suffix if any, and its one layer now is renamed from

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 49d21d840086bda8be8bf65b1a24fdd83376ee68
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := c993a4f86d161e2922d445a3b79a344ab50a6f26
-
+GIT_UG_REPO_REV              := f414425390a790867e076c38a5400fe13c59d812
 
 ENV = env
 ifeq ($(OS),Windows_NT)

--- a/doc/api-docs/cli.rst
+++ b/doc/api-docs/cli.rst
@@ -12,7 +12,7 @@ package.  See `Installing InVEST <installing.html>`_
 
 It is also available to Windows users who installed InVEST with the downloadable
 installer. Just replace ``invest`` in the commands below with the full path to 
-``invest.exe`` (e.g. ``C:\InVEST_3.8.0_x86\invest-3-x86\invest.exe``)
+``invest.exe`` (e.g. ``C:\InVEST_3.8.9_x64\invest-3-x64\invest.exe``)
 
 Usage
 =====

--- a/installer/windows/invest-autotest.bat
+++ b/installer/windows/invest-autotest.bat
@@ -1,6 +1,6 @@
-@REM Run this script from within the invest-3-x86 directory to run the
+@REM Run this script from within the invest-3-x64 directory to run the
 @REM invest-autotest program on windows.
 @REM
-@REM Assumes that 32-bit python is on the PATH.
+@REM Assumes that 64-bit python is on the PATH.
 
 python "%CD%\invest-autotest.py" --cwd="..\sample_data" --binary="%CD%\invest.exe

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -114,7 +114,6 @@ SetCompressor zlib
 !define MUI_ICON "InVEST-2.ico"
 
 ; Add an advanced options control for the welcome page.
-;!define MUI_PAGE_CUSTOMFUNCTION_SHOW WarnArchitecture
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW AddAdvancedOptions
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE ValidateAdvZipFile
 !insertmacro MUI_PAGE_WELCOME
@@ -181,10 +180,8 @@ Function AddAdvancedOptions
         Call EnableAdvFileSelect
     ${EndIf}
 
-
-    ${If} ${RunningX64}
-        Call WarnArchitecture
-    ${Else}
+    ; if install computer is 32-bit then warn the user of a 64-bit app.
+    ${IfNot} ${RunningX64}
         Call WarnArchitecture
     ${EndIf}
 FunctionEnd

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -1,9 +1,9 @@
 ; Variables needed at the command line:
-; VERSION         - the version of InVEST we're building (example: 3.4.5)
+; VERSION         - the version of InVEST we're building (example: 3.8.9)
 ;                   This string must not contain characters that are
 ;                   problematic in Windows paths (no : , etc)
 ; BINDIR          - The local folder of binaries to include.
-; ARCHITECTURE    - The architecture we're building for.  Generally this is x86.
+; ARCHITECTURE    - The architecture we're building for. Generally this is x64.
 ; FORKNAME        - The username of the InVEST fork we're building off of.
 ; DATA_LOCATION   - Where (relative to datportal) the data should be downloaded
 ;                   from.
@@ -24,9 +24,9 @@
 ;    sample data as a single zipfile with the installer, as might be the case
 ;    for sysadmins installing on many computers, or Natcappers installing on
 ;    user's computers at a training.  To make this work, a specially formatted
-;    zipfile must be used.  This zipfile may be created with paver by calling:
+;    zipfile must be used.  This zipfile may be created with make by calling:
 ;
-;        $ paver build_data --single-archive
+;        $ make sampledata_single
 ;
 ;    Alternately, this zipfile may be assembled by hand, so long as the
 ;    zipfile has all sample data folders at the top level.  Whatever is in the
@@ -34,11 +34,11 @@
 ;
 ;    It's also worth noting that this 'Advanced' install may be used at the
 ;    command-line, optionally as part of a silent install.  If we assume that
-;    the InVEST 3.3.1 installer and the advanced sampledata zipfile are copied
+;    the InVEST 3.8.9 installer and the advanced sampledata zipfile are copied
 ;    to the same directory, and we open a cmd prompt within that same
 ;    directory:
 ;
-;        > .\InVEST_3.3.1_Setup_x86.exe /S /DATAZIP=%CD%\sampledata.zip
+;        > .\InVEST_3.8.8_Setup_x64.exe /S /DATAZIP=%CD%\sampledata.zip
 ;
 ;    This will execute the installer silently, and extract the contents of
 ;    sampledata.zip to the installation directory.
@@ -114,6 +114,7 @@ SetCompressor zlib
 !define MUI_ICON "InVEST-2.ico"
 
 ; Add an advanced options control for the welcome page.
+;!define MUI_PAGE_CUSTOMFUNCTION_SHOW WarnArchitecture
 !define MUI_PAGE_CUSTOMFUNCTION_SHOW AddAdvancedOptions
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE ValidateAdvZipFile
 !insertmacro MUI_PAGE_WELCOME
@@ -158,7 +159,9 @@ var AdvCheckbox
 var AdvFileField
 var AdvZipFile
 var LocalDataZipFile
+var WarnLabel
 Function AddAdvancedOptions
+    ; NSD_CREATE* macros take 5 params: x, y, width, height and text
     ${NSD_CreateCheckBox} 120u -18u 15% 12u "Advanced"
     pop $AdvCheckbox
     ${NSD_OnClick} $AdvCheckbox EnableAdvFileSelect
@@ -176,6 +179,13 @@ Function AddAdvancedOptions
     ${If} $LocalDataZipFile != ""
         ${NSD_Check} $AdvCheckbox
         Call EnableAdvFileSelect
+    ${EndIf}
+
+
+    ${If} ${RunningX64}
+        Call WarnArchitecture
+    ${Else}
+        Call WarnArchitecture
     ${EndIf}
 FunctionEnd
 
@@ -218,6 +228,14 @@ Function ValidateAdvZipFile
         ; Save the value in the advanced filefield as $LocalDataZipFile
         strcpy $LocalDataZipFile $0
     ${EndIf}
+FunctionEnd
+
+Function WarnArchitecture
+    !define msg1 " Warning: 32-bit architecture detected. Installing $\r$\n"
+    !define msg2 " 64-bit software could lead to unexpected results. $\r$\n"
+    ${NSD_CreateLabel} 120u -56u 50% 16u "${msg1}${msg2}"
+    pop $WarnLabel
+    SetCtlColors $WarnLabel 0x000000 0xFFE300
 FunctionEnd
 
 ; NSIS 3.x defines these variables, NSIS 2.x does not.  This supports both versions.
@@ -274,7 +292,7 @@ Function Un.onInit
 FunctionEnd
 
 ; Copied into the invest folder later in the NSIS script
-!define INVEST_BINARIES "$INSTDIR\invest-3-x86"
+!define INVEST_BINARIES "$INSTDIR\invest-3-x64"
 !define INVEST_ICON "${INVEST_BINARIES}\InVEST-2.ico"
 !define SAMPLEDATADIR "$INSTDIR\sample_data"
 !macro StartMenuLink linkName modelName


### PR DESCRIPTION
This PR adds a warning message to the InVEST installer on the landing page. The message warns 32-bit computer users that the 64-bit software being installed probably won't work. 

![installer-warning-screenshot-small](https://user-images.githubusercontent.com/2659980/97868900-8420ed80-1cde-11eb-8316-a93b7b9643b0.png)


Fixes #4 