### PR TITLE
Pin GDAL to 3.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.1.2
+GDAL==3.1.2
 Pyro4==4.77  # pip-only
 pandas>=1.0
 numpy>=1.11.0,!=1.16.0


### PR DESCRIPTION
# Description
 #390 , #402 

The `VirtualXPath` lines only happen with GDAL>=3.1.3. For the release, we can just pin the version. I don't see any related issue on the GDAL github so I'll look into it further and open an issue there if appropriate
