### PR TITLE
I. #406 Refactor and patch GLOBIO msa bugs.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -107,6 +107,9 @@ Unreleased Changes (3.9)
       'watersheds' to match the name of the vector file (including the suffix).
     * Added pour point detection option as an alternative to providing an
       outlet features vector.
+* GLOBIO
+    * Fixing a bug with how the ``msa`` results were masked and operated on
+      that could cause bad results in the ``msa`` outputs.
 * Habitat Quality:
     * Refactor of Habitat Quality that implements TaskGraph
     * Threat files are now indicated in the Threat Table csv input under

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 909d349aa4e813d9502889fcbbff8aece9fdb7b1
+GIT_SAMPLE_DATA_REPO_REV    := 59c4ae80d43c18e614e1295a3f1560617e6ffd09
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data


### PR DESCRIPTION
# Description
Fixes #406 

The following problems were discovered when eye spotting the sample data results.

This PR refactors the `msa` operations to fix masking and dictionary mutation issues. These operations were `raster_calculator` tasks but are now wrapped in a function such that passing in `raw` static types can be avoided which provides cleaner code within the operation itself. 

The big issue was the operations initiating the result with `numpy.empty` which creates random initial values. The sequence of  checking `<, >` for `msa` value ranges against the `distance_to_infrastructure` raster would then `pop` the `<, >` from the `raw` dictionary and replace all the `numpty.empty` values for THAT block. However, on subsequent calls that `pop` would return the default `None` and thus the ranges for `<, >` would not be covered, leaving in random `numpy.empty` values. 

That overall problem has been fixed here with more thorough checking of `nodata` values, using `numpy.full_like` with an initial value of the output nodata value. 

These changes had no effect on current state of tests for this model.

First noted issue in #402 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)