### PR TITLE
Add logger name to logging format

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,6 +32,12 @@
 
 
 .. :changelog:
+3.9.1
+-----
+* General:
+    * Include logger name in the logging format. This is helpful for the cython
+      modules, which can't log module, function, or line number info.
+
 3.9.0 (2020-12-11)
 ------------------
 * General:

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -20,6 +20,7 @@ import pygeoprocessing
 LOGGER = logging.getLogger(__name__)
 LOG_FMT = (
     "%(asctime)s "
+    "(%(name)s) "
     "%(module)s.%(funcName)s(%(lineno)d) "
     "%(levelname)s %(message)s")
 


### PR DESCRIPTION
# Description
Fixes #15 (sort of)
See my comment [here](https://github.com/natcap/invest/issues/15#issuecomment-754910712) about why this isn't a perfect solution. Having the extra info should be useful for all cython modules, in both invest and pygeoprocessing. 
I'm attaching an example of how the logs look now (search 'routing', 'geoprocessing_core', 'sdr_core' to see examples). Is it annoying having the redundant `name` and `module` info for non-cython logging? I could try adding it as a custom handler for each cython module. Personally I don't mind the redundancy.
[InVEST-Sediment-Delivery-Ratio-Model-(SDR)-log-2021-01-05--14_37_29.txt](https://github.com/natcap/invest/files/5772748/InVEST-Sediment-Delivery-Ratio-Model-.SDR.-log-2021-01-05--14_37_29.txt)


# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
