### PR TITLE
Mask nodata areas of forest carbon raster output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -114,6 +114,8 @@ Unreleased Changes (3.9)
     * Fixed a broken link to the local User's Guide
     * Fixed bug that was causing overflow errors to appear in the logs when 
       running with the sample data.
+    * Mask out nodata areas of the carbon map output. Now there should be no
+      output data outside of the input LULC rasater area.
 * GLOBIO
     * Fixing a bug with how the ``msa`` results were masked and operated on
       that could cause bad results in the ``msa`` outputs.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 59c4ae80d43c18e614e1295a3f1560617e6ffd09
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 510db35b4883cdc46e4784aa7a137ae481e352a7
+GIT_TEST_DATA_REPO_REV      := 718d2035c59f1917d836208a0769dab101ac4bcc
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -24,8 +24,8 @@ LOGGER = logging.getLogger(__name__)
 # grid cells are 100km. Becky says 500km is a good upper bound to search
 DISTANCE_UPPER_BOUND = 500e3
 
-# helpful to have a global nodata defined for all the carbon map rasters
-CARBON_MAP_NODATA = -9999
+# helpful to have a global nodata defined for the whole model
+NODATA_VALUE = -1
 
 ARGS_SPEC = {
     "model_name": "Forest Carbon Edge Effect Model",
@@ -378,7 +378,7 @@ def execute(args):
         func=pygeoprocessing.raster_calculator,
         args=(carbon_maps_band_list, combine_carbon_maps,
               output_file_registry['carbon_map'], gdal.GDT_Float32,
-              CARBON_MAP_NODATA),
+              NODATA_VALUE),
         target_path_list=[output_file_registry['carbon_map']],
         task_name='combine_carbon_maps')
 
@@ -415,10 +415,10 @@ def combine_carbon_maps(*carbon_maps):
     nodata_mask = numpy.empty(carbon_maps[0].shape, dtype=numpy.bool)
     nodata_mask[:] = True
     for carbon_map in carbon_maps:
-        valid_mask = carbon_map != CARBON_MAP_NODATA
+        valid_mask = carbon_map != NODATA_VALUE
         nodata_mask &= ~valid_mask
         result[valid_mask] += carbon_map[valid_mask]
-    result[nodata_mask] = CARBON_MAP_NODATA
+    result[nodata_mask] = NODATA_VALUE
     return result
 
 
