### PR TITLE
Change UFRM field names from using dot to underscore

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -141,6 +141,10 @@ Unreleased Changes (3.9)
 * Urban Cooling
     * Split energy savings valuation and work productivity valuation into 
       separate UI options.
+* Urban Flood Risk
+    * Changed output field names ``aff.bld`` and ``serv.blt`` to ``aff_bld``
+      and ``serv_blt`` respectively to fix an issue where ArcGIS would not 
+      display properly.
 
 ..
 ..

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 817adf2ffb68a5b5c636e5d8a08c20acd4c8ea81
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := 682503a4f6373b81363924387bc74f3d17fb9979
+GIT_UG_REPO_REV              := 57f5c9716709ca2185d8a1607c4ec6f4e7a630d0
 
 ENV = env
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -429,9 +429,9 @@ def _write_summary_vector(
     If ``damage_per_aoi_stats`` is provided, then these additional columns will
     be written to the vector::
 
-        * ``'aff.bld'``: Potential damage to built infrastructure in $,
+        * ``'aff_bld'``: Potential damage to built infrastructure in $,
           per watershed.
-        * ``'serv.blt'``: Spatial indicator of the importance of the runoff
+        * ``'serv_blt'``: Spatial indicator of the importance of the runoff
           retention service
 
     Args:
@@ -480,7 +480,7 @@ def _write_summary_vector(
     if not damage_per_aoi_stats:
         damage_per_aoi_stats = {}
     else:
-        target_fields += ['aff.bld', 'serv.blt']
+        target_fields += ['aff_bld', 'serv_blt']
 
     for field_name in target_fields:
         field_def = ogr.FieldDefn(field_name, ogr.OFTReal)
@@ -512,11 +512,11 @@ def _write_summary_vector(
             pixel_count = runoff_ret_vol_stats[feature_id]['count']
             if pixel_count > 0:
                 damage_sum = damage_per_aoi_stats[feature_id]
-                target_feature.SetField('aff.bld', damage_sum)
+                target_feature.SetField('aff_bld', damage_sum)
 
-                # This is the service.built equation.
+                # This is the service_built equation.
                 target_feature.SetField(
-                    'serv.blt', (
+                    'serv_blt', (
                         damage_sum * runoff_ret_vol_stats[feature_id]['sum']))
 
         if feature_id in flood_volume_stats:

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -64,14 +64,14 @@ class UFRMTests(unittest.TestCase):
 
         # Check that all four expected fields are there.
         self.assertEqual(
-            set(('aff.bld', 'serv.blt', 'rnf_rt_idx', 'rnf_rt_m3',
+            set(('aff_bld', 'serv_blt', 'rnf_rt_idx', 'rnf_rt_m3',
                  'flood_vol')),
             set(field.GetName() for field in result_layer.schema))
 
         result_feature = result_layer.GetFeature(0)
         for fieldname, expected_value in (
-                ('aff.bld', 187010830.32202843),
-                ('serv.blt', 13253546667257.65),
+                ('aff_bld', 187010830.32202843),
+                ('serv_blt', 13253546667257.65),
                 ('rnf_rt_idx', 0.70387527942),
                 ('rnf_rt_m3', 70870.4765625),
                 ('flood_vol', 29815.640625)):


### PR DESCRIPTION
# Description
Fixes #397 

This is a simple PR that fixes an issue where dots in the field names of the output vector would cause ArcGIS to fail when looking at the attribute table.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [x] Linted corresponding files
- [x] Updated the user's guide (if needed)
