### PR TITLE
Bugfix/431 mac launch failure space in filepath

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,6 +47,8 @@ Unreleased Changes (3.9.1)
       python, this environment variable may need to be defined by hand like
       so: ``QT_MAC_WANTS_LAYER=1 python -m natcap.invest``.  A warning will
       be raised if this environment variable is not present on mac.
+    * Fixing an issue on Mac OS X where saving the InVEST application to a
+      filepath containing spaces would prevent the application from launching.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/installer/darwin/build_app_bundle.sh
+++ b/installer/darwin/build_app_bundle.sh
@@ -51,6 +51,9 @@ echo '#' >> $new_command_file
 echo '# the QT_MAC_WANTS_LAYER definition is supposed to have been set by the' >> $new_command_file
 echo "# runtime hook, but doesn't seem to be working.  Setting it here allows the" >> $new_command_file
 echo "# binary to run on OSX Big Sur." >> $new_command_file
-echo 'QT_MAC_WANTS_LAYER=1 `dirname $0`/invest_dist/invest launch' >> $new_command_file
+echo "#" >> $new_command_file
+echo "# Taken from https://stackoverflow.com/a/246128/299084" >> $new_command_file
+echo 'DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"' >> $new_command_file
+echo 'QT_MAC_WANTS_LAYER=1 "$DIR/invest_dist/invest" launch' >> $new_command_file
 chmod a+x $new_command_file
 


### PR DESCRIPTION
# Description

This PR updates the method used to determine the directory of the InVEST application bundle in a way that is more tolerant to spaces.

I've tested that this works with a space in the filename (`InVEST 3.app`) on my mac.

Fixes #431 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- ~~[ ] Updated the user's guide (if needed)~~
