### PR TITLE
Bugfix/sdr 465 spatial overlap validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,6 +50,9 @@ Unreleased Changes (3.9.1)
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.
+* SDR
+    * Fixed a bug in validation that did not warn against different coordinate
+      systems (all SDR inputs must share a common coordinate system).
 
 3.9.0 (2020-12-11)
 ------------------

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -30,7 +30,7 @@ ARGS_SPEC = {
     "args_with_spatial_overlap": {
         "spatial_keys": ["dem_path", "erosivity_path", "erodibility_path",
                          "lulc_path", "drainage_path", "watersheds_path", ],
-        "different_projections_ok": True,
+        "different_projections_ok": False,
     },
     "args": {
         "workspace_dir": validation.WORKSPACE_SPEC,


### PR DESCRIPTION
This PR brings SDR validation in line with what the model's `execute` method expects and what the Users Guide describes. All inputs must share a common, projected, coordinate system.
Fixes #465 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
