### PR TITLE
Bugfix/docs 402 local docs not found for Forest Carbon Edge Effects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -108,6 +108,10 @@ Unreleased Changes (3.9)
       'watersheds' to match the name of the vector file (including the suffix).
     * Added pour point detection option as an alternative to providing an
       outlet features vector.
+* Forest Carbon Edge Effects
+    * Fixed a broken link to the local User's Guide
+* Finfish
+    * Fixed a bug where the suffix input was not being used for output paths.
 * GLOBIO
     * Fixing a bug with how the ``msa`` results were masked and operated on
       that could cause bad results in the ``msa`` outputs.
@@ -143,8 +147,6 @@ Unreleased Changes (3.9)
       to "333" leading to high export spikes in some pixels.
     * Fixed an issue where sediment deposition progress logging was not
       progressing linearly.
-* Finfish
-    * Fixed a bug where the suffix input was not being used for output paths.
 * Urban Cooling
     * Split energy savings valuation and work productivity valuation into
       separate UI options.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -108,10 +108,10 @@ Unreleased Changes (3.9)
       'watersheds' to match the name of the vector file (including the suffix).
     * Added pour point detection option as an alternative to providing an
       outlet features vector.
-* Forest Carbon Edge Effects
-    * Fixed a broken link to the local User's Guide
 * Finfish
     * Fixed a bug where the suffix input was not being used for output paths.
+* Forest Carbon Edge Effects
+    * Fixed a broken link to the local User's Guide
 * GLOBIO
     * Fixing a bug with how the ``msa`` results were masked and operated on
       that could cause bad results in the ``msa`` outputs.

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -30,7 +30,7 @@ CARBON_MAP_NODATA = -9999
 ARGS_SPEC = {
     "model_name": "Forest Carbon Edge Effect Model",
     "module": __name__,
-    "userguide_html": "forest_carbon_edge_effect.html",
+    "userguide_html": "carbon_edge.html",
     "args_with_spatial_overlap": {
         "spatial_keys": ["aoi_vector_path", "lulc_raster_path"],
     },

--- a/src/natcap/invest/ui/forest_carbon.py
+++ b/src/natcap/invest/ui/forest_carbon.py
@@ -11,7 +11,7 @@ class ForestCarbonEdgeEffect(model.InVESTModel):
             label='Forest Carbon Edge Effect Model',
             target=natcap.invest.forest_carbon_edge_effect.execute,
             validator=natcap.invest.forest_carbon_edge_effect.validate,
-            localdoc='forest_carbon_edge_effect.html')
+            localdoc=natcap.invest.forest_carbon_edge_effect.ARGS_SPEC.userguide_html)
 
         self.lulc_raster_path = inputs.File(
             args_key='lulc_raster_path',


### PR DESCRIPTION
Needed to fix an incorrect filename for the html file.
Addresses an item in #402 

Also found an out-of-alpha-order entry in HISTORY, so I moved the finfish section

# Checklist
- [x ] Updated HISTORY.rst (if these changes are user-facing)

- [x ] Updated the user's guide (if needed)
