### PR TITLE
pandas 1.2.0 compatibility (and rtree/pysinstaller compatibility)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,4 @@ pygeoprocessing>=2.1.1 # pip-only
 taskgraph[niced_processes]>=0.10.2 # pip-only
 psutil>=5.6.6
 chardet>=3.0.4
-xlrd>=1.2.0
-xlwt
+xlrd>=1.2.0  # we can drop this if we restrict to pandas>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ GDAL>=3.1.2
 Pyro4==4.77  # pip-only
 pandas>=1.0
 numpy>=1.11.0,!=1.16.0
-Rtree>=0.8.2,!=0.9.1
+Rtree>=0.8.2,!=0.9.1,<=0.9.4
 Shapely>=1.7.1,<2.0.0
 scipy>=0.16.1,<1.5.0 # pip-only
 pygeoprocessing>=2.1.1 # pip-only

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 
 GDAL>=3.1.2
 Pyro4==4.77  # pip-only
-pandas>=1.0,<1.2.0
+pandas>=1.2.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1,<=0.9.4  # for pyinstaller compatibility (issue #439)
 Shapely>=1.7.1,<2.0.0
@@ -23,4 +23,3 @@ pygeoprocessing>=2.1.1 # pip-only
 taskgraph[niced_processes]>=0.10.2 # pip-only
 psutil>=5.6.6
 chardet>=3.0.4
-xlrd>=1.2.0  # we can drop this if we restrict to pandas>=1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pygeoprocessing>=2.1.1 # pip-only
 taskgraph[niced_processes]>=0.10.2 # pip-only
 psutil>=5.6.6
 chardet>=3.0.4
