### PR TITLE
Changes to go with new UI spec format

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,16 +38,18 @@ workbench-alpha
 * General:
     * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
       and server on the localhost, to support the workbench.
-    * Add ``/colnames`` POST endpoint to the server API. This endpoint accepts a
-      vector filepath and returns a list of the vector's column names (used to
-      determine options for a dropdown menu input).
+    * Add ``/colnames`` POST endpoint to the server API. This endpoint accepts
+      a vector filepath and returns a list of the vector's column names (used 
+      to determine options for a dropdown menu input).
     * Add ``/vector_has_points`` POST endpoint to the server API. This endpoint
       accepts a vector filepath and returns a boolean indicating whether the
-      vector might have point geometries (can't be certain because the type could
-      be ``ogr.wkbUnknown``). This is used by the DelineateIt UI.
-    * Rename finfish ARGS_SPEC ``module_name`` to ``model_name`` to be consistent
-      with all other models.
+      vector might have point geometries (can't be certain because the type 
+      could be ``ogr.wkbUnknown``). This is used by the DelineateIt UI.
+    * Rename finfish ARGS_SPEC ``module_name`` to ``model_name`` to be 
+      consistent with all other models.
     * Minor rephrasing of some ``ARGS_SPEC.args.arg.name`` values.
+    * Dynamically populated dropdown inputs' arg specs now have a ``type`` of
+      ``option_string`` and ``validation_options['options']`` is an empty list.
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,9 @@ workbench-alpha
       accepts a vector filepath and returns a boolean indicating whether the
       vector might have point geometries (can't be certain because the type could
       be ``ogr.wkbUnknown``). This is used by the DelineateIt UI.
+    * Rename finfish ARGS_SPEC ``module_name`` to ``model_name`` to be consistent
+      with all other models.
+    * Minor rephrasing of some ``ARGS_SPEC.args.arg.name`` values.
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,9 +38,13 @@ workbench-alpha
 * General:
     * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
       and server on the localhost, to support the workbench.
-    * Add ``/colnames`` endpoint to the server API. This endpoint accepts a
+    * Add ``/colnames`` POST endpoint to the server API. This endpoint accepts a
       vector filepath and returns a list of the vector's column names (used to
       determine options for a dropdown menu input).
+    * Add ``/vector_has_points`` POST endpoint to the server API. This endpoint
+      accepts a vector filepath and returns a boolean indicating whether the
+      vector might have point geometries (can't be certain because the type could
+      be ``ogr.wkbUnknown``). This is used by the DelineateIt UI.
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,7 +41,7 @@ workbench-alpha
     * Add ``/colnames`` POST endpoint to the server API. This endpoint accepts
       a vector filepath and returns a list of the vector's column names (used 
       to determine options for a dropdown menu input).
-    * Add ``/vector_has_points`` POST endpoint to the server API. This endpoint
+    * Add ``/vector_may_have_points`` POST endpoint to the server API. This endpoint
       accepts a vector filepath and returns a boolean indicating whether the
       vector might have point geometries (can't be certain because the type 
       could be ``ogr.wkbUnknown``). This is used by the DelineateIt UI.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,9 @@ workbench-alpha
 * General:
     * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
       and server on the localhost, to support the workbench.
+    * Add ``/colnames`` endpoint to the server API. This endpoint accepts a
+      vector filepath and returns a list of the vector's column names (used to
+      determine options for a dropdown menu input).
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -195,12 +195,15 @@ ARGS_SPEC = {
             "name": "Sea Level Rise Vector"
         },
         "slr_field": {
-            "type": "freestyle_string",
+            "type": "option_string",
             "required": "slr_vector_path",
             "about": (
                 "The name of a field in the SLR vector table from which to "
                 "load values"),
-            "name": "Sea Level Rise field name"
+            "name": "Sea Level Rise field name",
+            "validation_options": {
+                "options": []
+            }
         }
     }
 }

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -316,34 +316,7 @@ def execute(args):
 
     graph.close()
     graph.join()
