### PR TITLE
Task/458 renew code signing cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,7 @@ signcode:
 signcode_windows:
 	$(GSUTIL) cp 'gs://stanford_cert/$(P12_FILE)' '$(BUILD_DIR)/$(P12_FILE)'
 	powershell.exe "& '$(SIGNTOOL)' sign /f '$(BUILD_DIR)\$(P12_FILE)' /p '$(CERT_KEY_PASS)' '$(BIN_TO_SIGN)'"
+	powershell.exe "& '$(SIGNTOOL)' timestamp -t http://timestamp.sectigo.com '$(BIN_TO_SIGN)'"
 	-$(RM) $(BUILD_DIR)/$(P12_FILE)
 	@echo "Installer was signed with signtool"
 

--- a/Makefile
+++ b/Makefile
@@ -351,9 +351,9 @@ $(MAC_BINARIES_ZIP_FILE): $(DIST_DIR) $(MAC_APPLICATION_BUNDLE) $(USERGUIDE_TARG
 build/vcredist_x86.exe: | build
 	powershell.exe -Command "Start-BitsTransfer -Source https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe -Destination build\vcredist_x86.exe"
 
-CERT_FILE := StanfordUniversity.crt
-KEY_FILE := Stanford-natcap-code-signing-2019-03-07.key.pem
-P12_FILE := Stanford-natcap-code-signing-2019-03-07.p12
+CERT_FILE := codesigning-2021.crt
+KEY_FILE := Stanford-natcap-code-signing-cert-expires-2024-01-26.key.pem
+P12_FILE := Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
 KEYCHAIN_NAME := codesign_keychain
 codesign_mac:
 	# download the p12 certificate file from google cloud
@@ -371,7 +371,7 @@ codesign_mac:
 	# this is essential to avoid the UI password prompt
 	security set-key-partition-list -S apple-tool:,apple: -s -k '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
 	# sign the dmg using certificate that's looked up by unique identifier 'Stanford Univeristy'
-	codesign --verbose --sign 'Stanford University' $(MAC_DISK_IMAGE_FILE)
+	codesign --timestamp --verbose --sign 'Stanford University' $(MAC_DISK_IMAGE_FILE)
 	# relock the keychain (not sure if this is important?)
 	security lock-keychain '$(KEYCHAIN_NAME)'
 


### PR DESCRIPTION
# Description

This PR updates our code-signing certificate for mac and windows binaries, assuming the password has also been updated in your repo's secrets (which I have already done for `natcap/invest`.  Binaries created are now signed AND timestamped, which should help prevent a certificate revocation or expiration issue from affecting previously-signed binaries in the future.

Binaries have been re-signed and timestamped and uploaded to GCP and Github Releases for each release that had signed binaries.

I have verified that what's in `Makefile` completes as expected, with the signed binaries having the expected digital signature and timestamp, as demonstrated by [this build](https://github.com/phargogh/invest/runs/1795220689).  Here's the windows one:

![Screenshot 2021-01-29 161045](https://user-images.githubusercontent.com/4583897/106340094-8a772500-624d-11eb-828d-544fae8f638b.png)

And here's the mac signed output:

```
Executable=/Users/jdouglass/Downloads/InVEST_3.8.9.post1272+g45d6415a.dmg
Identifier=InVEST_3.8.9.post1272+g45d6415a
Format=disk image
CodeDirectory v=20100 size=304 flags=0x0(none) hashes=1+6 location=embedded
Signature size=9747
Authority=Stanford University
Authority=InCommon RSA Code Signing CA
Authority=USERTrust RSA Certification Authority
Timestamp=Jan 29, 2021 at 3:52:22 PM
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements count=1 size=108
```


Fixes #458 

# Checklist
- [x] ~~Updated HISTORY.rst (if these changes are user-facing)~~ Changes not user-facing

- [x] ~~Updated the user's guide (if needed)~~ No user's guide changes needed
