### PR TITLE
masking nodata values needs to use a numpy.isclose equality check

### DIFF
--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1676,7 +1676,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = depth_array != nodata
+        valid_mask = ~numpy.isclose(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2563,6 +2563,7 @@ def _aggregate_raster_values_in_radius(
     n_cols = band.XSize
     geotransform = raster.GetGeoTransform()
     nodata = band.GetNoDataValue()
+    LOGGER.debug(f'{base_raster_path} nodata value: {nodata}')
 
     # we can assume square pixels at this point because
     # we already warped input raster and defined square pixels
@@ -2644,7 +2645,7 @@ def _aggregate_raster_values_in_radius(
                     xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
                     win_ysize=win_ysize)
                 if nodata is not None:
-                    mask = (array != nodata) & temp_kernel_mask
+                    mask = ~numpy.isclose(array, nodata) & temp_kernel_mask
                 else:
                     mask = kernel_mask
                 if numpy.count_nonzero(mask) > 0:


### PR DESCRIPTION
A couple array masking operations were not properly masking nodata values because they weren't using `numpy.isclose` to compare floats.

This addresses one of the items in #402 

# Checklist
- [ x] Updated HISTORY.rst (if these changes are user-facing) - I'm pretty sure we never released a version with this bug.

- [ x] Updated the user's guide (if needed)