+openpyxl

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -587,7 +587,8 @@ def read_csv_to_dataframe(
         dataframe = pandas.read_csv(
             path, engine=engine, encoding=encoding, sep=sep, **kwargs)
     except UnicodeDecodeError as error:
-        LOGGER.error(f'{path} must be encoded as utf-8')
+        LOGGER.error(
+            f'{path} must be encoded as utf-8 or avoid non-ASCII characters')
         raise error
     # this won't work on integer types, which happens if you set header=None
     # however, there's little reason to use this function if there's no header

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -582,8 +582,12 @@ def read_csv_to_dataframe(
     # allow encoding kwarg to override this if it's provided
     if not encoding and has_utf8_bom(path):
         encoding = 'utf-8-sig'
-    dataframe = pandas.read_csv(path, engine=engine, encoding=encoding,
-                                sep=sep, **kwargs)
+    try:
+        dataframe = pandas.read_csv(
+            path, engine=engine, encoding=encoding, sep=sep, **kwargs)
+    except UnicodeDecodeError as error:
+        LOGGER.error(f'{path} must be encoded as utf-8')
+        raise error
     # this won't work on integer types, which happens if you set header=None
     # however, there's little reason to use this function if there's no header
     dataframe.columns = dataframe.columns.str.strip()

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -13,7 +13,6 @@ import warnings
 
 import pygeoprocessing
 import pandas
-import xlrd
 from osgeo import gdal, osr
 import numpy
 
@@ -529,9 +528,7 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
         if excel_ok:
             try:
                 dataframe = pandas.read_excel(filepath)
-            # XLRDError is for backwards compatibility with pandas<1.2.0
-            # ValueError is for pandas>=1.2.0
-            except (xlrd.biffh.XLRDError, ValueError):
+            except ValueError:
                 return "File could not be opened as a CSV or Excel file."
         else:
             return ("File could not be opened as a CSV. "

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -529,7 +529,9 @@ def check_csv(filepath, required_fields=None, excel_ok=False):
         if excel_ok:
             try:
                 dataframe = pandas.read_excel(filepath)
-            except xlrd.biffh.XLRDError:
+            # XLRDError is for backwards compatibility with pandas<1.2.0
+            # ValueError is for pandas>=1.2.0
+            except (xlrd.biffh.XLRDError, ValueError):
                 return "File could not be opened as a CSV or Excel file."
         else:
             return ("File could not be opened as a CSV. "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -886,7 +886,10 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 """
             ).strip())
         with self.assertRaises(UnicodeDecodeError) as cm:
-            utils.read_csv_to_dataframe(csv_file)
+            # In pandas 1.2.0, there's a bug where sep=None combined
+            # with this UnicodeDecodeError leaves the file handle open,
+            # and our tearDown function errors. So setting sep=',' for now.
+            utils.read_csv_to_dataframe(csv_file, sep=',')
         self.assertTrue("decode byte" in str(cm.exception))
 
     def test_override_default_encoding(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -871,7 +871,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df['HEADER2'][1], 5)
 
     def test_non_utf8_encoding(self):
-        """utils: test that non-ASCII characters raise an error"""
+        """utils: test non-ASCII chars with non-UTF8 encoding raises error"""
         from natcap.invest import utils
 
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -871,7 +871,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df['HEADER2'][1], 5)
 
     def test_non_utf8_encoding(self):
-        """utils: test that non-UTF8 encoding doesn't raise an error"""
+        """utils: test that non-ASCII characters raise an error"""
         from natcap.invest import utils
 
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
@@ -885,12 +885,9 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 bar
                 """
             ).strip())
-        df = utils.read_csv_to_dataframe(csv_file)
-        # the default engine='python' should replace the unknown characters
-        # different encodings of replacement character depending on the system
-        self.assertTrue(df['header'][0] in ['f\xce\xce', 
-            'f\N{REPLACEMENT CHARACTER}\N{REPLACEMENT CHARACTER}'])
-        self.assertEqual(df['header'][1], 'bar')
+        with self.assertRaises(UnicodeDecodeError) as cm:
+            utils.read_csv_to_dataframe(csv_file)
+        self.assertTrue("decode byte" in str(cm.exception))
 
     def test_override_default_encoding(self):
         """utils: test that you can override the default encoding kwarg"""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -650,7 +650,7 @@ class CSVValidation(unittest.TestCase):
         self.assertTrue('missing from this table' in error_msg)
 
     def test_csv_not_utf_8(self):
-        """Validation: test that non-UTF8 CSVs can validate."""
+        """Validation: test non-UTF8 CSVs w/ non-ASCII chars return msg."""
         from natcap.invest import validation
 
         df = pandas.DataFrame([
@@ -664,12 +664,8 @@ class CSVValidation(unittest.TestCase):
         # https://en.wikipedia.org/wiki/ISO/IEC_8859-5
         df.to_csv(target_file, encoding='iso8859_5')
 
-        # Note that non-UTF8 encodings should pass this check, but aren't
-        # actually being read correctly. Characters outside the ASCII set may
-        # be replaced with a replacement character.
-        # UTF16, UTF32, etc. will still raise an error.
         error_msg = validation.check_csv(target_file)
-        self.assertEqual(error_msg, None)
+        self.assertTrue('File must be encoded as a UTF-8 CSV' in error_msg)
 
     def test_excel_missing_fieldnames(self):
         """Validation: test that we can check missing fieldnames in excel."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -676,7 +676,7 @@ class CSVValidation(unittest.TestCase):
             {'foo': 2, 'bar': 3, 'baz': 4},
             {'foo': 3, 'bar': 4, 'baz': 5}])
 
-        target_file = os.path.join(self.workspace_dir, 'test.xls')
+        target_file = os.path.join(self.workspace_dir, 'test.xlsx')
         df.to_excel(target_file)
 
         error_msg = validation.check_csv(

--- a/tests/test_wind_energy.py
+++ b/tests/test_wind_energy.py
@@ -188,7 +188,6 @@ class WindEnergyUnitTests(unittest.TestCase):
             'operation_maintenance_cost': .035,
             'miscellaneous_capex_cost': .05
         }
-        print(result)
         self.assertDictEqual(expected_result, result)
 
     def test_calculate_grid_dist_on_raster(self):

--- a/tests/test_wind_energy.py
+++ b/tests/test_wind_energy.py
@@ -182,10 +182,13 @@ class WindEnergyUnitTests(unittest.TestCase):
             csv_path, parameter_list)
 
         expected_result = {
-            'air_density': 1.225, 'exponent_power_curve': 2.0,
-            'decommission_cost': 0.037000000000000005,
-            'operation_maintenance_cost': .035, 'miscellaneous_capex_cost': .05
+            'air_density': 1.225,
+            'exponent_power_curve': 2.0,
+            'decommission_cost': 0.037,
+            'operation_maintenance_cost': .035,
+            'miscellaneous_capex_cost': .05
         }
+        print(result)
         self.assertDictEqual(expected_result, result)
 
     def test_calculate_grid_dist_on_raster(self):


### PR DESCRIPTION
# Description
Fixes #428 and fixes #439 

This PR makes invest compatible with pandas 1.2.0 and maintains backwards-compatibility. The following changes needed to be accommodated.
* The default behavior of the `read_csv` python engine changed to allow a `UnicodeDecodeError` to bubble up instead of replacing problematic characters.
* `openpyxl` is now preferred over `xlrd` for reading `.xlsx` files and so new types of exceptions are raised when reading fails.
* Changes to default float precision in `read_csv`

This PR also restricts `rtree` to a version that is compatible with our pyinstaller frozen environments, for the time-being.

# Checklist
- [ ] Updated HISTORY.rst - no user-facing changes

- [ ] Updated the user's guide - no changes
