### PR TITLE
Bugfix/384 dev build hangs on big sur

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,12 @@ Unreleased Changes (3.9.1)
     * Restructured API reference docs and removed outdated and redundant pages.
     * Include logger name in the logging format. This is helpful for the cython
       modules, which can't log module, function, or line number info.
+    * Fixed an issue with the InVEST application launching on Mac OS X 11
+      "Big Sur".  When launching the InVEST ``.app`` bundle, the environment
+      variable ``QT_MAC_WANTS_LAYER`` is defined.  If running InVEST through
+      python, this environment variable may need to be defined by hand like
+      so: ``QT_MAC_WANTS_LAYER=1 python -m natcap.invest``.  A warning will
+      be raised if this environment variable is not present on mac.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.
@@ -52,7 +58,7 @@ Unreleased Changes (3.9.1)
     * Making InVEST compatible with Pygeoprocessing 2.0 by updating:
         * ``convolve_2d()`` keyword ``ignore_nodata`` to
           ``ignore_nodata_and_edges``.
-        * ``get_raster_info()`` / ``get_vector_info()`` keyword ``projection`` 
+        * ``get_raster_info()`` / ``get_vector_info()`` keyword ``projection``
           to ``projection_wkt``.
     * Improve consistency and context for error messages related to raster
       reclassification across models by using ``utils.reclassify_raster``.
@@ -124,7 +130,7 @@ Unreleased Changes (3.9.1)
     * Fixed a bug where the suffix input was not being used for output paths.
 * Forest Carbon Edge Effect
     * Fixed a broken link to the local User's Guide
-    * Fixed bug that was causing overflow errors to appear in the logs when 
+    * Fixed bug that was causing overflow errors to appear in the logs when
       running with the sample data.
     * Mask out nodata areas of the carbon map output. Now there should be no
       output data outside of the input LULC rasater area.
@@ -170,7 +176,7 @@ Unreleased Changes (3.9.1)
       separate UI options.
 * Urban Flood Risk
     * Changed output field names ``aff.bld`` and ``serv.blt`` to ``aff_bld``
-      and ``serv_blt`` respectively to fix an issue where ArcGIS would not 
+      and ``serv_blt`` respectively to fix an issue where ArcGIS would not
       display properly.
 
 3.8.9 (2020-09-15)

--- a/installer/darwin/build_app_bundle.sh
+++ b/installer/darwin/build_app_bundle.sh
@@ -47,6 +47,10 @@ sed -i '' "s|++VERSION++|${1}|g" "$new_plist_file"
 
 # This is the command that will launch the application.
 echo '#!/bin/bash' > $new_command_file
-echo '`dirname $0`/invest_dist/invest launch' >> $new_command_file
+echo '#' > $new_command_file
+echo '# the QT_MAC_WANTS_LAYER definition is supposed to have been set by the' > $new_command_file
+echo "# runtime hook, but doesn't seem to be working.  Setting it here allows the" > $new_command_file
+echo "# binary to run on OSX Big Sur." > $new_command_file
+echo 'QT_MAC_WANTS_LAYER=1 `dirname $0`/invest_dist/invest launch' >> $new_command_file
 chmod a+x $new_command_file
 

--- a/installer/darwin/build_app_bundle.sh
+++ b/installer/darwin/build_app_bundle.sh
@@ -47,10 +47,10 @@ sed -i '' "s|++VERSION++|${1}|g" "$new_plist_file"
 
 # This is the command that will launch the application.
 echo '#!/bin/bash' > $new_command_file
-echo '#' > $new_command_file
-echo '# the QT_MAC_WANTS_LAYER definition is supposed to have been set by the' > $new_command_file
-echo "# runtime hook, but doesn't seem to be working.  Setting it here allows the" > $new_command_file
-echo "# binary to run on OSX Big Sur." > $new_command_file
+echo '#' >> $new_command_file
+echo '# the QT_MAC_WANTS_LAYER definition is supposed to have been set by the' >> $new_command_file
+echo "# runtime hook, but doesn't seem to be working.  Setting it here allows the" >> $new_command_file
+echo "# binary to run on OSX Big Sur." >> $new_command_file
 echo 'QT_MAC_WANTS_LAYER=1 `dirname $0`/invest_dist/invest launch' >> $new_command_file
 chmod a+x $new_command_file
 

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -8,6 +8,9 @@ import collections
 import pprint
 import multiprocessing
 import json
+import warnings
+import platform
+import os
 
 try:
     from . import __version__
@@ -525,6 +528,16 @@ def main(user_args=None):
     # testing of the model interfaces.
     if (args.subcommand == 'run' and not args.headless or
             args.subcommand == 'quickrun'):
+
+        # Creating this warning for future us to alert us to potential issues
+        # if/when we forget to define QT_MAC_WANTS_LAYER at runtime.
+        if (platform.system() == "Darwin" and
+                "QT_MAC_WANTS_LAYER"  not in os.environ):
+            warnings.warn(
+                "Mac OS X Big Sur may require the 'QT_MAC_WANTS_LAYER' "
+                "environment variable to be defined in order to run.  If "
+                "the application hangs on startup, set 'QT_MAC_WANTS_LAYER=1' "
+                "in the shell running this CLI.", RuntimeWarning)
 
         from natcap.invest.ui import inputs
 


### PR DESCRIPTION
# Description

This PR (which is a follow-up to #392 ) fixes an issue with launching the InVEST application on Mac OS X Big Sur, which is a stopgap issue until the Qt folks can release an update for this (see link in https://github.com/natcap/invest/issues/384#issuecomment-729107894 for further discussion about Qt build requirements).  It turns out that simply defining the environment variable in the pyinstaller runtime hook wasn't enough, and the most effective workaround is to have the variable defined in the parent shell itself.

There are 2 different behaviors for this environment variable addressed here:

1. **If we're running `InVEST.app` binary bundle** - the environment variable is set in the init script that calls the pyinstaller binary itself.
2. **If we're running InVEST through python** - a `RuntimeWarning` is raised noting that this _might_ be an issue, and, if it is, how to define the variable.

I've tested this fix locally on my Big Sur install, seems to work OK.  The same fix has also worked for the ROOT binaries.

@emlys if you get a chance, could you try this out on your mac as well to make sure it works in High Sierra?  Thanks in advance! 

Fixes #384 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) _(not needed)_