-
-
-def _vector_may_contain_points(vector_path, layer_id=0):
-    """Test if a vector layer may contain points.
-
-    This function is intended to be used by the InVEST UI only.
-
-    Args:
-        vector_path (string): The path to a vector on disk.
-        layer_id=0 (int or string): The ID or name of the layer to check.
-
-    Returns:
-        A ``bool`` indicating whether a vector contains points.  ``False`` if
-        the vector cannot be opened at all or if the layer is invalid.
-
-    """
-    vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
-    if vector is None:
-        return False
-
-    layer = vector.GetLayer(layer_id)
-    if layer is None:
-        return False
-
-    if layer.GetGeomType() in (ogr.wkbPoint, ogr.wkbUnknown):
-        return True
-    return False
-
+    
 
 def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
     """Identify stream pixels based on a user-defined threshold.

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -316,7 +316,34 @@ def execute(args):
 
     graph.close()
     graph.join()
-    
+
+
+def _vector_may_contain_points(vector_path, layer_id=0):
+    """Test if a vector layer may contain points.
+
+    This function is intended to be used by the InVEST UI only.
+
+    Args:
+        vector_path (string): The path to a vector on disk.
+        layer_id=0 (int or string): The ID or name of the layer to check.
+
+    Returns:
+        A ``bool`` indicating whether a vector contains points.  ``False`` if
+        the vector cannot be opened at all or if the layer is invalid.
+
+    """
+    vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
+    if vector is None:
+        return False
+
+    layer = vector.GetLayer(layer_id)
+    if layer is None:
+        return False
+
+    if layer.GetGeomType() in (ogr.wkbPoint, ogr.wkbUnknown):
+        return True
+    return False
+
 
 def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
     """Identify stream pixels based on a user-defined threshold.

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -106,7 +106,7 @@ ARGS_SPEC = {
                 "in the outlet vector will not be included in the "
                 "delineation.  If ``False``, an invalid geometry "
                 "will cause DelineateIt to crash."),
-            "name": "Crash on invalid geometries"
+            "name": "Skip invalid geometries"
         }
     }
 }

