### PR TITLE
Adding missing line between RST code block definition and code. RE:#472.

### DIFF
--- a/doc/api-docs/scripting.rst
+++ b/doc/api-docs/scripting.rst
@@ -289,6 +289,7 @@ number are:
 Using the parameter study example, this might look like:
 
 .. code-block:: python
+
     if __name__ == '__main__':
        args['n_workers'] = 4  # Use 4 processes
 


### PR DESCRIPTION
# Description

This is a super trivial PR to correct an RST issue accidentally introduced in #467 .

Fixes #472 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing) (was updated in prior PR)

- ~~[ ] Updated the user's guide (if needed)~~
