### PR TITLE
Bugfix/UI server 455 logging from flask

### DIFF
--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -6,17 +6,20 @@ import importlib
 import json
 import logging
 import pprint
+import sys
 import textwrap
 
 from flask import Flask
 from flask import request
-from flask.logging import default_handler
 import natcap.invest.cli
 import natcap.invest.datastack
+from natcap.invest.utils import LOG_FMT
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
-LOGGER.addHandler(default_handler)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(LOG_FMT)
+handler.setFormatter(formatter)
+LOGGER.addHandler(handler)
 
 app = Flask(__name__)
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -10,11 +10,13 @@ import textwrap
 
 from flask import Flask
 from flask import request
+from flask.logging import default_handler
 import natcap.invest.cli
 import natcap.invest.datastack
 
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(default_handler)
 
 app = Flask(__name__)
 


### PR DESCRIPTION
This PR sets up a sys.stdout StreamHandler for logging from the Flask app, roughly following the "Other Libraries" section of these docs https://flask.palletsprojects.com/en/1.1.x/logging/. 

Previously, using `logging.basicConfig` left some mysterious behavior where messages weren't showing up in stdout or stderr, but sometimes would appear there only when the program closed. 

Fixes #455 

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
