### PR TITLE
Bugfix for read_csv-related tests with non-UTF8 encodings

### DIFF
--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -582,13 +582,9 @@ def read_csv_to_dataframe(
     # allow encoding kwarg to override this if it's provided
     if not encoding and has_utf8_bom(path):
         encoding = 'utf-8-sig'
-    try:
-        dataframe = pandas.read_csv(
-            path, engine=engine, encoding=encoding, sep=sep, **kwargs)
-    except UnicodeDecodeError as error:
-        LOGGER.error(
-            f'{path} must be encoded as utf-8 or avoid non-ASCII characters')
-        raise error
+    dataframe = pandas.read_csv(path, engine=engine, encoding=encoding,
+                                sep=sep, **kwargs)
+
     # this won't work on integer types, which happens if you set header=None
     # however, there's little reason to use this function if there's no header
     dataframe.columns = dataframe.columns.str.strip()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -871,7 +871,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df['HEADER2'][1], 5)
 
     def test_non_utf8_encoding(self):
-        """utils: test non-ASCII chars with non-UTF8 encoding raises error"""
+        """utils: test that non-UTF8 encoding doesn't raise an error"""
         from natcap.invest import utils
 
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
@@ -885,12 +885,13 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 bar
                 """
             ).strip())
-        with self.assertRaises(UnicodeDecodeError) as cm:
-            # In pandas 1.2.0, there's a bug where sep=None combined
-            # with this UnicodeDecodeError leaves the file handle open,
-            # and our tearDown function errors. So setting sep=',' for now.
-            utils.read_csv_to_dataframe(csv_file, sep=',')
-        self.assertTrue("decode byte" in str(cm.exception))
+
+        df = utils.read_csv_to_dataframe(csv_file)
+        # the default engine='python' should replace the unknown characters
+        # different encodings of replacement character depending on the system
+        self.assertTrue(df['header'][0] in ['f\xce\xce', 
+            'f\N{REPLACEMENT CHARACTER}\N{REPLACEMENT CHARACTER}'])
+        self.assertEqual(df['header'][1], 'bar')
 
     def test_override_default_encoding(self):
         """utils: test that you can override the default encoding kwarg"""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -650,7 +650,7 @@ class CSVValidation(unittest.TestCase):
         self.assertTrue('missing from this table' in error_msg)
 
     def test_csv_not_utf_8(self):
-        """Validation: test non-UTF8 CSVs w/ non-ASCII chars return msg."""
+        """Validation: test that non-UTF8 CSVs can validate."""
         from natcap.invest import validation
 
         df = pandas.DataFrame([
@@ -664,8 +664,12 @@ class CSVValidation(unittest.TestCase):
         # https://en.wikipedia.org/wiki/ISO/IEC_8859-5
         df.to_csv(target_file, encoding='iso8859_5')
 
+        # Note that non-UTF8 encodings should pass this check, but aren't
+        # actually being read correctly. Characters outside the ASCII set may
+        # be replaced with a replacement character.
+        # UTF16, UTF32, etc. will still raise an error.
         error_msg = validation.check_csv(target_file)
-        self.assertTrue('File must be encoded as a UTF-8 CSV' in error_msg)
+        self.assertEqual(error_msg, None)
 
     def test_excel_missing_fieldnames(self):
         """Validation: test that we can check missing fieldnames in excel."""


### PR DESCRIPTION
This PR reverts some changes to `utils.read_csv_to_dataframe` and related tests. Those changes were made to accomodate a pandas change that turned out to be a regression.  So this PR makes invest compatible with the latest pandas bugfix release (1.2.1) where they continue to replace un-readable non-ASCII chars when reading a csv without a specified encoding.

Fixes #450 

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