@@ -550,7 +550,7 @@ def _calculate_lulc_carbon_map(
             is_tropical_forest = 0
         if ignore_tropical_type and is_tropical_forest == 1:
             # if tropical forest above ground, lookup table is nodata
-            lucode_to_per_cell_carbon[int(lucode)] = CARBON_MAP_NODATA
+            lucode_to_per_cell_carbon[int(lucode)] = NODATA_VALUE
         else:
             try:
                 lucode_to_per_cell_carbon[int(lucode)] = float(
@@ -570,7 +570,7 @@ def _calculate_lulc_carbon_map(
 
     utils.reclassify_raster(
         (lulc_raster_path, 1), lucode_to_per_cell_carbon,
-        carbon_map_path, gdal.GDT_Float32, CARBON_MAP_NODATA,
+        carbon_map_path, gdal.GDT_Float32, NODATA_VALUE,
         reclass_error_details)
 
 
@@ -607,7 +607,6 @@ def _map_distance_from_tropical_forest_edge(
         if int(ludata['is_tropical_forest']) == 1]
 
     # Make a raster where 1 is non-forest landcover types and 0 is forest
-    forest_mask_nodata = 255
     lulc_nodata = pygeoprocessing.get_raster_info(
         base_lulc_raster_path)['nodata']
 
@@ -618,17 +617,17 @@ def _map_distance_from_tropical_forest_edge(
                 each forest LULC code is in `forest_codes`.
         Returns:
             numpy.ndarray with the same shape as lulc_array. All pixels are
-                0 (forest), 1 (non-forest), or 255 (nodata).
+                0 (forest), 1 (non-forest), or -1 (nodata).
         """
         non_forest_mask = ~numpy.isin(lulc_array, forest_codes)
         nodata_mask = lulc_array == lulc_nodata
-        # where LULC has nodata, set value to forest_mask_nodata value (255)
+        # where LULC has nodata, set value to nodata value (-1)
         # where LULC has data, set to 0 if LULC is a forest type, 1 if it's not
-        return numpy.where(nodata_mask, forest_mask_nodata, non_forest_mask)
+        return numpy.where(nodata_mask, NODATA_VALUE, non_forest_mask)
 
     pygeoprocessing.raster_calculator(
         [(base_lulc_raster_path, 1)], mask_non_forest_op,
-        target_non_forest_mask_path, gdal.GDT_Byte, forest_mask_nodata)
+        target_non_forest_mask_path, gdal.GDT_Byte, NODATA_VALUE)
 
     # Do the distance transform on non-forest pixels
     # This is the distance from each pixel to the nearest pixel with value 1.
@@ -639,20 +638,21 @@ def _map_distance_from_tropical_forest_edge(
         (target_non_forest_mask_path, 1), edge_distance_path)
 
     # mask out the meaningless distance pixels so they don't affect the output
+    lulc_raster = gdal.OpenEx(base_lulc_raster_path)
+    lulc_band = lulc_raster.GetRasterBand(1)
     edge_distance_raster = gdal.OpenEx(edge_distance_path, gdal.GA_Update)
     edge_distance_band = edge_distance_raster.GetRasterBand(1)
-    for (lulc_offset, lulc_block), (_, distance_block) in zip(
-            pygeoprocessing.iterblocks(
-                (base_lulc_raster_path, 1), largest_block=2**12),
-            pygeoprocessing.iterblocks(
-                (edge_distance_path, 1), largest_block=2**12)):
+
+    for offset_dict in pygeoprocessing.iterblocks((base_lulc_raster_path, 1), offset_only=True):
         # where LULC has nodata, overwrite edge distance with nodata value
+        lulc_block = lulc_band.ReadAsArray(**offset_dict)
+        distance_block = edge_distance_band.ReadAsArray(**offset_dict)
         masked_distance_block = numpy.where(
-            lulc_block == lulc_nodata, -1, distance_block)
+            lulc_block == lulc_nodata, NODATA_VALUE, distance_block)
         edge_distance_band.WriteArray(
             masked_distance_block, 
-            xoff=lulc_offset['xoff'], 
-            yoff=lulc_offset['yoff'])
+            xoff=offset_dict['xoff'], 
+            yoff=offset_dict['yoff'])
 
 
 def _build_spatial_index(
@@ -770,8 +770,8 @@ def _calculate_tropical_forest_edge_carbon_map(
     # fill nodata, in case we skip entire memory blocks that are non-forest
     pygeoprocessing.new_raster_from_base(
         edge_distance_path, tropical_forest_edge_carbon_map_path,
-        gdal.GDT_Float32, band_nodata_list=[CARBON_MAP_NODATA],
-        fill_value_list=[CARBON_MAP_NODATA])
+        gdal.GDT_Float32, band_nodata_list=[NODATA_VALUE],
+        fill_value_list=[NODATA_VALUE])
     edge_carbon_raster = gdal.OpenEx(
         tropical_forest_edge_carbon_map_path, gdal.GA_Update)
     edge_carbon_band = edge_carbon_raster.GetRasterBand(1)
@@ -907,7 +907,7 @@ def _calculate_tropical_forest_edge_carbon_map(
         # Ensure the result has nodata everywhere the distance was invalid
         result = numpy.empty(
             edge_distance_block.shape, dtype=numpy.float32)
-        result[:] = CARBON_MAP_NODATA
+        result[:] = NODATA_VALUE
         # convert biomass to carbon in this stage
         result[valid_edge_distance_mask] = (
             average_biomass * biomass_to_carbon_conversion_factor)

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -618,11 +618,11 @@ def _map_distance_from_tropical_forest_edge(
                 each forest LULC code is in `forest_codes`.
         Returns:
             numpy.ndarray with the same shape as lulc_array. All pixels are
-                0 (forest), 1 (non-forest), or -1 (nodata).
+                0 (forest), 1 (non-forest), or 255 (nodata).
         """
         non_forest_mask = ~numpy.isin(lulc_array, forest_codes)
         nodata_mask = lulc_array == lulc_nodata
-        # where LULC has nodata, set value to nodata value (-1)
+        # where LULC has nodata, set value to nodata value (255)
         # where LULC has data, set to 0 if LULC is a forest type, 1 if it's not
         return numpy.where(nodata_mask, forest_mask_nodata, non_forest_mask)
 

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -613,8 +613,7 @@ def _map_distance_from_tropical_forest_edge(
 
     def mask_non_forest_op(lulc_array):
         """Converts forest lulc codes to 1."""
-        non_forest_mask = ~numpy.in1d(
-            lulc_array.flatten(), forest_codes).reshape(lulc_array.shape)
+        non_forest_mask = ~numpy.isin(lulc_array, forest_codes)
         nodata_mask = lulc_array == lulc_nodata
         return numpy.where(nodata_mask, forest_mask_nodata, non_forest_mask)
 
@@ -775,6 +774,7 @@ def _calculate_tropical_forest_edge_carbon_map(
         n_cells_processed += (
             edge_distance_data['win_xsize'] * edge_distance_data['win_ysize'])
         valid_edge_distance_mask = (edge_distance_block > 0)
+        print(numpy.any(edge_distance_block < 0))
 
         # if no valid forest pixels to calculate, skip to the next block
         if not valid_edge_distance_mask.any():

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -610,6 +610,7 @@ def _map_distance_from_tropical_forest_edge(
     lulc_nodata = pygeoprocessing.get_raster_info(
         base_lulc_raster_path)['nodata']
 
+    forest_mask_nodata = 255
     def mask_non_forest_op(lulc_array):
         """Convert forest lulc codes to 0.
         Args:
@@ -623,11 +624,11 @@ def _map_distance_from_tropical_forest_edge(
         nodata_mask = lulc_array == lulc_nodata
         # where LULC has nodata, set value to nodata value (-1)
         # where LULC has data, set to 0 if LULC is a forest type, 1 if it's not
-        return numpy.where(nodata_mask, NODATA_VALUE, non_forest_mask)
+        return numpy.where(nodata_mask, forest_mask_nodata, non_forest_mask)
 
     pygeoprocessing.raster_calculator(
         [(base_lulc_raster_path, 1)], mask_non_forest_op,
-        target_non_forest_mask_path, gdal.GDT_Byte, NODATA_VALUE)
+        target_non_forest_mask_path, gdal.GDT_Byte, forest_mask_nodata)
 
     # Do the distance transform on non-forest pixels
     # This is the distance from each pixel to the nearest pixel with value 1.

--- a/tests/test_forest_carbon_edge.py
+++ b/tests/test_forest_carbon_edge.py
@@ -57,6 +57,18 @@ class ForestCarbonEdgeTests(unittest.TestCase):
                 args['workspace_dir'], 'aggregated_carbon_stocks.shp'),
             os.path.join(REGRESSION_DATA, 'agg_results_base.shp'))
 
+        expected_carbon_raster = gdal.OpenEx(os.path.join(REGRESSION_DATA, 
+                                                          'carbon_map.tif'))
+        expected_carbon_band = expected_carbon_raster.GetRasterBand(1)
+        expected_carbon_array = expected_carbon_band.ReadAsArray()
+        actual_carbon_raster = gdal.OpenEx(os.path.join(REGRESSION_DATA, 
+                                                        'carbon_map.tif'))
+        actual_carbon_band = actual_carbon_raster.GetRasterBand(1)
+        actual_carbon_array = actual_carbon_band.ReadAsArray()
+        self.assertTrue(numpy.allclose(expected_carbon_array, 
+                                       actual_carbon_array))
+
+
     def test_carbon_dup_output(self):
         """Forest Carbon Edge: test for existing output overlap."""
         from natcap.invest import forest_carbon_edge_effect


### PR DESCRIPTION
# Description
#402
Fixes #414 

The shapes in what should be nodata areas of the output carbon map were happening because the function `pygeoprocessing.distance_transform_edt` does not preserve nodata areas. Its docstring says,

> It is computationally convenient to calculate the distance transform on the entire raster irrespective of nodata placement and thus produces a raster that will have distance transform values even in pixels that are nodata in the base.

Masking out the areas of the `edge_distance` raster that are nodata in the `lulc` raster isn't super convenient because you have to read in both rasters blockwise simultaneously and then overwrite the `edge_distance` raster.

I see a few options and I'd like to get another opinion before going further with this and updating the test data:
1. Mask out the nodata areas in `pygeoprocessing.distance_transform_edt`. I like this option because I feel like the current behavior is going against a pattern of preserving nodata across operations. 
2. (implemented in this PR) Mask out the nodata areas in `forest_carbon_edge_effect._map_distance_from_tropical_forest_edge`. You could argue that the model has the responsibility to modify the output from `pygeoprocessing` if it needs it to be masked.
3. Ignore it? I'm guessing we ignored this issue on purpose when the model was first made. Maybe it's fine to have those extra shapes and users will know to ignore them.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
