### PR TITLE
Update gha setup miniconda version

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -42,7 +42,7 @@ jobs:
               run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Restore pip cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~\AppData\Local\pip\Cache
                   key: windows-py${{ env.PYTHON_VERSION }}-${{ env.PYTHON_ARCH}}-pip-${{ hashFiles('**/requirements*.txt') }}-exe
@@ -186,7 +186,7 @@ jobs:
                   brew install pandoc
 
             - name: Restore conda cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~/opt/anaconda3
                   key: mac-py${{ env.PYTHON_VERSION }}-${{ env.PYTHON_ARCH}}-conda-${{ hashFiles('**/requirements*.txt') }}-exe

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -48,7 +48,7 @@ jobs:
                   key: windows-py${{ env.PYTHON_VERSION }}-${{ env.PYTHON_ARCH}}-pip-${{ hashFiles('**/requirements*.txt') }}-exe
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: winbin-env
                   auto-update-conda: true
@@ -192,7 +192,7 @@ jobs:
                   key: mac-py${{ env.PYTHON_VERSION }}-${{ env.PYTHON_ARCH}}-conda-${{ hashFiles('**/requirements*.txt') }}-exe
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: macbin-env
                   auto-update-conda: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,7 @@ jobs:
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: ${{ matrix.os }}-test-env
                   auto-update-conda: true
@@ -151,7 +151,7 @@ jobs:
               run: git fetch origin +refs/tags/*:refs/tags/*
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: source-env
                   auto-update-conda: true
@@ -237,7 +237,7 @@ jobs:
                   key: windows-py37-pipcache-sampledata-${{ hashfiles('requirements.txt') }}
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: validate-env
                   auto-update-conda: true
@@ -291,7 +291,7 @@ jobs:
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
             - name: Setup conda environment
-              uses: conda-incubator/setup-miniconda@v1.7.0
+              uses: conda-incubator/setup-miniconda@v2
               with:
                   activate-environment: ui-env
                   auto-update-conda: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~\AppData\Local\pip\Cache
                   key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-${{ hashFiles('**/requirements*.txt') }}-model-tests
@@ -68,7 +68,7 @@ jobs:
             # Test data is way, way faster by contrast (on the order of a few
             # seconds to archive).
             - name: Restore git-LFS test data cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: data/invest-test-data
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}
@@ -231,7 +231,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Restore pip cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~\AppData\Local\pip\Cache
                   key: windows-py37-pipcache-sampledata-${{ hashfiles('requirements.txt') }}
@@ -279,13 +279,13 @@ jobs:
 
               # Taken from https://github.com/actions/cache/blob/master/examples.md#python---pip
             - name: Restore pip cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: ~\AppData\Local\pip\Cache
                   key: ${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.python-architecture }}-pip-${{ hashFiles('**/requirements*.txt') }}-ui-tests
 
             - name: Restore git-LFS test data cache
-              uses: actions/cache@v1
+              uses: actions/cache@v2
               with:
                   path: data/invest-test-data
                   key: git-lfs-testdata-${{ hashfiles('Makefile') }}


### PR DESCRIPTION
# Description
Update github action versions for setup-miniconda to patch the warning / security issue for `add-path` being deprecated. Also bumped the github actions cache.


Fixes #346 
