### PR TITLE
Create upper bound for geos and bump PROJ

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,10 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.1.2
+GDAL>=3.2.1
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 geos<3.9.0
-proj>=7.2.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ GDAL>=3.1.2
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 geos<3.9.0
+proj>=7.2.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@
 GDAL>=3.1.2
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
+geos<3.9.0
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -685,6 +685,7 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
 
     LOGGER.info("indexing geometry of landmass and creating shore points")
 
+    print("aoi geom: ", aoi_shapely)
     for landmass_polygon in landmass_shapely:
 
         lines_in_aoi_list = []
@@ -699,9 +700,11 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
 
             # Already clipped landlines to AOI plus max-fetch extent
             # still want to clip lines by actual AOI for shore point creation
+            print("landmass_line: ", landmass_line)
             if aoi_shapely_prepped.intersects(landmass_line):
                 intersected_shapely_geom = aoi_shapely.intersection(
                     landmass_line)
+                print("intersected geom: ", intersected_shapely_geom)
                 if intersected_shapely_geom.type == 'LineString':
                     lines_in_aoi_list.append(intersected_shapely_geom)
                 elif intersected_shapely_geom.type == 'MultiLineString':

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -685,7 +685,6 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
 
     LOGGER.info("indexing geometry of landmass and creating shore points")
 
-    print("aoi geom: ", aoi_shapely)
     for landmass_polygon in landmass_shapely:
 
         lines_in_aoi_list = []
@@ -700,11 +699,9 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
 
             # Already clipped landlines to AOI plus max-fetch extent
             # still want to clip lines by actual AOI for shore point creation
-            print("landmass_line: ", landmass_line)
             if aoi_shapely_prepped.intersects(landmass_line):
                 intersected_shapely_geom = aoi_shapely.intersection(
                     landmass_line)
-                print("intersected geom: ", intersected_shapely_geom)
                 if intersected_shapely_geom.type == 'LineString':
                     lines_in_aoi_list.append(intersected_shapely_geom)
                 elif intersected_shapely_geom.type == 'MultiLineString':

--- a/tests/test_wave_energy.py
+++ b/tests/test_wave_energy.py
@@ -112,7 +112,8 @@ class WaveEnergyUnitTests(unittest.TestCase):
         result = wave_energy._pixel_size_based_on_coordinate_transform(
             raster_path, coord_trans, point)
 
-        expected_res = (5553.933063, -1187.370813)
+        # Updated expected_res with PROJ 7.2.0
+        expected_res = (5553.93227018, -1187.3713182)
 
         # Compare
         for res, exp in zip(result, expected_res):


### PR DESCRIPTION
# Description
This PR attempts to hotfix some critical issues with dependencies that came up here: #476 . They relate to GEOS and PROJ libraries.

This PR  sets an upper bound `geos<3.9.0` to avoid a confirmed bug in GEOS https://github.com/libgeos/geos/issues/408 .

This PR also updates a Wave Energy test for PROJ 7.2.0 and sets a GDAL lower bound to `3.2.1` that will grab PROJ 7.2.0+. I believe this precision difference is due to improvements on PROJ handling coordindate transformations. 

*NOTE*: There are still conda builds of GDAL 3.2.1 that support PROJ < 7.2.0, but I think it'll grab the later version for us consistently. We just have no direct handle on PROJ without using conda.

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
