### PR TITLE
Update TaskGraph to 0.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.0,<1.8.0
 scipy>=0.16.1,<1.5.0 # pip-only
 pygeoprocessing>=2.1.1 # pip-only
-taskgraph[niced_processes]==0.9.1
+taskgraph[niced_processes]>=0.10.0
 psutil>=5.6.6
 chardet>=3.0.4
 xlrd>=1.2.0

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -346,6 +346,7 @@ def execute(args):
                     threat_values_task = task_graph.add_task(
                          func=_raster_values_in_bounds,
                          args=((threat_path, 1), 0.0, 1.0),
+                         store_result=True,
                          task_name=f'check_threat_values{lulc_key}_{threat}')
                     threat_values_task_lookup[threat_values_task.task_name] = {
                         'task': threat_values_task,

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -300,6 +300,7 @@ def execute(args):
         _determine_valid_viewpoints,
         args=(file_registry['clipped_dem'],
               file_registry['structures_clipped']),
+        store_result=True,
         dependent_task_list=[clipped_viewpoints_task, clipped_dem_task],
         task_name='determine_valid_viewpoints')
 

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -332,6 +332,7 @@ def execute(args):
         args=(
             (flood_vol_raster_path, 1),
             reprojected_aoi_path),
+        store_result=True,
         dependent_task_list=[flood_vol_task, reprojected_aoi_task],
         task_name='zonal_statistics over the flood_volume raster')
 
@@ -340,6 +341,7 @@ def execute(args):
         args=(
             (runoff_retention_raster_path, 1),
             reprojected_aoi_path),
+        store_result=True,
         dependent_task_list=[runoff_retention_task],
         task_name='zonal_statistics over runoff_retention raster')
 
@@ -348,6 +350,7 @@ def execute(args):
         args=(
             (runoff_retention_vol_raster_path, 1),
             reprojected_aoi_path),
+        store_result=True,
         dependent_task_list=[runoff_retention_vol_task],
         task_name='zonal_statistics over runoff_retention_volume raster')
 
@@ -377,6 +380,7 @@ def execute(args):
             args=(reprojected_aoi_path,
                   reprojected_structures_path,
                   args['infrastructure_damage_loss_table_path']),
+            store_result=True,
             dependent_task_list=[
                 reprojected_aoi_task,
                 reproject_built_infrastructure_task],


### PR DESCRIPTION
# Description
Updates InVEST to TaskGraph 0.10.0 and uses the `store_result` param, which is not backwards compatible. 

Fixes #275 

# Checklist
- Nothing user facing.