### PR TITLE
changed logging level to debug for validation.timeout thread messages…

### DIFF
--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -622,7 +622,7 @@ def timeout(func, *args, timeout=5, **kwargs):
         message_queue.put(func(*args, **kwargs))
 
     thread = threading.Thread(target=wrapper_func)
-    LOGGER.info(f'Starting file checking thread with timeout={timeout}')
+    LOGGER.debug(f'Starting file checking thread with timeout={timeout}')
     thread.start()
     thread.join(timeout=timeout)
 
@@ -634,7 +634,7 @@ def timeout(func, *args, timeout=5, **kwargs):
         return None
 
     else:
-        LOGGER.info('File checking thread completed.')
+        LOGGER.debug('File checking thread completed.')
         # get any warning messages returned from the thread
         return message_queue.get()
 


### PR DESCRIPTION
This PR changes these `validation.timeout` messages to `debug` level - so that UI users do not have to see them by default.

```
2020-12-09 07:16:26,116 validation.timeout(625) INFO Starting file checking thread with timeout=5
2020-12-09 07:16:26,202 validation.timeout(637) INFO File checking thread completed.
2020-12-09 07:16:26,204 validation.timeout(625) INFO Starting file checking thread with timeout=5
2020-12-09 07:16:26,212 validation.timeout(637) INFO File checking thread completed.
2020-12-09 07:16:26,212 validation.timeout(625) INFO Starting file checking thread with timeout=5
2020-12-09 07:16:26,214 validation.timeout(637) INFO File checking thread completed.
2020-12-09 07:16:26,214 validation.timeout(625) INFO Starting file checking thread with timeout=5
2020-12-09 07:16:26,219 validation.timeout(637) INFO File checking thread completed.
```

Addresses one item in #402 

# Checklist
- [x ] Updated HISTORY.rst (if these changes are user-facing)

- [ x] Updated the user's guide (if needed)
