### PR TITLE
Rename finfish module_name to model_name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,9 @@
 * General:
     * Include logger name in the logging format. This is helpful for the cython
       modules, which can't log module, function, or line number info.
+* Finfish:
+    * Rename ARGS_SPEC property ``module_name`` to ``model_name`` to be 
+      consistent with the other models.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,7 +41,7 @@
 * Finfish:
     * Rename ARGS_SPEC property ``module_name`` to ``model_name`` to be 
       consistent with the other models.
-* Fisheries Habitat Scenario Tool
+* Fisheries Habitat Scenario Tool:
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.
 

--- a/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
+++ b/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
@@ -11,7 +11,7 @@ from .. import validation
 LOGGER = logging.getLogger(__name__)
 
 ARGS_SPEC = {
-    "module_name": "Finfish Aquaculture",
+    "model_name": "Finfish Aquaculture",
     "module": __name__,
     "userguide_html": "marine_fish.html",
     "args": {


### PR DESCRIPTION
All models besides finfish have a `model_name` attribute in their spec but finfish has `module_name`. This matters now because the workbench expects a `model_name` property to exist in the `getSpec` server response.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
