### PR TITLE
Bumping shapely requirement for Mac OS Big Sur issue #383

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -61,6 +61,8 @@ Unreleased Changes (3.9)
       a small but noticeable amount of time in launching a model.
     * The number of files included in the python source distribution has been
       reduced to just those needed to install the python package and run tests.
+    * Bumped the ``shapely`` requirements to ``>=1.7.1`` to address a library
+      import issue on Mac OS Big Sur.
 * Coastal Blue Carbon
     * Refactor of Coastal Blue Carbon that implements TaskGraph for task
       management across the model and fixes a wide range of issues with the model

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Pyro4==4.77  # pip-only
 pandas>=1.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
-Shapely>=1.7.0,<1.8.0
+Shapely>=1.7.1,<2.0.0
 scipy>=0.16.1,<1.5.0 # pip-only
 pygeoprocessing>=2.1.1 # pip-only
 taskgraph[niced_processes]==0.9.1


### PR DESCRIPTION
# Description

Bumps the shapely version to fix a low-level library import issue revealed on Mac OS Big Sur because of the new way that the OS's linker handles dynamic libraries.

The version bump also raises the shapely version ceiling to ~~`<=2.0`~~ `<2.0` since the shapely devs are working on that version.

Fixes #383

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
