### PR TITLE
Update HQ default half sat for sample data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -133,7 +133,7 @@ Unreleased Changes (3.9)
       value. Now, the decay does not ignore those nodata edges causing values
       on the edges to decay more quickly. The area of study should have
       adequate boundaries to account for these edge effects.
-    * Update default half saturation value for sample data to 0.05 from 0.5.
+    * Update default half saturation value for sample data to 0.05 from 0.1.
 * Seasonal Water Yield
     * Fixed a bug where precip or eto rasters of ``GDT_Float64`` with values
       greater than 32-bit would overflow to ``-inf``.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -133,6 +133,7 @@ Unreleased Changes (3.9)
       value. Now, the decay does not ignore those nodata edges causing values
       on the edges to decay more quickly. The area of study should have
       adequate boundaries to account for these edge effects.
+    * Update default half saturation value for sample data to 0.05 from 0.5.
 * Seasonal Water Yield
     * Fixed a bug where precip or eto rasters of ``GDT_Float64`` with values
       greater than 32-bit would overflow to ``-inf``.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 59c4ae80d43c18e614e1295a3f1560617e6ffd09
+GIT_SAMPLE_DATA_REPO_REV    := b7a51f189315e08484b5ba997a5c1de88ab7f06d
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 510db35b4883cdc46e4784aa7a137ae481e352a7
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := afc9a3ce2cba5c8e263ae18ad66ca350d4884a42
+GIT_UG_REPO_REV              := bbfa26dc0c9158d13d209c1bc61448a9166708da
 
 ENV = env
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -180,7 +180,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": (
-                "A positive floating point value that is defaulted at 0.5. "
+                "A positive floating point value that is defaulted at 0.05. "
                 "This is the value of the parameter k in equation (4). In "
                 "general, set k to half of the highest grid cell degradation "
                 "value on the landscape.  To perform this model calibration "

--- a/src/natcap/invest/ui/habitat_quality.py
+++ b/src/natcap/invest/ui/habitat_quality.py
@@ -148,7 +148,7 @@ class HabitatQuality(model.InVESTModel):
             args_key='half_saturation_constant',
             helptext=(
                 "A positive floating point value that is defaulted at "
-                "0.5. This is the value of the parameter k in equation "
+                "0.05. This is the value of the parameter k in equation "
                 "(4). In general, set k to half of the highest grid "
                 "cell degradation value on the landscape.  To perform "
                 "this model calibration the model must be run once in "


### PR DESCRIPTION
# Description
Handles an issue from #402 brought up by Stacie about our default value not demonstrating a good output for quality.

Update value from 0.5 to 0.05. Also update the revisions for sample data and users guide that now reflect this change.

I mentioned not being able to see differences between runs when changing that half saturation value. I no longer see that as the case and confirmed that the reexecution hashes were different from TG. Seems to be okay now.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
