### PR TITLE
Raise when AOI, Wind Data don't intersect

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -56,6 +56,8 @@ Unreleased Changes (3.9.1)
 * SDR
     * Fixed a bug in validation that did not warn against different coordinate
       systems (all SDR inputs must share a common coordinate system).
+* Wind Energy
+    * Raising ValueError when AOI does not intersect Wind Data points.
 
 3.9.0 (2020-12-11)
 ------------------

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -2405,6 +2405,11 @@ def _clip_vector_by_vector(
         base_layer_defn.GetName(), base_layer.GetSpatialRef(), base_geom_type)
     base_layer.Clip(clip_layer, target_layer)
 
+    empty_clip = False
+    if target_layer.GetFeatureCount() <= 0:
+        empty_clip = True
+
+    # Allow function to clean up resources
     target_layer = None
     target_vector = None
     clip_vector = None
@@ -2414,6 +2419,12 @@ def _clip_vector_by_vector(
 
     if base_sr_wkt != target_sr_wkt:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+    if empty_clip:
+        raise ValueError(
+            f"Clipping {base_vector_path} by {clip_vector_path} returned 0"
+            " features. If an AOI was provided this could mean the AOI and"
+            " Wind Data do not intersect spatially.")
 
     LOGGER.info('Finished _clip_vector_by_vector')
 

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -2406,6 +2406,9 @@ def _clip_vector_by_vector(
     base_layer.Clip(clip_layer, target_layer)
 
     empty_clip = False
+    # Check if the feature count is less than 1, indicating the two vectors
+    # did not intersect. This will raise a ValueError below. GetFeatureCount
+    # can return -1 if the count is not known or too expensive to compute.
     if target_layer.GetFeatureCount() <= 0:
         empty_clip = True
 

--- a/tests/test_wind_energy.py
+++ b/tests/test_wind_energy.py
@@ -734,6 +734,32 @@ class WindEnergyRegressionTests(unittest.TestCase):
 
         self.assertRaises(ValueError, wind_energy.execute, args)
 
+    def test_clip_vector_value_error(self):
+        """WindEnergy: Test AOI doesn't intersect Wind Data points."""
+        from natcap.invest import wind_energy
+        from natcap.invest.utils import _assert_vectors_equal
+
+        args = WindEnergyRegressionTests.generate_base_args(self.workspace_dir)
+        args['aoi_vector_path'] = os.path.join(
+            SAMPLE_DATA, 'New_England_US_Aoi.shp')
+
+        # Make up some Wind Data points that live outside AOI
+        wind_data_csv = os.path.join(args['workspace_dir'], 'temp-wind-data.csv')
+        with open(wind_data_csv, 'w') as open_table:
+            open_table.write('LONG,LATI,LAM,K,REF\n')
+            open_table.write('-60.5,25.0,7.59,2.6,10\n')
+            open_table.write('-59.5,24.0,7.59,2.6,10\n')
+            open_table.write('-58.5,24.5,7.59,2.6,10\n')
+            open_table.write('-58.95,24.95,7.59,2.6,10\n')
+            open_table.write('-57.95,24.95,7.59,2.6,10\n')
+            open_table.write('-57.95,25.95,7.59,2.6,10\n')
+
+        args['wind_data_path'] = wind_data_csv
+
+        # AOI and wind data should not overlap, leading to a ValueError in 
+        # clip_vector_by_vector
+        self.assertRaises(ValueError, wind_energy.execute, args)
+
 
 class WindEnergyValidationTests(unittest.TestCase):
     """Tests for the Wind Energy Model ARGS_SPEC and validation."""

--- a/tests/test_wind_energy.py
+++ b/tests/test_wind_energy.py
@@ -758,7 +758,11 @@ class WindEnergyRegressionTests(unittest.TestCase):
 
         # AOI and wind data should not overlap, leading to a ValueError in 
         # clip_vector_by_vector
-        self.assertRaises(ValueError, wind_energy.execute, args)
+        with self.assertRaises(ValueError) as cm:
+            wind_energy.execute(args)
+
+        self.assertTrue(
+            "returned 0 features. If an AOI was" in str(cm.exception))
 
 
 class WindEnergyValidationTests(unittest.TestCase):


### PR DESCRIPTION
# Description
Wind Energy would crash when the AOI and Wind Data did not intersect. Because of how Wind Energy is structured I decided to raise a `ValueError ` in `clip_vector_by_vector` when the `target_layer` feature count was 0. 

Added a test with Wind Data points outside the AOI to make sure a `ValueError` is raised.

Fixes #13 

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
