### PR TITLE
Task/windows 402 ordering start menu models

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,9 +34,6 @@
 .. :changelog:
 Unreleased Changes (3.9)
 ------------------------
-* Annual Water Yield:
-    * Fixing bug that limited ``rsupply`` result when ``wyield_mn`` or
-      ``consump_mn`` was 0.
 * General:
     * Deprecating GDAL 2 and adding support for GDAL 3.
     * Adding function in utils.py to handle InVEST coordindate transformations.
@@ -68,6 +65,10 @@ Unreleased Changes (3.9)
     * Fixing model local documentation links for Windows and Mac binaries.
     * The InVEST binary builds now launch on Mac OS 11 "Big Sur".  This was
       addressed by defining the ``QT_MAC_WANTS_LAYER`` environment variable.
+    * Fixed the alphabetical ordering of Windows Start Menu shortcuts.
+* Annual Water Yield:
+    * Fixing bug that limited ``rsupply`` result when ``wyield_mn`` or
+      ``consump_mn`` was 0.
 * Coastal Blue Carbon
     * Refactor of Coastal Blue Carbon that implements TaskGraph for task
       management across the model and fixes a wide range of issues with the model

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -337,8 +337,8 @@ Section "InVEST Tools" Section_InVEST_Tools
 
     !define COASTALBLUECARBON "${SMPATH}\Coastal Blue Carbon"
     CreateDirectory "${COASTALBLUECARBON}"
-    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon Preprocessor" "cbc_pre"
-    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon" "cbc"
+    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon (1) Preprocessor" "cbc_pre"
+    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon (2)" "cbc"
 
     !define FISHERIES "${SMPATH}\Fisheries"
     CreateDirectory "${FISHERIES}"

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -337,13 +337,13 @@ Section "InVEST Tools" Section_InVEST_Tools
 
     !define COASTALBLUECARBON "${SMPATH}\Coastal Blue Carbon"
     CreateDirectory "${COASTALBLUECARBON}"
-    !insertmacro StartMenuLink "${COASTALBLUECARBON}\(1) Coastal Blue Carbon Preprocessor" "cbc_pre"
-    !insertmacro StartMenuLink "${COASTALBLUECARBON}\(2) Coastal Blue Carbon" "cbc"
+    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon Preprocessor" "cbc_pre"
+    !insertmacro StartMenuLink "${COASTALBLUECARBON}\Coastal Blue Carbon" "cbc"
 
     !define FISHERIES "${SMPATH}\Fisheries"
     CreateDirectory "${FISHERIES}"
-    !insertmacro StartMenuLink "${FISHERIES}\(1) Fisheries" "fisheries"
-    !insertmacro StartMenuLink "${FISHERIES}\(2) Fisheries Habitat Scenario Tool" "fisheries_hst"
+    !insertmacro StartMenuLink "${FISHERIES}\Fisheries" "fisheries"
+    !insertmacro StartMenuLink "${FISHERIES}\Fisheries Habitat Scenario Tool" "fisheries_hst"
 
 
     ; Write registry keys for convenient uninstallation via add/remove programs.


### PR DESCRIPTION
Windows start menu names had numeic prefixes for Fisheries & CBC models, which sorted them to the top of the model list. This PR changes their start menu names to:

Coastal Blue Carbon (1) Preprocessor
Coastal Blue Carbon (2)
Fisheries
Fisheries Habitat Scenario Tool

Addresses one item in #402 

# Checklist
- [x ] Updated HISTORY.rst (if these changes are user-facing)

- [ x] Updated the user's guide (if needed)