--- a/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
+++ b/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
@@ -11,7 +11,7 @@ from .. import validation
 LOGGER = logging.getLogger(__name__)
 
 ARGS_SPEC = {
-    "module_name": "Finfish Aquaculture",
+    "model_name": "Finfish Aquaculture",
     "module": __name__,
     "userguide_html": "marine_fish.html",
     "args": {

--- a/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
+++ b/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
@@ -37,8 +37,11 @@ ARGS_SPEC = {
                 "tables). Additionally, the numbers underneath this "
                 "farm identifier name must be unique integers for all "
                 "the inputs."),
-            "type": "freestyle_string",
+            "type": "option_string",
             "required": True,
+            "validation_options": {
+                "options": []
+            }
         },
         "g_param_a": {
             "name": "Fish Growth Parameter (a)",

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -68,7 +68,7 @@ ARGS_SPEC = {
                 "must intersect the Digital Elevation Model (DEM)."),
         },
         "structure_path": {
-            "name": "Features Impacted Scenic Quality",
+            "name": "Features Impacting Scenic Quality",
             "type": "vector",
             "required": True,
             "about": (

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -199,7 +199,7 @@ ARGS_SPEC = {
                 "A path to a GDAL-compatible raster.  Pixels indicate the "
                 "amount of local recharge in mm.  Required if "
                 "args['user_defined_local_recharge'] is True."),
-            "name": "Local Recharge ("
+            "name": "Local Recharge (Advanced)"
         },
         "user_defined_climate_zones": {
             "type": "boolean",

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -118,19 +118,24 @@ def get_vector_colnames():
     payload = request.get_json()
     LOGGER.debug(payload)
     vector_path = payload['vector_path']
-    colnames = []  
     # a lot of times the path will be empty so don't even try to open it
     if vector_path:  
         try:
             vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
             colnames = [defn.GetName() for defn in vector.GetLayer().schema]
+            LOGGER.debug(colnames)
+            return json.dumps(colnames)
         except Exception as e:
             LOGGER.error(f'Could not read column names from {vector_path}. '
                          f'ERROR: {e}')
-    LOGGER.debug(colnames)
-    return json.dumps(colnames)
-
-
+    else:
+        LOGGER.error(f'Empty vector path.')
+    # 422 Unprocessable Entity: the server understands the content type
+    # of the request entity, and the syntax of the request entity is 
+    # correct, but it was unable to process the contained instructions. 
+    return json.dumps([]), 422
+    
+    
 @app.route('/vector_may_have_points', methods=['POST'])
 def get_vector_may_have_points():
     """Return boolean indicating if a vector may contain points.

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import importlib
 import json
 import logging
+from osgeo import gdal
 import pprint
 import textwrap
 
@@ -100,6 +101,24 @@ def get_invest_validate():
     results = model_module.validate(args_dict, limit_to=limit_to)
     LOGGER.debug(results)
     return json.dumps(results)
+
+
+@app.route('/colnames', methods=['POST'])
+def get_vector_colnames():
+    """Get a list of column names from a vector.
+
+    Body (JSON string):
+        vector_path (string): path to a vector file
+    Returns:
+        a JSON string.
+    """
+    payload = request.get_json()
+    LOGGER.debug(payload)
+    vector_path = payload['vector_path']
+    vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
+    colnames = [defn.GetName() for defn in vector.GetLayer().schema]
+    LOGGER.debug(colnames)
+    return json.dumps(colnames)
 
 
 @app.route('/post_datastack_file', methods=['POST'])

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -118,12 +118,14 @@ def get_vector_colnames():
     payload = request.get_json()
     LOGGER.debug(payload)
     vector_path = payload['vector_path']
-    try:
-        vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
-        colnames = [defn.GetName() for defn in vector.GetLayer().schema]
-    except:
-        LOGGER.error(f'Could not read column names from vector {vector_path}')
-        colnames = []
+    colnames = []  
+    # a lot of times the path will be empty so don't even try to open it
+    if vector_path:  
+        try:
+            vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
+            colnames = [defn.GetName() for defn in vector.GetLayer().schema]
+        except:
+            LOGGER.error(f'Could not read column names from {vector_path}')
     LOGGER.debug({'colnames': colnames})
     return json.dumps({'colnames': colnames})
 
@@ -143,11 +145,15 @@ def get_vector_has_points():
     payload = request.get_json()
     LOGGER.debug(payload)
     vector_path = payload['vector_path']
-    try:
-        has_points = delineateit._vector_may_contain_points(vector_path)
-    except:
-        LOGGER.error(f'Could not determine if vector {vector_path} contains points.')
-        has_points = True  # it may still contain points
+    # default True because it may have point geometries unless proven otherwise
+    has_points = True
+    # a lot of times the path will be empty so don't even try to open it
+    if vector_path:
+        try:
+            has_points = delineateit._vector_may_contain_points(vector_path)
+        except:
+            LOGGER.error(
+                f'Could not tell if vector {vector_path} contains points.')
     LOGGER.debug({'has_points': has_points})
     return json.dumps({'has_points': has_points})
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -109,6 +109,7 @@ def get_vector_colnames():
 
     Body (JSON string):
         vector_path (string): path to a vector file
+        
     Returns:
         a JSON string.
     """

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -126,8 +126,8 @@ def get_vector_colnames():
             colnames = [defn.GetName() for defn in vector.GetLayer().schema]
         except:
             LOGGER.error(f'Could not read column names from {vector_path}')
-    LOGGER.debug({'colnames': colnames})
-    return json.dumps({'colnames': colnames})
+    LOGGER.debug(colnames)
+    return json.dumps(colnames)
 
 
 @app.route('/vector_has_points', methods=['POST'])

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -126,7 +126,7 @@ def get_vector_colnames():
             colnames = [defn.GetName() for defn in vector.GetLayer().schema]
         except Exception as e:
             LOGGER.error(f'Could not read column names from {vector_path}. '
-                         f'ERROR: {e.message}')
+                         f'ERROR: {e}')
     LOGGER.debug(colnames)
     return json.dumps(colnames)
 
@@ -156,7 +156,7 @@ def get_vector_may_have_points():
         except:
             LOGGER.error(
                 f'Could not tell if vector {vector_path} may contain points. '
-                f'ERROR: {e.message}')
+                f'ERROR: {e}')
     LOGGER.debug({'may_have_points': may_have_points})
     return json.dumps({'may_have_points': may_have_points})
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -124,8 +124,9 @@ def get_vector_colnames():
         try:
             vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
             colnames = [defn.GetName() for defn in vector.GetLayer().schema]
-        except:
-            LOGGER.error(f'Could not read column names from {vector_path}')
+        except Exception as e:
+            LOGGER.error(f'Could not read column names from {vector_path}. '
+                         f'ERROR: {e.message}')
     LOGGER.debug(colnames)
     return json.dumps(colnames)
 
@@ -153,7 +154,8 @@ def get_vector_has_points():
             has_points = delineateit._vector_may_contain_points(vector_path)
         except:
             LOGGER.error(
-                f'Could not tell if vector {vector_path} contains points.')
+                f'Could not tell if vector {vector_path} contains points. '
+                f'ERROR: {e.message}')
     LOGGER.debug({'has_points': has_points})
     return json.dumps({'has_points': has_points})
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -126,7 +126,7 @@ def get_vector_colnames():
             LOGGER.debug(colnames)
             return json.dumps(colnames)
         except Exception as e:
-            LOGGER.error(f'Could not read column names from {vector_path}. '
+            LOGGER.exception(f'Could not read column names from {vector_path}. '
                          f'ERROR: {e}')
     else:
         LOGGER.error(f'Empty vector path.')
@@ -135,7 +135,7 @@ def get_vector_colnames():
     # correct, but it was unable to process the contained instructions. 
     return json.dumps([]), 422
     
-    
+
 @app.route('/vector_may_have_points', methods=['POST'])
 def get_vector_may_have_points():
     """Return boolean indicating if a vector may contain points.
@@ -159,7 +159,7 @@ def get_vector_may_have_points():
             may_have_points = delineateit._vector_may_contain_points(
                 vector_path)
         except Exception as e:
-            LOGGER.error(
+            LOGGER.exception(
                 f'Could not tell if vector {vector_path} may contain points. '
                 f'ERROR: {e}')
     LOGGER.debug({'may_have_points': may_have_points})

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -153,7 +153,7 @@ def get_vector_may_have_points():
         try:
             may_have_points = delineateit._vector_may_contain_points(
                 vector_path)
-        except:
+        except Exception as e:
             LOGGER.error(
                 f'Could not tell if vector {vector_path} may contain points. '
                 f'ERROR: {e}')

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -131,8 +131,8 @@ def get_vector_colnames():
     return json.dumps(colnames)
 
 
-@app.route('/vector_has_points', methods=['POST'])
-def get_vector_has_points():
+@app.route('/vector_may_have_points', methods=['POST'])
+def get_vector_may_have_points():
     """Return boolean indicating if a vector may contain points.
     This is used by the DelineateIt UI to determine if the 'snap points' 
     option should be enabled.
@@ -147,17 +147,18 @@ def get_vector_has_points():
     LOGGER.debug(payload)
     vector_path = payload['vector_path']
     # default True because it may have point geometries unless proven otherwise
-    has_points = True
+    may_have_points = True
     # a lot of times the path will be empty so don't even try to open it
     if vector_path:
         try:
-            has_points = delineateit._vector_may_contain_points(vector_path)
+            may_have_points = delineateit._vector_may_contain_points(
+                vector_path)
         except:
             LOGGER.error(
-                f'Could not tell if vector {vector_path} contains points. '
+                f'Could not tell if vector {vector_path} may contain points. '
                 f'ERROR: {e.message}')
-    LOGGER.debug({'has_points': has_points})
-    return json.dumps({'has_points': has_points})
+    LOGGER.debug({'may_have_points': may_have_points})
+    return json.dumps({'may_have_points': may_have_points})
 
 
 @app.route('/post_datastack_file', methods=['POST'])

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -103,7 +103,7 @@ ARGS_SPEC = {
             ),
         },
         "t_air_average_radius": {
-            "name": "T_air moving average radius (m)",
+            "name": "Air Temperature Maximum Blending Distance (m)",
             "type": "number",
             "required": True,
             "validation_options": {

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -435,7 +435,9 @@ def check_option_string(value, options):
         otherwise.
 
     """
-    if value not in options:
+    # if options is an empty list, that means it's dynamically populated
+    # so no need to validate
+    if options and value not in options:
         return "Value must be one of: %s" % sorted(options)
 
 

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -203,44 +203,6 @@ class DelineateItTests(unittest.TestCase):
             self.assertTrue(shapely_feature.equals(expected_geom))
             self.assertEqual(expected_fields, feature.items())
 
-    def test_vector_may_contain_points(self):
-        """DelineateIt: Check whether a layer contains points."""
-        from natcap.invest.delineateit import delineateit
-
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
-
-        # Verify invalid filepath returns False.
-        invalid_filepath = os.path.join(self.workspace_dir, 'nope.foo')
-        self.assertFalse(
-            delineateit._vector_may_contain_points(invalid_filepath))
-
-        # Verify invalid layer ID returns False
-        gpkg_driver = gdal.GetDriverByName('GPKG')
-        new_vector_path = os.path.join(self.workspace_dir, 'vector.gpkg')
-        new_vector = gpkg_driver.Create(
-            new_vector_path, 0, 0, 0, gdal.GDT_Unknown)
-        point_layer = new_vector.CreateLayer(
-            'point_layer', srs, ogr.wkbPoint)
-        polygon_layer = new_vector.CreateLayer(
-            'polygon_layer', srs, ogr.wkbPolygon)
-        unknown_layer = new_vector.CreateLayer(
-            'unknown_type_layer', srs, ogr.wkbUnknown)
-
-        unknown_layer = None
-        polygon_layer = None
-        point_layer = None
-        new_vector = None
-
-        self.assertTrue(delineateit._vector_may_contain_points(
-                        new_vector_path, 'point_layer'))
-        self.assertFalse(delineateit._vector_may_contain_points(
-                         new_vector_path, 'polygon_layer'))
-        self.assertTrue(delineateit._vector_may_contain_points(
-                        new_vector_path, 'unknown_type_layer'))
-        self.assertFalse(delineateit._vector_may_contain_points(
-                         new_vector_path, 'NOT A LAYER'))
-
     def test_check_geometries(self):
         """DelineateIt: Check that we can reasonably repair geometries."""
         from natcap.invest.delineateit import delineateit

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -203,6 +203,44 @@ class DelineateItTests(unittest.TestCase):
             self.assertTrue(shapely_feature.equals(expected_geom))
             self.assertEqual(expected_fields, feature.items())
 
+    def test_vector_may_contain_points(self):
+        """DelineateIt: Check whether a layer contains points."""
+        from natcap.invest.delineateit import delineateit
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
+
+        # Verify invalid filepath returns False.
+        invalid_filepath = os.path.join(self.workspace_dir, 'nope.foo')
+        self.assertFalse(
+            delineateit._vector_may_contain_points(invalid_filepath))
+
+        # Verify invalid layer ID returns False
+        gpkg_driver = gdal.GetDriverByName('GPKG')
+        new_vector_path = os.path.join(self.workspace_dir, 'vector.gpkg')
+        new_vector = gpkg_driver.Create(
+            new_vector_path, 0, 0, 0, gdal.GDT_Unknown)
+        point_layer = new_vector.CreateLayer(
+            'point_layer', srs, ogr.wkbPoint)
+        polygon_layer = new_vector.CreateLayer(
+            'polygon_layer', srs, ogr.wkbPolygon)
+        unknown_layer = new_vector.CreateLayer(
+            'unknown_type_layer', srs, ogr.wkbUnknown)
+
+        unknown_layer = None
+        polygon_layer = None
+        point_layer = None
+        new_vector = None
+
+        self.assertTrue(delineateit._vector_may_contain_points(
+                        new_vector_path, 'point_layer'))
+        self.assertFalse(delineateit._vector_may_contain_points(
+                         new_vector_path, 'polygon_layer'))
+        self.assertTrue(delineateit._vector_may_contain_points(
+                        new_vector_path, 'unknown_type_layer'))
+        self.assertFalse(delineateit._vector_may_contain_points(
+                         new_vector_path, 'NOT A LAYER'))
+
     def test_check_geometries(self):
         """DelineateIt: Check that we can reasonably repair geometries."""
         from natcap.invest.delineateit import delineateit

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -13,18 +13,18 @@ class EndpointFunctionTests(unittest.TestCase):
         test_client = ui_server.app.test_client()
         # an empty path
         response = test_client.post('/colnames', json={'vector_path': ''})
-        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        colnames = json.loads(response.get_data(as_text=True))
         self.assertEqual(colnames, [])
         # a vector with one column
         path = os.path.join(
             TEST_DATA_PATH, 'aquaculture', 'Input', 'Finfish_Netpens.shp')
         response = test_client.post('/colnames', json={'vector_path': path})
-        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        colnames = json.loads(response.get_data(as_text=True))
         self.assertEqual(colnames, ['FarmID'])
         # a non-vector file shouldn't raise an error
         path = os.path.join(TEST_DATA_PATH, 'ndr', 'input', 'dem.tif')
         response = test_client.post('/colnames', json={'vector_path': path})
-        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        colnames = json.loads(response.get_data(as_text=True))
         self.assertEqual(colnames, [])
 
     def test_get_vector_has_points(self):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -7,8 +7,14 @@ TEST_DATA_PATH = os.path.join(
 
 
 class EndpointFunctionTests(unittest.TestCase):
+    """Tests for some UI server endpoint functions.
+
+    Other endpoints have tests in the workbench repo. These ones need 
+    vector/raster test data so it makes more sense to have them here.
+    """
 
     def test_get_vector_colnames(self):
+        """UI server: getVectorColnames endpoint"""
         from natcap.invest import ui_server
         test_client = ui_server.app.test_client()
         # an empty path
@@ -28,6 +34,7 @@ class EndpointFunctionTests(unittest.TestCase):
         self.assertEqual(colnames, [])
 
     def test_get_vector_may_have_points(self):
+        """UI server: getVectorMayHavePoints endpoint"""
         from natcap.invest import ui_server
         test_client = ui_server.app.test_client()
         # an empty path

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -27,35 +27,39 @@ class EndpointFunctionTests(unittest.TestCase):
         colnames = json.loads(response.get_data(as_text=True))
         self.assertEqual(colnames, [])
 
-    def test_get_vector_has_points(self):
+    def test_get_vector_may_have_points(self):
         from natcap.invest import ui_server
         test_client = ui_server.app.test_client()
         # an empty path
         response = test_client.post(
-            '/vector_has_points', 
+            '/vector_may_have_points', 
             json={'vector_path': ''})
-        has_points = json.loads(response.get_data(as_text=True))['has_points']
-        self.assertEqual(has_points, True)
+        may_have_points = json.loads(
+            response.get_data(as_text=True))['may_have_points']
+        self.assertEqual(may_have_points, True)
         # a vector with no point geometries
         path = os.path.join(
             TEST_DATA_PATH, 'aquaculture', 'Input', 'Finfish_Netpens.shp')
         response = test_client.post(
-            '/vector_has_points', 
+            '/vector_may_have_points', 
             json={'vector_path': path})
-        has_points = json.loads(response.get_data(as_text=True))['has_points']
-        self.assertEqual(has_points, False)
+        may_have_points = json.loads(
+            response.get_data(as_text=True))['may_have_points']
+        self.assertEqual(may_have_points, False)
         # a vector with point geometries
         path = os.path.join(
             TEST_DATA_PATH, 'delineateit', 'input', 'outlets.shp')
         response = test_client.post(
-            '/vector_has_points', 
+            '/vector_may_have_points', 
             json={'vector_path': path})
-        has_points = json.loads(response.get_data(as_text=True))['has_points']
-        self.assertEqual(has_points, True)
+        may_have_points = json.loads(
+            response.get_data(as_text=True))['may_have_points']
+        self.assertEqual(may_have_points, True)
         # a non-vector file
         path = os.path.join(TEST_DATA_PATH, 'ndr', 'input', 'dem.tif')
         response = test_client.post(
-            '/vector_has_points', 
+            '/vector_may_have_points', 
             json={'vector_path': path})
-        has_points = json.loads(response.get_data(as_text=True))['has_points']
-        self.assertEqual(has_points, False)
+        may_have_points = json.loads(
+            response.get_data(as_text=True))['may_have_points']
+        self.assertEqual(may_have_points, False)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,61 @@
+import os
+import json
+import unittest
+
+TEST_DATA_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'data', 'invest-test-data')
+
+
+class EndpointFunctionTests(unittest.TestCase):
+
+    def test_get_vector_colnames(self):
+        from natcap.invest import ui_server
+        test_client = ui_server.app.test_client()
+        # an empty path
+        response = test_client.post('/colnames', json={'vector_path': ''})
+        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        self.assertEqual(colnames, [])
+        # a vector with one column
+        path = os.path.join(
+            TEST_DATA_PATH, 'aquaculture', 'Input', 'Finfish_Netpens.shp')
+        response = test_client.post('/colnames', json={'vector_path': path})
+        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        self.assertEqual(colnames, ['FarmID'])
+        # a non-vector file shouldn't raise an error
+        path = os.path.join(TEST_DATA_PATH, 'ndr', 'input', 'dem.tif')
+        response = test_client.post('/colnames', json={'vector_path': path})
+        colnames = json.loads(response.get_data(as_text=True))['colnames']
+        self.assertEqual(colnames, [])
+
+    def test_get_vector_has_points(self):
+        from natcap.invest import ui_server
+        test_client = ui_server.app.test_client()
+        # an empty path
+        response = test_client.post(
+            '/vector_has_points', 
+            json={'vector_path': ''})
+        has_points = json.loads(response.get_data(as_text=True))['has_points']
+        self.assertEqual(has_points, True)
+        # a vector with no point geometries
+        path = os.path.join(
+            TEST_DATA_PATH, 'aquaculture', 'Input', 'Finfish_Netpens.shp')
+        response = test_client.post(
+            '/vector_has_points', 
+            json={'vector_path': path})
+        has_points = json.loads(response.get_data(as_text=True))['has_points']
+        self.assertEqual(has_points, False)
+        # a vector with point geometries
+        path = os.path.join(
+            TEST_DATA_PATH, 'delineateit', 'input', 'outlets.shp')
+        response = test_client.post(
+            '/vector_has_points', 
+            json={'vector_path': path})
+        has_points = json.loads(response.get_data(as_text=True))['has_points']
+        self.assertEqual(has_points, True)
+        # a non-vector file
+        path = os.path.join(TEST_DATA_PATH, 'ndr', 'input', 'dem.tif')
+        response = test_client.post(
+            '/vector_has_points', 
+            json={'vector_path': path})
+        has_points = json.loads(response.get_data(as_text=True))['has_points']
+        self.assertEqual(has_points, False)

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -20,6 +20,7 @@ class EndpointFunctionTests(unittest.TestCase):
         # an empty path
         response = test_client.post('/colnames', json={'vector_path': ''})
         colnames = json.loads(response.get_data(as_text=True))
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(colnames, [])
         # a vector with one column
         path = os.path.join(
@@ -27,10 +28,11 @@ class EndpointFunctionTests(unittest.TestCase):
         response = test_client.post('/colnames', json={'vector_path': path})
         colnames = json.loads(response.get_data(as_text=True))
         self.assertEqual(colnames, ['FarmID'])
-        # a non-vector file shouldn't raise an error
+        # a non-vector file
         path = os.path.join(TEST_DATA_PATH, 'ndr', 'input', 'dem.tif')
         response = test_client.post('/colnames', json={'vector_path': path})
         colnames = json.loads(response.get_data(as_text=True))
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(colnames, [])
 
     def test_get_vector_may_have_points(self):
@@ -43,7 +45,8 @@ class EndpointFunctionTests(unittest.TestCase):
             json={'vector_path': ''})
         may_have_points = json.loads(
             response.get_data(as_text=True))['may_have_points']
-        self.assertEqual(may_have_points, True)
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(may_have_points, False)
         # a vector with no point geometries
         path = os.path.join(
             TEST_DATA_PATH, 'aquaculture', 'Input', 'Finfish_Netpens.shp')
@@ -69,4 +72,5 @@ class EndpointFunctionTests(unittest.TestCase):
             json={'vector_path': path})
         may_have_points = json.loads(
             response.get_data(as_text=True))['may_have_points']
+        self.assertEqual(response.status_code, 422)
         self.assertEqual(may_have_points, False)


### PR DESCRIPTION
Goes with https://github.com/natcap/invest-workbench/pull/84.
* Adding an endpoint that accepts a vector filepath, opens the vector, and returns a list of its column names. A couple of models use this to fill in a dropdown menu input's list of options.
* Add an endpoint that calls `delineateit._vector_may_contain_points`. This is used in the DelineateIt UI to determine if the 'snap points' option should be enabled.
* Fix a couple of args spec properties

I just realized that using a filepath could be problematic in the future. If we tried to `invest serve` on a remote server or in a docker container it wouldn't have access to the file. Maybe we should look into doing small geospatial functions like these on the javascript side.