### PR TITLE
Consistent ARGS_SPEC name values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,6 +50,7 @@ workbench-alpha
     * Minor rephrasing of some ``ARGS_SPEC.args.arg.name`` values.
     * Dynamically populated dropdown inputs' arg specs now have a ``type`` of
       ``option_string`` and ``validation_options['options']`` is an empty list.
+    * Standardize formatting of `ARGS_SPEC` `name` values.
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,7 +50,7 @@ workbench-alpha
     * Minor rephrasing of some ``ARGS_SPEC.args.arg.name`` values.
     * Dynamically populated dropdown inputs' arg specs now have a ``type`` of
       ``option_string`` and ``validation_options['options']`` is an empty list.
-    * Standardize formatting of `ARGS_SPEC` `name` values.
+    * Standardize formatting of ``ARGS_SPEC`` ``name`` values.
 
 Unreleased Changes (3.9.1)
 --------------------------

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -141,7 +141,7 @@ ARGS_SPEC = {
             "about": (
                 "The discount rate in the price of carbon as a floating "
                 "point percent."),
-            "name": "market discount rate (r)"
+            "name": "market discount rate"
         },
         "rate_change": {
             "type": "number",
@@ -149,7 +149,7 @@ ARGS_SPEC = {
             "about": (
                 "The floating point percent increase of the price of "
                 "carbon per year."),
-            "name": "annual price increase (c)"
+            "name": "carbon price change"
         }
     }
 }

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -36,7 +36,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster representing the land-cover of the"
                 "current scenario."),
-            "name": "current " + utils.LULC_ARG_NAME
+            "name": "current LULC"
         },
         "calc_sequestration": {
             "type": "boolean",
@@ -59,7 +59,7 @@ ARGS_SPEC = {
                 "enabled, this should be the reference, or baseline, future "
                 "scenario against which to compare the REDD policy "
                 "scenario."),
-            "name": "future " + utils.LULC_ARG_NAME
+            "name": "future LULC"
         },
         "do_redd": {
             "type": "boolean",
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster representing the land-cover of "
                 "the REDD policy future scenario.  This scenario will be "
                 "compared to the baseline future scenario."),
-            "name": "REDD " + utils.LULC_ARG_NAME
+            "name": "REDD LULC"
         },
         "carbon_pools_path": {
             "validation_options": {
@@ -105,7 +105,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "calc_sequestration",
             "about": "The calendar year of the current scenario.",
-            "name": "current landcover year"
+            "name": "current LULC year"
         },
         "lulc_fut_year": {
             "validation_options": {
@@ -114,7 +114,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "calc_sequestration",
             "about": "The calendar year of the future scenario.",
-            "name": "future landcover year"
+            "name": "future LULC year"
         },
         "do_valuation": {
             "type": "boolean",

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -36,7 +36,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster representing the land-cover of the"
                 "current scenario."),
-            "name": "current landcover"
+            "name": "current " + utils.LULC_ARG_NAME
         },
         "calc_sequestration": {
             "type": "boolean",
@@ -59,7 +59,7 @@ ARGS_SPEC = {
                 "enabled, this should be the reference, or baseline, future "
                 "scenario against which to compare the REDD policy "
                 "scenario."),
-            "name": "future landcover"
+            "name": "future " + utils.LULC_ARG_NAME
         },
         "do_redd": {
             "type": "boolean",
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster representing the land-cover of "
                 "the REDD policy future scenario.  This scenario will be "
                 "compared to the baseline future scenario."),
-            "name": "REDD policy)"
+            "name": "REDD " + utils.LULC_ARG_NAME
         },
         "carbon_pools_path": {
             "validation_options": {

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -36,7 +36,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster representing the land-cover of the"
                 "current scenario."),
-            "name": "Current Land Use/Land Cover"
+            "name": "current landcover"
         },
         "calc_sequestration": {
             "type": "boolean",
@@ -45,7 +45,7 @@ ARGS_SPEC = {
                 "Check to enable sequestration analysis. This requires "
                 "inputs of Land Use/Land Cover maps for both current and "
                 "future scenarios."),
-            "name": "Calculate Sequestration"
+            "name": "calculate sequestration"
         },
         "lulc_fut_path": {
             "type": "raster",
@@ -59,7 +59,7 @@ ARGS_SPEC = {
                 "enabled, this should be the reference, or baseline, future "
                 "scenario against which to compare the REDD policy "
                 "scenario."),
-            "name": "Future Landcover"
+            "name": "future landcover"
         },
         "do_redd": {
             "type": "boolean",
@@ -69,7 +69,7 @@ ARGS_SPEC = {
                 "three Land Use/Land Cover maps: one for the current "
                 "scenario, one for the future baseline scenario, and one for "
                 "the future REDD policy scenario."),
-            "name": "REDD Scenario Analysis"
+            "name": "REDD scenario analysis"
         },
         "lulc_redd_path": {
             "type": "raster",
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster representing the land-cover of "
                 "the REDD policy future scenario.  This scenario will be "
                 "compared to the baseline future scenario."),
-            "name": "REDD Policy)"
+            "name": "REDD policy)"
         },
         "carbon_pools_path": {
             "validation_options": {
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "'C_Below', 'C_Soil', 'C_Dead' as described in the User's "
                 "Guide.  The values in LULC must at least include the LULC "
                 "IDs in the land cover maps."),
-            "name": "Carbon Pools"
+            "name": "carbon pools"
         },
         "lulc_cur_year": {
             "validation_options": {
@@ -105,7 +105,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "calc_sequestration",
             "about": "The calendar year of the current scenario.",
-            "name": "Current Landcover Calendar Year"
+            "name": "current landcover year"
         },
         "lulc_fut_year": {
             "validation_options": {
@@ -114,7 +114,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "calc_sequestration",
             "about": "The calendar year of the future scenario.",
-            "name": "Future Landcover Calendar Year"
+            "name": "future landcover year"
         },
         "do_valuation": {
             "type": "boolean",
@@ -125,7 +125,7 @@ ARGS_SPEC = {
                 "with a future scenario is done and/or a REDD scenario "
                 "calculate NPV for either and report in final HTML "
                 "document."),
-            "name": "Run Valuation Model"
+            "name": "do valuation"
         },
         "price_per_metric_ton_of_c": {
             "type": "number",
@@ -138,8 +138,10 @@ ARGS_SPEC = {
         "discount_rate": {
             "type": "number",
             "required": "do_valuation",
-            "about": "The discount rate as a floating point percent.",
-            "name": "Market Discount in Price of Carbon (%)"
+            "about": (
+                "The discount rate in the price of carbon as a floating "
+                "point percent."),
+            "name": "market discount rate (r)"
         },
         "rate_change": {
             "type": "number",
@@ -147,7 +149,7 @@ ARGS_SPEC = {
             "about": (
                 "The floating point percent increase of the price of "
                 "carbon per year."),
-            "name": "Annual Rate of Change in Price of Carbon (%)"
+            "name": "annual price increase (c)"
         }
     }
 }

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -245,7 +245,8 @@ ARGS_SPEC = {
             "required": False,
             "about": (
                 "A boolean value indicating whether the model should run an "
-                "economic analysis."),
+                "economic analysis calculating the net present value of "
+                "sequestered carbon."),
         },
         "use_price_table": {
             "name": "use price table",

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -168,12 +168,12 @@ ARGS_SPEC = {
                 "Landcover codes match those in the biophysical table and in "
                 "the landcover transitions table."
             ),
-            "name": "Landcover Snapshots Table",
+            "name": "landcover snapshots table",
         },
         "analysis_year": {
             "type": "number",
             "required": False,
-            "name": "Analysis Year",
+            "name": "analysis year",
             "about": (
                 "An analysis year extends the transient analysis "
                 "beyond the transition years. If not provided, the "
@@ -181,7 +181,7 @@ ARGS_SPEC = {
             ),
         },
         "biophysical_table_path": {
-            "name": "Biophysical Table",
+            "name": "biophysical table",
             "type": "csv",
             "required": True,
             "validation_options": {
@@ -213,7 +213,7 @@ ARGS_SPEC = {
             ),
         },
         "landcover_transitions_table": {
-            "name": "Landcover Transitions Table",
+            "name": "landcover transitions table",
             "type": "csv",
             "validation_options": {
                 "required_fields": ['lulc-class'],
@@ -240,7 +240,7 @@ ARGS_SPEC = {
             ),
         },
         "do_economic_analysis": {
-            "name": "Calculate Net Present Value of Sequestered Carbon",
+            "name": "calculate net present value of sequestered carbon",
             "type": "boolean",
             "required": False,
             "about": (
@@ -248,7 +248,7 @@ ARGS_SPEC = {
                 "economic analysis."),
         },
         "use_price_table": {
-            "name": "Use Price Table",
+            "name": "use price table",
             "type": "boolean",
             "required": False,
             "about": (
@@ -257,13 +257,13 @@ ARGS_SPEC = {
                 "is provided and to be used instead."),
         },
         "price": {
-            "name": "Price",
+            "name": "price",
             "type": "number",
             "required": "do_economic_analysis and (not use_price_table)",
             "about": "The price per Megatonne CO2e at the base year.",
         },
         "inflation_rate": {
-            "name": "Interest Rate (%)",
+            "name": "interest rate (%)",
             "type": "number",
             "required": "do_economic_analysis and (not use_price_table)",
             "about": (
@@ -271,7 +271,7 @@ ARGS_SPEC = {
                 "5 would represent a 5% inflation rate."),
         },
         "price_table_path": {
-            "name": "Price Table",
+            "name": "price table",
             "type": "csv",
             "required": "use_price_table",
             "about": (
@@ -282,7 +282,7 @@ ARGS_SPEC = {
                 "year, if provided."),
         },
         "discount_rate": {
-            "name": "Discount Rate (%)",
+            "name": "discount rate (%)",
             "type": "number",
             "required": "do_economic_analysis",
             "about": (

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -168,7 +168,7 @@ ARGS_SPEC = {
                 "Landcover codes match those in the biophysical table and in "
                 "the landcover transitions table."
             ),
-            "name": "landcover snapshots table",
+            "name": "LULC snapshots table",
         },
         "analysis_year": {
             "type": "number",
@@ -213,7 +213,7 @@ ARGS_SPEC = {
             ),
         },
         "landcover_transitions_table": {
-            "name": "landcover transitions table",
+            "name": "LULC transitions table",
             "type": "csv",
             "validation_options": {
                 "required_fields": ['lulc-class'],

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -240,7 +240,7 @@ ARGS_SPEC = {
             ),
         },
         "do_economic_analysis": {
-            "name": "calculate net present value of sequestered carbon",
+            "name": "do valuation",
             "type": "boolean",
             "required": False,
             "about": (
@@ -263,7 +263,7 @@ ARGS_SPEC = {
             "about": "The price per Megatonne CO2e at the base year.",
         },
         "inflation_rate": {
-            "name": "interest rate (%)",
+            "name": "interest rate",
             "type": "number",
             "required": "do_economic_analysis and (not use_price_table)",
             "about": (
@@ -282,7 +282,7 @@ ARGS_SPEC = {
                 "year, if provided."),
         },
         "discount_rate": {
-            "name": "discount rate (%)",
+            "name": "discount rate",
             "type": "number",
             "required": "do_economic_analysis",
             "about": (

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
                 "Path to a polygon vector that is projected in a coordinate "
                 "system with units of meters. The polygon should intersect "
                 "the landmass and the shelf contour line"),
-            "name": "Area of Interest"
+            "name": "area of interest"
         },
         "model_resolution": {
             "validation_options": {
@@ -70,7 +70,7 @@ ARGS_SPEC = {
                 "Coastline features smaller than this distance will not be "
                 "represented by the shoreline points. Points will be spaced "
                 "at intervals of half the model resolution."),
-            "name": "Model resolution (meters)"
+            "name": "model resolution"
         },
         "landmass_vector_path": {
             "type": "vector",
@@ -78,7 +78,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a polygon vector representing landmasses in the "
                 "region of interest."),
-            "name": "Landmass vector"
+            "name": "landmasses"
         },
         "wwiii_vector_path": {
             "type": "vector",
@@ -86,7 +86,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a point vector containing wind and wave data. This "
                 "global dataset is provided with the InVEST sample data."),
-            "name": "WaveWatchIII vector"
+            "name": "WaveWatchIII dataset"
         },
         "max_fetch_distance": {
             "validation_options": {
@@ -99,7 +99,7 @@ ARGS_SPEC = {
                 "points. Points with rays equal to this distance accumulate "
                 "ocean-driven wave exposure along those rays and "
                 "local-wind-driven wave exposure along the shorter rays."),
-            "name": "Maximum Fetch Distance (meters)"
+            "name": "maximum fetch distance"
         },
         "bathymetry_raster_path": {
             "type": "raster",
@@ -109,7 +109,7 @@ ARGS_SPEC = {
                 "Bathymetry values should be negative and units of meters. "
                 "Positive values will be ignored. This should cover the area "
                 "extending beyond the AOI to the max_fetch_distance."),
-            "name": "Bathymetry raster"
+            "name": "bathymetry"
         },
         "shelf_contour_vector_path": {
             "type": "vector",
@@ -117,13 +117,13 @@ ARGS_SPEC = {
             "about": (
                 "Path to a polyline vector delineating the edge "
                 "of the continental shelf or another bathymetry contour."),
-            "name": "Continental Shelf Contour vector"
+            "name": "continental shelf contour"
         },
         "dem_path": {
             "type": "raster",
             "required": True,
             "about": "Path to a raster representing elevation on land. ",
-            "name": "Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "dem_averaging_radius": {
             "validation_options": {
@@ -132,9 +132,9 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": (
-                "A radius around each shore point within which to average "
-                "the elevation values of the DEM raster."),
-            "name": "Elevation averaging radius (meters)"
+                "A radius in meters around each shore point within which to "
+                "average the elevation values of the DEM raster."),
+            "name": "elevation averaging radius"
         },
         "habitat_table_path": {
             "validation_options": {
@@ -146,7 +146,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a CSV file that specifies habitat layer input data "
                 "and parameters."),
-            "name": "Habitats Table"
+            "name": "habitats table"
         },
         "geomorphology_vector_path": {
             "type": "vector",
@@ -154,7 +154,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a polyline vector that has a field called 'RANK' "
                 "with values from 1 to 5."),
-            "name": "Geomorphology vector"
+            "name": "geomorphology"
         },
         "geomorphology_fill_value": {
             "validation_options": {
@@ -166,14 +166,14 @@ ARGS_SPEC = {
                 "A value from 1 to 5 that will be used as a geomorphology "
                 "rank for any points not proximate (given the model "
                 "resolution) to the geomorphology_vector_path."),
-            "name": "Geomorphology fill value"
+            "name": "geomorphology fill value"
         },
         "population_raster_path": {
             "type": "raster",
             "required": False,
             "about": (
                 "Path to a raster with values representing totals per pixel."),
-            "name": "Human Population Raster"
+            "name": "human population"
         },
         "population_radius": {
             "validation_options": {
@@ -182,9 +182,9 @@ ARGS_SPEC = {
             "type": "number",
             "required": "population_raster_path",
             "about": (
-                "A radius around each shore point within which to compute "
-                "the average population density."),
-            "name": "Population search radius"
+                "A radius in meters around each shore point within which to "
+                "compute the average population density."),
+            "name": "population search radius"
         },
         "slr_vector_path": {
             "type": "vector",
@@ -192,7 +192,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a point vector with a field of sea-level-rise "
                 "rates or amounts."),
-            "name": "Sea Level Rise Vector"
+            "name": "sea level rise"
         },
         "slr_field": {
             "type": "freestyle_string",
@@ -200,7 +200,7 @@ ARGS_SPEC = {
             "about": (
                 "The name of a field in the SLR vector table from which to "
                 "load values"),
-            "name": "Sea Level Rise field name"
+            "name": "sea level rise field name"
         }
     }
 }

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -200,7 +200,7 @@ ARGS_SPEC = {
             "about": (
                 "The name of a field in the SLR vector table from which to "
                 "load values"),
-            "name": "sea level rise field name"
+            "name": "sea level rise field"
         }
     }
 }

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
                 "Path to a polygon vector that is projected in a coordinate "
                 "system with units of meters. The polygon should intersect "
                 "the landmass and the shelf contour line"),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "model_resolution": {
             "validation_options": {
@@ -123,7 +123,7 @@ ARGS_SPEC = {
             "type": "raster",
             "required": True,
             "about": "Path to a raster representing elevation on land. ",
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "dem_averaging_radius": {
             "validation_options": {

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -84,7 +84,7 @@ ARGS_SPEC = {
                 "tobacco, tomato, triticale, tropicalnes, tung, turnipfor, "
                 "vanilla, vegetablenes, vegfor, vetch, walnut, watermelon, "
                 "wheat, yam, and yautia."),
-            "name": "landcover to crop table"
+            "name": "LULC to crop table"
         },
         "aggregate_polygon_path": {
             "type": "vector",

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -44,7 +44,7 @@ ARGS_SPEC = {
                 "coordinate system with units of meters (e.g. UTM) because "
                 "pixel areas are divided by 10000 in order to report some "
                 "results in hectares."),
-            "name": "Land-Use/Land-Cover Map"
+            "name": "landcover"
         },
         "landcover_to_crop_table_path": {
             "validation_options": {
@@ -84,7 +84,7 @@ ARGS_SPEC = {
                 "tobacco, tomato, triticale, tropicalnes, tung, turnipfor, "
                 "vanilla, vegetablenes, vegfor, vetch, walnut, watermelon, "
                 "wheat, yam, and yautia."),
-            "name": "Landcover to Crop Table"
+            "name": "landcover to crop table"
         },
         "aggregate_polygon_path": {
             "type": "vector",
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "A polygon vector containing features with which to "
                 "aggregate/summarize final results. It is fine to have "
                 "overlapping polygons."),
-            "name": "Aggregate results polygon"
+            "name": "aggregate results polygon"
         },
         "model_data_path": {
             "type": "directory",
@@ -110,7 +110,7 @@ ARGS_SPEC = {
                 "selected, or can be manually downloaded from "
                 "http://releases.naturalcapitalproject.org/.  If downloaded "
                 "with InVEST, the default value should be used."),
-            "name": "Directory to model data"
+            "name": "model data"
         }
     }
 }

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -44,7 +44,7 @@ ARGS_SPEC = {
                 "coordinate system with units of meters (e.g. UTM) because "
                 "pixel areas are divided by 10000 in order to report some "
                 "results in hectares."),
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "landcover_to_crop_table_path": {
             "validation_options": {

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -40,7 +40,7 @@ ARGS_SPEC = {
                 "coordinate system with units of meters (e.g. UTM) because "
                 "pixel areas are divided by 10000 in order to report some "
                 "results in hectares."),
-            "name": "Land-Use/Land-Cover Map"
+            "name": "landcover"
         },
         "landcover_to_crop_table_path": {
             "validation_options": {
@@ -53,7 +53,7 @@ ARGS_SPEC = {
                 "contained in the landcover/use raster.   The allowed crop "
                 "names are barley, maize, oilpalm, potato, rice, soybean, "
                 "sugarbeet, sugarcane, sunflower, and wheat."),
-            "name": "Landcover to Crop Table"
+            "name": "landcover to crop table"
         },
         "fertilization_rate_table_path": {
             "validation_options": {
@@ -69,7 +69,7 @@ ARGS_SPEC = {
                 "simulation.  Must include the headers 'crop_name', "
                 "'nitrogen_rate',  'phosphorous_rate', and "
                 "'potassium_rate'."),
-            "name": "Fertilization Rate Table Path"
+            "name": "fertilization rate table"
         },
         "aggregate_polygon_path": {
             "type": "vector",
@@ -78,7 +78,7 @@ ARGS_SPEC = {
                 "A polygon vector containing features with which to "
                 "aggregate/summarize final results. It is fine to have "
                 "overlapping polygons."),
-            "name": "Aggregate results polygon"
+            "name": "aggregate results polygon"
         },
         "model_data_path": {
             "validation_options": {
@@ -93,7 +93,7 @@ ARGS_SPEC = {
                 "http://releases.naturalcapitalproject.org/invest. "
                 "If downloaded with InVEST, the default value should be "
                 "used."),
-            "name": "Directory to model data"
+            "name": "model data"
         }
     }
 }

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -40,7 +40,7 @@ ARGS_SPEC = {
                 "coordinate system with units of meters (e.g. UTM) because "
                 "pixel areas are divided by 10000 in order to report some "
                 "results in hectares."),
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "landcover_to_crop_table_path": {
             "validation_options": {

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -53,7 +53,7 @@ ARGS_SPEC = {
                 "contained in the landcover/use raster.   The allowed crop "
                 "names are barley, maize, oilpalm, potato, rice, soybean, "
                 "sugarbeet, sugarcane, sunflower, and wheat."),
-            "name": "landcover to crop table"
+            "name": "LULC to crop table"
         },
         "fertilization_rate_table_path": {
             "validation_options": {

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -43,7 +43,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file with an elevation value for "
                 "each cell."),
-            "name": "Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "detect_pour_points": {
             "type": "boolean",
@@ -51,7 +51,7 @@ ARGS_SPEC = {
             "about": (
                 "If ``True``, the pour point detection algorithm will run, "
                 "creating a point vector file pour_points.gpkg."),
-            "name": "Detect pour points"
+            "name": "detect pour points"
         },
         "outlet_vector_path": {
             "type": "vector",
@@ -59,7 +59,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a layer of geometries representing watershed "
                 "outlets such as municipal water intakes or lakes."),
-            "name": "Outlet Features"
+            "name": "outlet features"
         },
         "snap_points": {
             "type": "boolean",
@@ -68,7 +68,7 @@ ARGS_SPEC = {
                 "Whether to snap point geometries to the nearest stream "
                 "pixel.  If ``True``, ``args['flow_threshold']`` and "
                 "``args['snap_distance']`` must also be defined."),
-            "name": "Snap points to the nearest stream"
+            "name": "snap points to the nearest stream"
         },
         "flow_threshold": {
             "validation_options": {
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "before it's considered part of a stream such that retention "
                 "stops and the remaining export is exported to the stream.  "
                 "Used to define streams from the DEM."),
-            "name": "Threshold Flow Accumulation"
+            "name": "threshold flow accumulation"
         },
         "snap_distance": {
             "validation_options": {
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "center of the nearest stream pixel.  Geometries that are "
                 "not points (such as Lines and Polygons) will not be "
                 "snapped.  MultiPoint geoemtries will also not be snapped."),
-            "name": "Pixel Distance to Snap Outlet Points"
+            "name": "pixel distance to snap outlet points"
         },
         "skip_invalid_geometry": {
             "type": "boolean",
@@ -106,7 +106,7 @@ ARGS_SPEC = {
                 "in the outlet vector will not be included in the "
                 "delineation.  If ``False``, an invalid geometry "
                 "will cause DelineateIt to crash."),
-            "name": "Crash on invalid geometries"
+            "name": "crash on invalid geometries"
         }
     }
 }

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -43,7 +43,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file with an elevation value for "
                 "each cell."),
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "detect_pour_points": {
             "type": "boolean",

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -68,7 +68,7 @@ ARGS_SPEC = {
                 "Whether to snap point geometries to the nearest stream "
                 "pixel.  If ``True``, ``args['flow_threshold']`` and "
                 "``args['snap_distance']`` must also be defined."),
-            "name": "snap points to the nearest stream"
+            "name": "snap points to stream"
         },
         "flow_threshold": {
             "validation_options": {
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "center of the nearest stream pixel.  Geometries that are "
                 "not points (such as Lines and Polygons) will not be "
                 "snapped.  MultiPoint geoemtries will also not be snapped."),
-            "name": "pixel distance to snap outlet points"
+            "name": "snap distance"
         },
         "skip_invalid_geometry": {
             "type": "boolean",
@@ -106,7 +106,7 @@ ARGS_SPEC = {
                 "in the outlet vector will not be included in the "
                 "delineation.  If ``False``, an invalid geometry "
                 "will cause DelineateIt to crash."),
-            "name": "crash on invalid geometries"
+            "name": "skip invalid geometries"
         }
     }
 }

--- a/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
+++ b/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
@@ -41,9 +41,9 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_a": {
-            "name": "fish growth parameter (a)",
+            "name": "α growth parameter",
             "about": (
-                "Default a = (0.038 g/day). If the user chooses to "
+                "Default α = (0.038 g/day). If the user chooses to "
                 "adjust these parameters, we recommend using them in "
                 "the simple growth model to determine if the time "
                 "taken for a fish to reach a target harvest weight "
@@ -52,9 +52,9 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_b": {
-            "name": "fish growth parameter (b)",
+            "name": "β growth parameter",
             "about": (
-                "Default b = (0.6667 g/day). If the user chooses to "
+                "Default β = (0.6667 g/day). If the user chooses to "
                 "adjust these parameters, we recommend using them in "
                 "the simple growth model to determine if the time "
                 "taken for a fish to reach a target harvest weight "
@@ -63,9 +63,9 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_tau": {
-            "name": "fish growth parameter (tau)",
+            "name": "τ growth parameter",
             "about": (
-                "Default tau = (0.08 C^-1).  Specifies how sensitive "
+                "Default τ = (0.08 C^-1).  Specifies how sensitive "
                 "finfish growth is to temperature.  If the user "
                 "chooses to adjust these parameters, we recommend "
                 "using them in the simple growth model to determine if "
@@ -76,31 +76,31 @@ ARGS_SPEC = {
             "required": True,
         },
         "use_uncertainty": {
-            "name": "enable uncertainty analysis",
+            "name": "do uncertainty analysis",
             "about": "Enable uncertainty analysis.",
             "type": "boolean",
             "required": True,
         },
         "g_param_a_sd": {
-            "name": "standard deviation for parameter (a)",
+            "name": "α standard deviation",
             "about": (
-                "Standard deviation for fish growth parameter a. "
+                "Standard deviation for fish growth parameter α. "
                 "This indicates the level of uncertainty in the "
-                "estimate for parameter a."),
+                "estimate for parameter α."),
             "type": "number",
             "required": "use_uncertainty",
         },
         "g_param_b_sd": {
-            "name": "standard deviation for parameter (b)",
+            "name": "β standard deviation",
             "about": (
-                "Standard deviation for fish growth parameter b. "
+                "Standard deviation for fish growth parameter β. "
                 "This indicates the level of uncertainty in the "
-                "estimate for parameter b."),
+                "estimate for parameter β."),
             "type": "number",
             "required": "use_uncertainty",
         },
         "num_monte_carlo_runs": {
-            "name": "number of Monte Carlo simulation runs",
+            "name": "number of Monte Carlo runs",
             "about": (
                 "Number of runs of the model to perform as part of a "
                 "Monte Carlo simulation.  A larger number will tend to "
@@ -110,7 +110,7 @@ ARGS_SPEC = {
             "required": "use_uncertainty",
         },
         "water_temp_tbl": {
-            "name": "daily water temperature at farm",
+            "name": "daily water temperature",
             "type": "csv",
             "required": True,
             "about": (
@@ -157,21 +157,22 @@ ARGS_SPEC = {
                 "here."),
         },
         "do_valuation": {
-            "name": "run valuation model",
+            "name": "do valuation",
             "about": "Run valuation model",
             "type": "boolean",
             "required": True,
         },
         "p_per_kg": {
-            "name": "market price per kilogram of processed fish",
+            "name": "processed fish price",
             "about": (
-                "Default value comes from Urner-Berry monthly fresh "
-                "sheet reports on price of farmed Atlantic salmon."),
+                "Market price per kilogram of processed fish. Default "
+                "value comes from Urner-Berry monthly fresh sheet "
+                "reports on price of farmed Atlantic salmon."),
             "type": "number",
             "required": "do_valuation",
         },
         "frac_p": {
-            "name": "fraction of price that accounts for costs",
+            "name": "cost fraction",
             "about": (
                 "Fraction of market price that accounts for costs "
                 "rather than profit.  Default value is 0.3 (30%)."),

--- a/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
+++ b/src/natcap/invest/finfish_aquaculture/finfish_aquaculture.py
@@ -18,7 +18,7 @@ ARGS_SPEC = {
         "workspace_dir": validation.WORKSPACE_SPEC,
         "results_suffix": validation.SUFFIX_SPEC,
         "ff_farm_loc": {
-            "name": "Finfish Farm Location",
+            "name": "finfish farm location",
             "about": (
                 "A GDAL-supported vector file containing polygon or "
                 "point geometries, with a latitude and longitude value and a "
@@ -28,7 +28,7 @@ ARGS_SPEC = {
             "required": True,
         },
         "farm_ID": {
-            "name": "Farm Identifier Name",
+            "name": "farm identifier name",
             "about": (
                 "The name of a column heading used to identify each "
                 "farm and link the spatial information from the "
@@ -41,7 +41,7 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_a": {
-            "name": "Fish Growth Parameter (a)",
+            "name": "fish growth parameter (a)",
             "about": (
                 "Default a = (0.038 g/day). If the user chooses to "
                 "adjust these parameters, we recommend using them in "
@@ -52,7 +52,7 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_b": {
-            "name": "Fish Growth Parameter (b)",
+            "name": "fish growth parameter (b)",
             "about": (
                 "Default b = (0.6667 g/day). If the user chooses to "
                 "adjust these parameters, we recommend using them in "
@@ -63,7 +63,7 @@ ARGS_SPEC = {
             "required": True,
         },
         "g_param_tau": {
-            "name": "Fish Growth Parameter (tau)",
+            "name": "fish growth parameter (tau)",
             "about": (
                 "Default tau = (0.08 C^-1).  Specifies how sensitive "
                 "finfish growth is to temperature.  If the user "
@@ -76,13 +76,13 @@ ARGS_SPEC = {
             "required": True,
         },
         "use_uncertainty": {
-            "name": "Enable uncertainty analysis",
+            "name": "enable uncertainty analysis",
             "about": "Enable uncertainty analysis.",
             "type": "boolean",
             "required": True,
         },
         "g_param_a_sd": {
-            "name": "Standard Deviation for Parameter (a)",
+            "name": "standard deviation for parameter (a)",
             "about": (
                 "Standard deviation for fish growth parameter a. "
                 "This indicates the level of uncertainty in the "
@@ -91,7 +91,7 @@ ARGS_SPEC = {
             "required": "use_uncertainty",
         },
         "g_param_b_sd": {
-            "name": "Standard Deviation for Parameter (b)",
+            "name": "standard deviation for parameter (b)",
             "about": (
                 "Standard deviation for fish growth parameter b. "
                 "This indicates the level of uncertainty in the "
@@ -100,7 +100,7 @@ ARGS_SPEC = {
             "required": "use_uncertainty",
         },
         "num_monte_carlo_runs": {
-            "name": "Number of Monte Carlo Simulation Runs",
+            "name": "number of Monte Carlo simulation runs",
             "about": (
                 "Number of runs of the model to perform as part of a "
                 "Monte Carlo simulation.  A larger number will tend to "
@@ -110,7 +110,7 @@ ARGS_SPEC = {
             "required": "use_uncertainty",
         },
         "water_temp_tbl": {
-            "name": "Table of Daily Water Temperature at Farm",
+            "name": "daily water temperature at farm",
             "type": "csv",
             "required": True,
             "about": (
@@ -129,7 +129,7 @@ ARGS_SPEC = {
                 "the netpens."),
         },
         "farm_op_tbl": {
-            "name": "Farm Operations Table",
+            "name": "farm operations table",
             "type": "csv",
             "required": True,
             "about": (
@@ -148,7 +148,7 @@ ARGS_SPEC = {
                 "Columbia are also included in the sample data table."),
         },
         "outplant_buffer": {
-            "name": "Outplant Date Buffer",
+            "name": "outplant date buffer",
             "type": "number",
             "required": True,
             "about": (
@@ -157,13 +157,13 @@ ARGS_SPEC = {
                 "here."),
         },
         "do_valuation": {
-            "name": "Run valuation model",
+            "name": "run valuation model",
             "about": "Run valuation model",
             "type": "boolean",
             "required": True,
         },
         "p_per_kg": {
-            "name": "Market Price per Kilogram of Processed Fish",
+            "name": "market price per kilogram of processed fish",
             "about": (
                 "Default value comes from Urner-Berry monthly fresh "
                 "sheet reports on price of farmed Atlantic salmon."),
@@ -171,7 +171,7 @@ ARGS_SPEC = {
             "required": "do_valuation",
         },
         "frac_p": {
-            "name": "Fraction of Price that Accounts to Costs",
+            "name": "fraction of price that accounts for costs",
             "about": (
                 "Fraction of market price that accounts for costs "
                 "rather than profit.  Default value is 0.3 (30%)."),
@@ -182,7 +182,7 @@ ARGS_SPEC = {
             }
         },
         "discount": {
-            "name": "Daily Market Discount Rate",
+            "name": "daily market discount rate",
             "about": (
                 "We use a 7% annual discount rate, adjusted to a "
                 "daily rate of 0.000192 for 0.0192% (7%/365 days)."),

--- a/src/natcap/invest/fisheries/fisheries.py
+++ b/src/natcap/invest/fisheries/fisheries.py
@@ -44,7 +44,7 @@ ARGS_SPEC = {
             "about": (
                 "The number of time steps the simulation shall execute "
                 "before completion. Must be a positive integer."),
-            "name": "number of time steps for model run"
+            "name": "number of time steps"
         },
         "population_type": {
             "validation_options": {
@@ -77,7 +77,7 @@ ARGS_SPEC = {
                 "Specifies whether or not the lifecycle classes provided in "
                 "the Population Parameters CSV file are distinguished by "
                 "sex."),
-            "name": "population classes are sex-specific"
+            "name": "sex-specific classes"
         },
         "harvest_units": {
             "validation_options": {
@@ -92,7 +92,7 @@ ARGS_SPEC = {
                 "Parameters CSV file must include a 'Weight' vector "
                 "alongside the survival matrix that contains the weight of "
                 "each lifecycle class and sex if model is sex-specific."),
-            "name": "harvest by individuals or weight"
+            "name": "harvest value type"
         },
         "do_batch": {
             "type": "boolean",
@@ -257,7 +257,7 @@ ARGS_SPEC = {
             "about": (
                 "Decimal fraction indicating the percentage of harvested "
                 "catch remaining after post-harvest processing is complete."),
-            "name": "fraction of harvest kept after processing"
+            "name": "fraction of harvest kept"
         },
         "unit_price": {
             "type": "number",

--- a/src/natcap/invest/fisheries/fisheries.py
+++ b/src/natcap/invest/fisheries/fisheries.py
@@ -33,7 +33,7 @@ ARGS_SPEC = {
                 "which should have a 'NAME' attribute.  The 'NAME' "
                 "attribute can be numeric or alphabetic, but must be unique "
                 "within the given file."),
-            "name": "Area of Interest"
+            "name": "area of interest"
         },
         "total_timesteps": {
             "validation_options": {
@@ -44,7 +44,7 @@ ARGS_SPEC = {
             "about": (
                 "The number of time steps the simulation shall execute "
                 "before completion. Must be a positive integer."),
-            "name": "Number of Time Steps for Model Run"
+            "name": "number of time steps for model run"
         },
         "population_type": {
             "validation_options": {
@@ -65,7 +65,7 @@ ARGS_SPEC = {
                 "CSV file must include a 'Duration' vector "
                 "alongside the survival matrix that contains the number of "
                 "time steps that each stage lasts."),
-            "name": "Population Model Type"
+            "name": "population model type"
         },
         "sexsp": {
             "validation_options": {
@@ -77,7 +77,7 @@ ARGS_SPEC = {
                 "Specifies whether or not the lifecycle classes provided in "
                 "the Population Parameters CSV file are distinguished by "
                 "sex."),
-            "name": "Population Classes are Sex-Specific"
+            "name": "population classes are sex-specific"
         },
         "harvest_units": {
             "validation_options": {
@@ -92,7 +92,7 @@ ARGS_SPEC = {
                 "Parameters CSV file must include a 'Weight' vector "
                 "alongside the survival matrix that contains the weight of "
                 "each lifecycle class and sex if model is sex-specific."),
-            "name": "Harvest by Individuals or Weight"
+            "name": "harvest by individuals or weight"
         },
         "do_batch": {
             "type": "boolean",
@@ -104,7 +104,7 @@ ARGS_SPEC = {
                 "Population Parameters CSV file.  For batch model runs, "
                 "users submit a directory path pointing to a set of "
                 "Population Parameters CSV files."),
-            "name": "Batch Processing"
+            "name": "batch processing"
         },
         "population_csv_path": {
             "type": "csv",
@@ -116,7 +116,7 @@ ARGS_SPEC = {
                 "information. Please consult the documentation to learn "
                 "more about what content should be provided and how the "
                 "CSV file should be structured."),
-            "name": "Population Parameters File"
+            "name": "population parameters file"
         },
         "population_csv_dir": {
             "type": "directory",
@@ -133,7 +133,7 @@ ARGS_SPEC = {
                 "created by the model run. Please consult the "
                 "documentation to learn more about what content should be "
                 "provided and how the CSV file should be structured."),
-            "name": "Population Parameters CSV Folder"
+            "name": "population parameters directory"
         },
         "spawn_units": {
             "validation_options": {
@@ -151,7 +151,7 @@ ARGS_SPEC = {
                 "provided by the user should correspond to the selected "
                 "choice. Used only for the Beverton-Holt and Ricker "
                 "recruitment functions."),
-            "name": "Spawners by Individuals or Weight (Beverton-Holt / Ricker)"
+            "name": "spawners by individuals or weight (Beverton-Holt / Ricker)"
         },
         "total_init_recruits": {
             "validation_options": {
@@ -165,7 +165,7 @@ ARGS_SPEC = {
                 "regions of interest or is distinguished by sex, this value "
                 "will be evenly divided and distributed into each "
                 "sub-population."),
-            "name": "Total Initial Recruits"
+            "name": "total initial recruits"
         },
         "recruitment_type": {
             "validation_options": {
@@ -187,7 +187,7 @@ ARGS_SPEC = {
                 "represents a single total recruitment value to be "
                 "distributed into the population model at the beginning of "
                 "each time step."),
-            "name": "Recruitment Function Type"
+            "name": "recruitment function type"
         },
         "alpha": {
             "type": "number",
@@ -197,7 +197,7 @@ ARGS_SPEC = {
                 "for the Beverton-Holt and Ricker recruitment functions. "
                 "Used only for the Beverton-Holt and Ricker recruitment "
                 "functions."),
-            "name": "Alpha (Beverton-Holt / Ricker)"
+            "name": "alpha (Beverton-Holt / Ricker)"
         },
         "beta": {
             "type": "number",
@@ -205,7 +205,7 @@ ARGS_SPEC = {
             "about": (
                 "Specifies the shape of the stock-recruit curve. Used only "
                 "for the Beverton-Holt and Ricker recruitment functions."),
-            "name": "Beta (Beverton-Holt / Ricker)"
+            "name": "beta (Beverton-Holt / Ricker)"
         },
         "total_recur_recruits": {
             "type": "number",
@@ -214,13 +214,13 @@ ARGS_SPEC = {
                 "Specifies the total number of recruits that come into the "
                 "population at each time step (a fixed number). Used only "
                 "for the Fixed recruitment function."),
-            "name": "Total Recruits per Time Step (Fixed)"
+            "name": "total recruits per time step (fixed)"
         },
         "migr_cont": {
             "type": "boolean",
             "required": True,
             "about": "if True, model uses migration.",
-            "name": "Migration Parameters"
+            "name": "migration parameters"
         },
         "migration_dir": {
             "validation_options": {
@@ -242,13 +242,13 @@ ARGS_SPEC = {
                 "should contain a decimal fraction indicating the percentage "
                 "of the population that will move from one area to another. "
                 "Each column should sum to one."),
-            "name": "Migration Matrix CSV Folder (Optional)"
+            "name": "migration matrices"
         },
         "val_cont": {
             "type": "boolean",
             "required": True,
             "about": "if True, model computes valuation.",
-            "name": "Valuation Parameters"
+            "name": "valuation parameters"
         },
         "frac_post_process": {
             "validation_options": {},
@@ -257,7 +257,7 @@ ARGS_SPEC = {
             "about": (
                 "Decimal fraction indicating the percentage of harvested "
                 "catch remaining after post-harvest processing is complete."),
-            "name": "Fraction of Harvest Kept After Processing"
+            "name": "fraction of harvest kept after processing"
         },
         "unit_price": {
             "type": "number",
@@ -267,7 +267,7 @@ ARGS_SPEC = {
                 "Individuals or Weight' was set to 'Individuals', this should "
                 "be the price per individual. If set to 'Weight', this "
                 "should be the price per unit weight."),
-            "name": "Unit Price"
+            "name": "unit price"
         }
     }
 }

--- a/src/natcap/invest/fisheries/fisheries.py
+++ b/src/natcap/invest/fisheries/fisheries.py
@@ -33,7 +33,7 @@ ARGS_SPEC = {
                 "which should have a 'NAME' attribute.  The 'NAME' "
                 "attribute can be numeric or alphabetic, but must be unique "
                 "within the given file."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "total_timesteps": {
             "validation_options": {

--- a/src/natcap/invest/fisheries/fisheries_hst.py
+++ b/src/natcap/invest/fisheries/fisheries_hst.py
@@ -22,7 +22,7 @@ ARGS_SPEC = {
         "workspace_dir": validation.WORKSPACE_SPEC,
         "results_suffix": validation.SUFFIX_SPEC,
         "sexsp": {
-            "name": "Population Classes are Sex-Specific",
+            "name": "population classes are sex-specific",
             "type": "option_string",
             "required": True,
             "validation_options": {
@@ -34,7 +34,7 @@ ARGS_SPEC = {
                 "distinguished by sex."),
         },
         "population_csv_path": {
-            "name": "Population Parameters File",
+            "name": "population parameters",
             "type": "csv",
             "required": True,
             "about": (
@@ -47,7 +47,7 @@ ARGS_SPEC = {
                 "file."),
         },
         "habitat_dep_csv_path": {
-            "name": "Habitat Dependency Parameters File",
+            "name": "habitat dependency parameters",
             "type": "csv",
             "required": True,
             "about": (
@@ -59,7 +59,7 @@ ARGS_SPEC = {
                 "documentation for help on how to format this file."),
         },
         "habitat_chg_csv_path": {
-            "name": "Habitat Area Change File",
+            "name": "habitat area change",
             "type": "csv",
             "required": True,
             "about": (
@@ -72,7 +72,7 @@ ARGS_SPEC = {
                 "to format this file."),
         },
         "gamma": {
-            "name": "Gamma",
+            "name": "gamma",
             "type": "number",
             "required": True,
             "validation_options": {

--- a/src/natcap/invest/fisheries/fisheries_hst.py
+++ b/src/natcap/invest/fisheries/fisheries_hst.py
@@ -22,7 +22,7 @@ ARGS_SPEC = {
         "workspace_dir": validation.WORKSPACE_SPEC,
         "results_suffix": validation.SUFFIX_SPEC,
         "sexsp": {
-            "name": "population classes are sex-specific",
+            "name": "sex-specific classes",
             "type": "option_string",
             "required": True,
             "validation_options": {

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -90,7 +90,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code for "
                 "each cell."),
-            "name": "landcover map"
+            "name": utils.LULC_ARG_NAME
         },
         "pools_to_calculate": {
             "validation_options": {

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -51,7 +51,7 @@ ARGS_SPEC = {
                 "is linearly weighted by distance such that the biomass in "
                 "the pixel is a function of each of these points with the "
                 "closest point having the highest effect."),
-            "name": "Number of nearest model points to average"
+            "name": "number of points to average"
         },
         "aoi_vector_path": {
             "validation_options": {
@@ -62,7 +62,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a set of polygons that will be used to aggregate "
                 "carbon values at the end of the run if provided."),
-            "name": "Service areas of interest"
+            "name": "areas of interest"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -79,7 +79,7 @@ ARGS_SPEC = {
                 "table must also contain entries for 'c_below', 'c_soil', "
                 "and 'c_dead'.  See the InVEST Forest Carbon User's Guide "
                 "for more information about these fields."),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "lulc_raster_path": {
             "type": "raster",
@@ -90,7 +90,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code for "
                 "each cell."),
-            "name": "Land-Use/Land-Cover Map"
+            "name": "landcover map"
         },
         "pools_to_calculate": {
             "validation_options": {
@@ -103,7 +103,7 @@ ARGS_SPEC = {
                 "'c_above', 'c_below', 'c_dead', 'c_soil' are used in the "
                 "carbon pool calculation.  Otherwise only 'c_above' is "
                 "considered."),
-            "name": "Carbon Pools to Calculate"
+            "name": "carbon pools"
         },
         "compute_forest_edge_effects": {
             "type": "boolean",
@@ -113,7 +113,7 @@ ARGS_SPEC = {
                 "account for above ground carbon stocks in tropical forest "
                 "types indicated by a '1' in the 'is_tropical_forest' field "
                 "in the biophysical table."),
-            "name": "Compute forest edge effects"
+            "name": "compute forest edge effects"
         },
         "tropical_forest_edge_carbon_model_vector_path": {
             "validation_options": {
@@ -125,18 +125,19 @@ ARGS_SPEC = {
                 "A vector with fields 'method', 'theta1', 'theta2', "
                 "'theta3' describing the global forest carbon edge models.  "
                 "Provided as default data for the model."),
-            "name": "Global forest carbon edge regression models"
+            "name": "global regression models"
         },
         "biomass_to_carbon_conversion_factor": {
             "type": "number",
             "required": "compute_forest_edge_effects",
             "about": (
-                "Number by which to scale forest edge biomass to convert to "
+                "Forest edge biomass-to-carbon conversion factor: a number by "
+                "which to scale forest edge biomass to convert to "
                 "carbon.  Default value is 0.47 (according to IPCC 2006). "
                 "This pertains to forest classes only; values in the "
                 "biophysical table for non-forest classes should already be "
                 "in terms of carbon, not biomass."),
-            "name": "Forest Edge Biomass to Carbon Conversion Factor"
+            "name": "biomass-carbon conversion factor"
         }
     }
 }

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -50,7 +50,7 @@ ARGS_SPEC = {
             "about": (
                 'used in "mode (a)" path to a base landcover map with'
                 ' integer codes'),
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "lulc_to_globio_table_path": {
             "validation_options": {
@@ -149,7 +149,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a set of polygons that can be used to aggregate MSA "
                 "sum and mean to a polygon."),
-            "name": "area of interest",
+            "name": utils.AOI_ARG_NAME
         },
         "globio_lulc_path": {
             "validation_options": {

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -39,7 +39,7 @@ ARGS_SPEC = {
             "type": "boolean",
             "required": False,
             "about": 'if True then "mode (b)" else "mode (a)"',
-            "name": "use predefined landcover"
+            "name": "use predefined LULC"
         },
         "lulc_path": {
             "type": "raster",
@@ -64,7 +64,7 @@ ARGS_SPEC = {
                 "must contain the fields 'lucode', 'globio_lucode'.  "
                 "See the InVEST User's Guide for more information "
                 "about these fields."),
-            "name": "landcover to GLOBIO landcover table"
+            "name": "LULC to GLOBIO LULC table"
         },
         "infrastructure_dir": {
             "validation_options": {
@@ -158,7 +158,7 @@ ARGS_SPEC = {
             "type": "raster",
             "required": "predefined_globio",
             "about": 'used in "mode (b)" path to predefined globio raster.',
-            "name": "GLOBIO landcover"
+            "name": "GLOBIO LULC"
         }
     }
 }

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -39,7 +39,7 @@ ARGS_SPEC = {
             "type": "boolean",
             "required": False,
             "about": 'if True then "mode (b)" else "mode (a)"',
-            "name": "Predefined land use map for GLOBIO"
+            "name": "use predefined landcover"
         },
         "lulc_path": {
             "type": "raster",
@@ -50,7 +50,7 @@ ARGS_SPEC = {
             "about": (
                 'used in "mode (a)" path to a base landcover map with'
                 ' integer codes'),
-            "name": "Land Use/Cover (Raster)"
+            "name": "landcover"
         },
         "lulc_to_globio_table_path": {
             "validation_options": {
@@ -64,7 +64,7 @@ ARGS_SPEC = {
                 "must contain the fields 'lucode', 'globio_lucode'.  "
                 "See the InVEST User's Guide for more information "
                 "about these fields."),
-            "name": "Landcover to GLOBIO Landcover Table"
+            "name": "landcover to GLOBIO landcover table"
         },
         "infrastructure_dir": {
             "validation_options": {
@@ -77,7 +77,7 @@ ARGS_SPEC = {
                 'maps of either GDAL compatible rasters or vectors. '
                 'These data will be used in the infrastructure '
                 'to calculation of MSA.'),
-            "name": "Infrastructure Directory"
+            "name": "infrastructure"
         },
         "pasture_path": {
             "type": "raster",
@@ -86,7 +86,7 @@ ARGS_SPEC = {
             },
             "required": "not predefined_globio",
             "about": 'used in "mode (a)" path to pasture raster',
-            "name": "Pasture (Raster)"
+            "name": "pasture"
         },
         "potential_vegetation_path": {
             "type": "raster",
@@ -96,7 +96,7 @@ ARGS_SPEC = {
             "required": "not predefined_globio",
             "about": (
                 'used in "mode (a)" path to potential vegetation raster'),
-            "name": "Potential Vegetation (Raster)"
+            "name": "potential vegetation"
         },
         "pasture_threshold": {
             "validation_options": {
@@ -105,7 +105,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "not predefined_globio",
             "about": 'used in "mode (a)"',
-            "name": "Pasture Threshold"
+            "name": "pasture threshold"
         },
         "intensification_fraction": {
             "validation_options": {
@@ -116,7 +116,7 @@ ARGS_SPEC = {
             "about": (
                 "A value between 0 and 1 denoting proportion of total "
                 "agriculture that should be classified as 'high input'."),
-            "name": "Proportion of of Agriculture Intensified"
+            "name": "intensification fraction"
         },
         "primary_threshold": {
             "validation_options": {
@@ -125,7 +125,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": "not predefined_globio",
             "about": 'used in "mode (a)"',
-            "name": "Primary Threshold"
+            "name": "primary threshold"
         },
         "msa_parameters_path": {
             "validation_options": {
@@ -138,7 +138,7 @@ ARGS_SPEC = {
                 "A CSV table containing MSA threshold values as defined in "
                 "the user's guide.  Provided for advanced users that may "
                 "wish to change those values."),
-            "name": "MSA Parameter Table"
+            "name": "MSA parameter table"
         },
         "aoi_path": {
             "type": "vector",
@@ -149,7 +149,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a set of polygons that can be used to aggregate MSA "
                 "sum and mean to a polygon."),
-            "name": "AOI",
+            "name": "area of interest",
         },
         "globio_lulc_path": {
             "validation_options": {
@@ -158,7 +158,7 @@ ARGS_SPEC = {
             "type": "raster",
             "required": "predefined_globio",
             "about": 'used in "mode (b)" path to predefined globio raster.',
-            "name": "GLOBIO Classified Land Use"
+            "name": "GLOBIO landcover"
         }
     }
 }

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -42,7 +42,7 @@ ARGS_SPEC = {
                 "The dataset should be in a projection where the units are "
                 "in meters and the projection used should be defined.  The "
                 "LULC codes must match the codes in the Sensitivity table."),
-            "name": "current" + utils.LULC_ARG_NAME
+            "name": "current " + utils.LULC_ARG_NAME
         },
         "lulc_fut_path": {
             "type": "raster",
@@ -61,7 +61,7 @@ ARGS_SPEC = {
                 "units are in meters and the projection used should be "
                 "defined. The LULC codes must match the codes in the "
                 "Sensitivity table."),
-            "name": "future" + utils.LULC_ARG_NAME
+            "name": "future " + utils.LULC_ARG_NAME
         },
         "lulc_bas_path": {
             "type": "raster",
@@ -85,7 +85,7 @@ ARGS_SPEC = {
                 "codes must match the codes in the Sensitivity table.  If "
                 "possible the baseline map should refer to a time when "
                 "intensive management of the landscape was relatively rare."),
-            "name": "baseline" + utils.LULC_ARG_NAME
+            "name": "baseline " + utils.LULC_ARG_NAME
         },
         "threats_table_path": {
             "validation_options": {

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -42,7 +42,7 @@ ARGS_SPEC = {
                 "The dataset should be in a projection where the units are "
                 "in meters and the projection used should be defined.  The "
                 "LULC codes must match the codes in the Sensitivity table."),
-            "name": "current " + utils.LULC_ARG_NAME
+            "name": "current LULC"
         },
         "lulc_fut_path": {
             "type": "raster",
@@ -61,7 +61,7 @@ ARGS_SPEC = {
                 "units are in meters and the projection used should be "
                 "defined. The LULC codes must match the codes in the "
                 "Sensitivity table."),
-            "name": "future " + utils.LULC_ARG_NAME
+            "name": "future LULC"
         },
         "lulc_bas_path": {
             "type": "raster",
@@ -85,7 +85,7 @@ ARGS_SPEC = {
                 "codes must match the codes in the Sensitivity table.  If "
                 "possible the baseline map should refer to a time when "
                 "intensive management of the landscape was relatively rare."),
-            "name": "baseline " + utils.LULC_ARG_NAME
+            "name": "baseline LULC"
         },
         "threats_table_path": {
             "validation_options": {

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -171,7 +171,7 @@ ARGS_SPEC = {
                 "the sensitivity of a habitat to a threat."
                 "Please see the users guide for more detailed information on "
                 "proper column values and column names for each threat."),
-            "name": "landcover threat sensitivity"
+            "name": "LULC threat sensitivity"
         },
         "half_saturation_constant": {
             "validation_options": {

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -42,7 +42,7 @@ ARGS_SPEC = {
                 "The dataset should be in a projection where the units are "
                 "in meters and the projection used should be defined.  The "
                 "LULC codes must match the codes in the Sensitivity table."),
-            "name": "current landcover"
+            "name": "current" + utils.LULC_ARG_NAME
         },
         "lulc_fut_path": {
             "type": "raster",
@@ -61,7 +61,7 @@ ARGS_SPEC = {
                 "units are in meters and the projection used should be "
                 "defined. The LULC codes must match the codes in the "
                 "Sensitivity table."),
-            "name": "future landcover"
+            "name": "future" + utils.LULC_ARG_NAME
         },
         "lulc_bas_path": {
             "type": "raster",
@@ -85,7 +85,7 @@ ARGS_SPEC = {
                 "codes must match the codes in the Sensitivity table.  If "
                 "possible the baseline map should refer to a time when "
                 "intensive management of the landscape was relatively rare."),
-            "name": "baseline landcover"
+            "name": "baseline" + utils.LULC_ARG_NAME
         },
         "threats_table_path": {
             "validation_options": {

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -42,7 +42,7 @@ ARGS_SPEC = {
                 "The dataset should be in a projection where the units are "
                 "in meters and the projection used should be defined.  The "
                 "LULC codes must match the codes in the Sensitivity table."),
-            "name": "Current Land Cover"
+            "name": "current landcover"
         },
         "lulc_fut_path": {
             "type": "raster",
@@ -61,7 +61,7 @@ ARGS_SPEC = {
                 "units are in meters and the projection used should be "
                 "defined. The LULC codes must match the codes in the "
                 "Sensitivity table."),
-            "name": "Future Land Cover"
+            "name": "future landcover"
         },
         "lulc_bas_path": {
             "type": "raster",
@@ -85,7 +85,7 @@ ARGS_SPEC = {
                 "codes must match the codes in the Sensitivity table.  If "
                 "possible the baseline map should refer to a time when "
                 "intensive management of the landscape was relatively rare."),
-            "name": "Baseline Land Cover"
+            "name": "baseline landcover"
         },
         "threats_table_path": {
             "validation_options": {
@@ -128,7 +128,7 @@ ARGS_SPEC = {
                 "filepath is relative to the THREAT CSV input. Entries can "
                 "be left empty if looking at current scenario only."
                 ),
-            "name": "Threats Data"
+            "name": "threats data"
         },
         "access_vector_path": {
             "validation_options": {
@@ -145,7 +145,7 @@ ARGS_SPEC = {
                 "The ACCESS values should range from 0 - 1, where 1 "
                 "is fully accessible.  Any cells not covered by a polygon "
                 "will be set to 1."),
-            "name": "Accessibility to Threats (Vector) (Optional)"
+            "name": "accessibility to threats"
         },
         "sensitivity_table_path": {
             "validation_options": {
@@ -171,7 +171,7 @@ ARGS_SPEC = {
                 "the sensitivity of a habitat to a threat."
                 "Please see the users guide for more detailed information on "
                 "proper column values and column names for each threat."),
-            "name": "Sensitivity of Land Cover Types to Each Threat"
+            "name": "landcover threat sensitivity"
         },
         "half_saturation_constant": {
             "validation_options": {
@@ -189,7 +189,7 @@ ARGS_SPEC = {
                 "Note that the choice of k only determines the spread and "
                 "central tendency of habitat quality cores and does not "
                 "affect the rank."),
-            "name": "Half-Saturation Constant"
+            "name": "half-saturation constant"
         },
     }
 }

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -150,7 +150,7 @@ ARGS_SPEC = {
             }
         },
         "aoi_vector_path": {
-            "name": "area of interest",
+            "name": utils.AOI_ARG_NAME,
             "about": (
                 "A GDAL-supported vector file containing feature containing "
                 "one or more planning regions. subregions. An optional field "

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -72,7 +72,7 @@ ARGS_SPEC = {
         "results_suffix": validation.SUFFIX_SPEC,
         "n_workers": validation.N_WORKERS_SPEC,
         "info_table_path": {
-            "name": "Habitat Stressor Information CSV or Excel File",
+            "name": "habitat stressor table",
             "about": (
                 "A CSV or Excel file that contains the name of the habitat "
                 "(H) or stressor (s) on the `NAME` column that matches the "
@@ -88,7 +88,7 @@ ARGS_SPEC = {
             }
         },
         "criteria_table_path": {
-            "name": "Criteria Scores Table",
+            "name": "criteria scores table",
             "about": (
                 "A CSV or Excel file that contains the set of criteria "
                 "ranking  (rating, DQ and weight) of each stressor on each "
@@ -100,11 +100,11 @@ ARGS_SPEC = {
             "required": True,
         },
         "resolution": {
-            "name": "Resolution of Analysis (meters)",
+            "name": "resolution of analysis",
             "about": (
                 "The size that should be used to grid the given habitat and "
                 "stressor files into rasters. This value will be the pixel "
-                "size of the completed raster files."),
+                "size (meters) of the completed raster files."),
             "type": "number",
             "required": True,
             "validation_options": {
@@ -112,7 +112,7 @@ ARGS_SPEC = {
             }
         },
         "max_rating": {
-            "name": "Maximum Criteria Score",
+            "name": "maximum criteria score",
             "about": (
                 "This is the highest score that is used to rate a criteria "
                 "within this model run. This value would be used to compare "
@@ -125,7 +125,7 @@ ARGS_SPEC = {
             }
         },
         "risk_eq": {
-            "name": "Risk Equation",
+            "name": "risk equation",
             "about": (
                 "Each of these represents an option of a risk calculation "
                 "equation. This will determine the numeric output of risk "
@@ -137,7 +137,7 @@ ARGS_SPEC = {
             }
         },
         "decay_eq": {
-            "name": "Decay Equation",
+            "name": "decay equation",
             "about": (
                 "Each of these represents an option of a decay equation "
                 "for the buffered stressors. If stressor buffering is "
@@ -150,7 +150,7 @@ ARGS_SPEC = {
             }
         },
         "aoi_vector_path": {
-            "name": "Area of Interest",
+            "name": "area of interest",
             "about": (
                 "A GDAL-supported vector file containing feature containing "
                 "one or more planning regions. subregions. An optional field "
@@ -164,11 +164,11 @@ ARGS_SPEC = {
             }
         },
         "visualize_outputs": {
-            "name": "Generate GeoJSONs for Web Visualization",
+            "name": "generate geoJSONs",
             "help": (
-                "Check to enable the generation of GeoJSON outputs. This "
-                "could be used to visualize the risk scores on a map in the "
-                "HRA visualization web application."),
+                "Check to enable the generation of GeoJSON outputs for web "
+                "visualization. This could be used to visualize the risk "
+                "scores on a map in the HRA visualization web application."),
             "type": "boolean",
             "required": True,
         }

--- a/src/natcap/invest/hydropower/hydropower_water_yield.py
+++ b/src/natcap/invest/hydropower/hydropower_water_yield.py
@@ -41,7 +41,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file containing LULC code "
                 "(expressed as integers) for each cell."),
-            "name": "Land Use"
+            "name": "land use"
         },
         "depth_to_root_rest_layer_path": {
             "type": "raster",
@@ -54,7 +54,7 @@ ARGS_SPEC = {
                 "restricting layer depth value for each cell. The root "
                 "restricting layer depth value should be in "
                 "millimeters (mm)."),
-            "name": "Depth To Root Restricting Layer"
+            "name": "depth to root restricting layer"
         },
         "precipitation_path": {
             "type": "raster",
@@ -67,7 +67,7 @@ ARGS_SPEC = {
                 "annual precipitation values for each cell. The "
                 "precipitation values should be in millimeters "
                 "(mm)."),
-            "name": "Precipitation"
+            "name": "precipitation"
         },
         "pawc_path": {
             "type": "raster",
@@ -80,7 +80,7 @@ ARGS_SPEC = {
                 "water content values for each cell.  The plant available "
                 "water content fraction should be a value between 0 "
                 "and 1."),
-            "name": "Plant Available Water Fraction"
+            "name": "plant available water fraction"
         },
         "eto_path": {
             "type": "raster",
@@ -93,7 +93,7 @@ ARGS_SPEC = {
                 "reference evapotranspiration values for each cell.  The "
                 "reference evapotranspiration values should be in "
                 "millimeters (mm)."),
-            "name": "Reference Evapotranspiration"
+            "name": "reference evapotranspiration"
         },
         "watersheds_path": {
             "validation_options": {
@@ -107,7 +107,7 @@ ARGS_SPEC = {
                 "watershed.  Each polygon that represents a watershed is "
                 "required to have a field 'ws_id' that is a unique integer "
                 "which identifies that watershed."),
-            "name": "Watersheds"
+            "name": "watersheds"
         },
         "sub_watersheds_path": {
             "validation_options": {
@@ -122,7 +122,7 @@ ARGS_SPEC = {
                 "Watersheds shapefile.  Each polygon that represents a "
                 "sub-watershed is required to have a field 'subws_id' that "
                 "is a unique integer which identifies that sub-watershed."),
-            "name": "Sub-Watersheds"
+            "name": "sub-watersheds"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -135,7 +135,7 @@ ARGS_SPEC = {
                 "containing data on biophysical coefficients used in this "
                 "model.  The following columns are required: "
                 "'lucode' (integer), 'root_depth' (mm), 'Kc' (coefficient)."),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "seasonality_constant": {
             "validation_options": {
@@ -147,7 +147,7 @@ ARGS_SPEC = {
                 "Floating point value on the order of 1 to 30 "
                 "corresponding to the seasonal distribution of "
                 "precipitation."),
-            "name": "Z parameter"
+            "name": "z parameter"
         },
         "demand_table_path": {
             "validation_options": {
@@ -165,7 +165,7 @@ ARGS_SPEC = {
                 "land-use/land-cover map.  NOTE: the accounting for pixel "
                 "area is important since larger areas will consume more "
                 "water for the same land-cover type."),
-            "name": "Water Demand Table"
+            "name": "water demand table"
         },
         "valuation_table_path": {
             "validation_options": {
@@ -180,7 +180,7 @@ ARGS_SPEC = {
                 "values.  The table should have the following column "
                 "fields: 'ws_id', 'efficiency', 'fraction', 'height', "
                 "'kw_price', 'cost', 'time_span', and 'discount'."),
-            "name": "Hydropower Valuation Table"
+            "name": "hydropower valuation table"
         }
     }
 }

--- a/src/natcap/invest/hydropower/hydropower_water_yield.py
+++ b/src/natcap/invest/hydropower/hydropower_water_yield.py
@@ -41,7 +41,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file containing LULC code "
                 "(expressed as integers) for each cell."),
-            "name": "land use"
+            "name": utils.LULC_ARG_NAME
         },
         "depth_to_root_rest_layer_path": {
             "type": "raster",

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -41,7 +41,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the Working with the DEM section of the "
                 "InVEST User's Guide for more information."),
-            "name": "DEM"
+            "name": "digital elevation model"
         },
         "lulc_path": {
             "type": "raster",
@@ -53,7 +53,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster file containing integer values "
                 "representing the LULC code for each cell.  The LULC code "
                 "should be an integer."),
-            "name": "Land Use"
+            "name": "land use"
         },
         "runoff_proxy_path": {
             "type": "raster",
@@ -62,7 +62,7 @@ ARGS_SPEC = {
                 "Weighting factor to nutrient loads.  Internally this value "
                 "is normalized by its average values so a variety of data "
                 "can be used including precipitation or quickflow."),
-            "name": "Nutrient Runoff Proxy"
+            "name": "nutrient runoff proxy"
         },
         "watersheds_path": {
             "type": "vector",
@@ -77,7 +77,7 @@ ARGS_SPEC = {
                 "where water quality will be analyzed.  It must have the "
                 "integer field 'ws_id' where the values uniquely identify "
                 "each watershed."),
-            "name": "Watersheds"
+            "name": "watersheds"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -91,19 +91,19 @@ ARGS_SPEC = {
                 "must contain the fields 'lucode', 'load_n' (or p), 'eff_n' "
                 "(or p), and 'crit_len_n' (or p) depending on which "
                 "nutrients are selected."),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "calc_p": {
             "type": "boolean",
             "required": True,
             "about": "Select to calculate phosphorous export.",
-            "name": "Calculate phosphorous retention"
+            "name": "calculate phosphorous retention"
         },
         "calc_n": {
             "type": "boolean",
             "required": True,
             "about": "Select to calculate nitrogen export.",
-            "name": "Calculate Nitrogen Retention"
+            "name": "calculate nitrogen retention"
         },
         "threshold_flow_accumulation": {
             "validation_options": {
@@ -116,7 +116,7 @@ ARGS_SPEC = {
                 "before it's considered part of a stream such that "
                 "retention stops and the remaining export is exported to the "
                 "stream.  Used to define streams from the DEM."),
-            "name": "Threshold Flow Accumulation"
+            "name": "threshold flow accumulation"
         },
         "k_param": {
             "type": "number",
@@ -132,7 +132,7 @@ ARGS_SPEC = {
         "subsurface_critical_length_n": {
             "type": "number",
             "required": "calc_n",
-            "name": "Subsurface Critical Length (Nitrogen)",
+            "name": "subsurface critical length (nitrogen)",
             "about": (
                 "The distance (traveled subsurface and downslope) after "
                 "which it is assumed that soil retains nutrient at its "
@@ -147,7 +147,7 @@ ARGS_SPEC = {
         "subsurface_critical_length_p": {
             "type": "number",
             "required": "calc_p",
-            "name": "Subsurface Critical Length (Phosphorous)",
+            "name": "subsurface critical length (phosphorous)",
             "about": (
                 "The distance (traveled subsurface and downslope) after "
                 "which it is assumed that soil retains nutrient at its "
@@ -162,7 +162,7 @@ ARGS_SPEC = {
         "subsurface_eff_n": {
             "type": "number",
             "required": "calc_n",
-            "name": "Subsurface Maximum Retention Efficiency (Nitrogen)",
+            "name": "subsurface maximum retention efficiency (nitrogen)",
             "about": (
                 "The maximum nutrient retention efficiency that can be "
                 "reached through subsurface flow, a floating point value "
@@ -172,7 +172,7 @@ ARGS_SPEC = {
         "subsurface_eff_p": {
             "type": "number",
             "required": "calc_p",
-            "name": "Subsurface Maximum Retention Efficiency (Phosphorous)",
+            "name": "subsurface maximum retention efficiency (phosphorous)",
             "about": (
                 "The maximum nutrient retention efficiency that can be "
                 "reached through subsurface flow, a floating point value "

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -132,7 +132,7 @@ ARGS_SPEC = {
         "subsurface_critical_length_n": {
             "type": "number",
             "required": "calc_n",
-            "name": "subsurface critical length (nitrogen)",
+            "name": "critical length (N)",
             "about": (
                 "The distance (traveled subsurface and downslope) after "
                 "which it is assumed that soil retains nutrient at its "
@@ -147,7 +147,7 @@ ARGS_SPEC = {
         "subsurface_critical_length_p": {
             "type": "number",
             "required": "calc_p",
-            "name": "subsurface critical length (phosphorous)",
+            "name": "critical length (P)",
             "about": (
                 "The distance (traveled subsurface and downslope) after "
                 "which it is assumed that soil retains nutrient at its "
@@ -162,7 +162,7 @@ ARGS_SPEC = {
         "subsurface_eff_n": {
             "type": "number",
             "required": "calc_n",
-            "name": "subsurface maximum retention efficiency (nitrogen)",
+            "name": "max retention efficiency (N)",
             "about": (
                 "The maximum nutrient retention efficiency that can be "
                 "reached through subsurface flow, a floating point value "
@@ -172,7 +172,7 @@ ARGS_SPEC = {
         "subsurface_eff_p": {
             "type": "number",
             "required": "calc_p",
-            "name": "subsurface maximum retention efficiency (phosphorous)",
+            "name": "max retention efficiency (P)",
             "about": (
                 "The maximum nutrient retention efficiency that can be "
                 "reached through subsurface flow, a floating point value "

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -41,7 +41,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the Working with the DEM section of the "
                 "InVEST User's Guide for more information."),
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "lulc_path": {
             "type": "raster",
@@ -53,7 +53,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster file containing integer values "
                 "representing the LULC code for each cell.  The LULC code "
                 "should be an integer."),
-            "name": "land use"
+            "name": utils.LULC_ARG_NAME
         },
         "runoff_proxy_path": {
             "type": "raster",

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -36,7 +36,7 @@ ARGS_SPEC = {
                 "This is the landcover map that's used to map biophysical "
                 "properties about habitat and floral resources of landcover "
                 "types to a spatial layout."),
-            "name": "landcover map"
+            "name": utils.LULC_ARG_NAME
         },
         "guild_table_path": {
             "validation_options": {

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -36,7 +36,7 @@ ARGS_SPEC = {
                 "This is the landcover map that's used to map biophysical "
                 "properties about habitat and floral resources of landcover "
                 "types to a spatial layout."),
-            "name": "Land Cover Map"
+            "name": "landcover map"
         },
         "guild_table_path": {
             "validation_options": {
@@ -61,7 +61,7 @@ ARGS_SPEC = {
                 "indicating the relative abundance of the particular species "
                 "with respect to the sum of all relative abundance weights "
                 "in the table."),
-            "name": "Guild Table"
+            "name": "guild table"
         },
         "landcover_biophysical_table_path": {
             "validation_options": {
@@ -84,7 +84,7 @@ ARGS_SPEC = {
                 "<br/>* For every season matching _FORAGING_ACTIVITY_PATTERN "
                 "in the guilds table, a column matching the pattern in "
                 "`_LANDCOVER_FLORAL_RESOURCES_INDEX_HEADER`."),
-            "name": "Land Cover Biophysical Table"
+            "name": "biophysical table"
         },
         "farm_vector_path": {
             "validation_options": {
@@ -114,7 +114,7 @@ ARGS_SPEC = {
                 "in the biophysical and guild table.  Any areas that "
                 "overlap the landcover map will replace nesting substrate "
                 "suitability with this value.  Ranges from 0..1."),
-            "name": "Farm Vector"
+            "name": "farms"
         }
     }
 }

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported vector file representing the area of "
                 "interest where the model will run the analysis."),
-            "name": "Area of Interest (Vector)"
+            "name": "area of interest"
         },
         "hostname": {
             "type": "freestyle_string",
@@ -83,9 +83,9 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": (
-                "Year to start PUD calculations, date starts on Jan "
-                "1st."),
-            "name": "Start Year (inclusive, must be >= 2005)"
+                "Year to start PUD calculations, inclusive (date starts on Jan "
+                "1st). Must be >= 2005."),
+            "name": "start year"
         },
         "end_year": {
             "validation_options": {
@@ -94,9 +94,9 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": (
-                "Year to end PUD calculations, date ends and includes Dec "
-                "31st."),
-            "name": "End Year (inclusive, must be <= 2017)"
+                "Year to end PUD calculations, inclusive (date goes through Dec "
+                "31st). Must be <= 2017"),
+            "name": "end year"
         },
         "grid_aoi": {
             "type": "boolean",
@@ -105,7 +105,7 @@ ARGS_SPEC = {
                 "If true the polygon vector in ``args['aoi_path']`` should be "
                 "gridded into a new vector and the recreation model should "
                 "be executed on that"),
-            "name": "Grid the AOI"
+            "name": "grid AOI"
         },
         "grid_type": {
             "validation_options": {
@@ -120,7 +120,7 @@ ARGS_SPEC = {
                 "Optional, but must exist if args['grid_aoi'] is True.  Is "
                 "one of 'hexagon' or 'square' and\nindicates the style of "
                 "gridding."),
-            "name": "Grid Type"
+            "name": "grid type"
         },
         "cell_size": {
             "validation_options": {
@@ -132,7 +132,7 @@ ARGS_SPEC = {
                 "The size of the grid units measured in the projection "
                 "units of the AOI. For example, UTM projections use "
                 "meters."),
-            "name": "Cell Size"
+            "name": "cell size"
         },
         "compute_regression": {
             "type": "boolean",
@@ -140,7 +140,7 @@ ARGS_SPEC = {
             "about": (
                 "If True, then process the predictor table and scenario "
                 "table (if present)."),
-            "name": "Compute Regression"
+            "name": "compute regression"
         },
         "predictor_table_path": {
             "validation_options": {
@@ -152,7 +152,7 @@ ARGS_SPEC = {
                 "A table that maps predictor IDs to files and their types "
                 "with required headers of 'id', 'path', and 'type'.  The "
                 "file paths can be absolute, or relative to the table."),
-            "name": "Predictor Table"
+            "name": "predictor table"
         },
         "scenario_predictor_table_path": {
             "validation_options": {
@@ -164,7 +164,7 @@ ARGS_SPEC = {
                 "A table that maps predictor IDs to files and their types "
                 "with required headers of 'id', 'path', and 'type'.  The "
                 "file paths can be absolute, or relative to the table."),
-            "name": "Scenario Predictor Table"
+            "name": "scenario predictor table"
         }
     }
 }

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported vector file representing the area of "
                 "interest where the model will run the analysis."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "hostname": {
             "type": "freestyle_string",

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -28,7 +28,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster file containing a base Digital "
                 "Elevation Model to execute the routing functionality "
                 "across."),
-            "name": "Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "dem_band_index": {
             "validation_options": {
@@ -39,7 +39,7 @@ ARGS_SPEC = {
             "about": (
                 "The band index to use from the raster. This positive "
                 "integer is 1-based. Default: 1"),
-            "name": "Band Index"
+            "name": "band index"
         },
         "algorithm": {
             "validation_options": {
@@ -53,26 +53,26 @@ ARGS_SPEC = {
                 "of each of the 8 neighbors of a cell.</li>"
                 "<li>MFD: Multiple Flow Direction. Fractional flow is "
                 "modeled between pixels.</li></ul>"),
-            "name": "Routing Algorithm"
+            "name": "routing algorithm"
         },
         "calculate_flow_direction": {
             "type": "boolean",
             "required": False,
             "about": "Select to calculate flow direction",
-            "name": "Calculate Flow Direction"
+            "name": "calculate flow direction"
         },
         "calculate_flow_accumulation": {
             "validation_options": {},
             "type": "boolean",
             "required": False,
             "about": "Select to calculate flow accumulation.",
-            "name": "Calculate Flow Accumulation"
+            "name": "calculate flow accumulation"
         },
         "calculate_stream_threshold": {
             "type": "boolean",
             "required": False,
             "about": "Select to calculate a stream threshold to flow accumulation.",
-            "name": "Calculate Stream Thresholds"
+            "name": "calculate stream thresholds"
         },
         "threshold_flow_accumulation": {
             "validation_options": {},
@@ -81,7 +81,7 @@ ARGS_SPEC = {
             "about": (
                 "The number of upstream cells that must flow into a cell "
                 "before it's classified as a stream."),
-            "name": "Threshold Flow Accumulation Limit"
+            "name": "threshold flow accumulation limit"
         },
         "calculate_downstream_distance": {
             "type": "boolean",
@@ -90,13 +90,13 @@ ARGS_SPEC = {
                 "If selected, creates a downstream distance raster based "
                 "on the thresholded flow accumulation stream "
                 "classification."),
-            "name": "Calculate Distance to stream"
+            "name": "calculate distance to stream"
         },
         "calculate_slope": {
             "type": "boolean",
             "required": False,
             "about": "If selected, calculates slope from the provided DEM.",
-            "name": "Calculate Slope"
+            "name": "calculate slope"
         }
     }
 }

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -36,13 +36,13 @@ ARGS_SPEC = {
             "type": "raster",
             "required": True,
             "about": "Path to the base landcover map",
-            "name": "base landcover"
+            "name": "base LULC"
         },
         "replacment_lucode": {
             "type": "number",
             "required": True,
             "about": "Code to replace when converting pixels",
-            "name": "replacement landcover code"
+            "name": "replacement LULC code"
         },
         "area_to_convert": {
             "validation_options": {
@@ -65,7 +65,7 @@ ARGS_SPEC = {
                 "A space separated string of landcover codes that are used "
                 "to determine the proximity when referring to 'towards' or "
                 "'away' from the base landcover codes"),
-            "name": "focal landcover codes"
+            "name": "focal LULC codes"
         },
         "convertible_landcover_codes": {
             "validation_options": {
@@ -79,7 +79,7 @@ ARGS_SPEC = {
                 "A space separated string of landcover codes that can be "
                 "converted in the generation phase found in "
                 "`args['base_lulc_path']`."),
-            "name": "convertible landcover codes"
+            "name": "convertible LULC codes"
         },
         "n_fragmentation_steps": {
             "validation_options": {

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -36,13 +36,13 @@ ARGS_SPEC = {
             "type": "raster",
             "required": True,
             "about": "Path to the base landcover map",
-            "name": "Base Land Use/Cover"
+            "name": "base landcover"
         },
         "replacment_lucode": {
             "type": "number",
             "required": True,
             "about": "Code to replace when converting pixels",
-            "name": "Replacement Landcover Code"
+            "name": "replacement landcover code"
         },
         "area_to_convert": {
             "validation_options": {
@@ -51,7 +51,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": "Max area (Ha) to convert",
-            "name": "Max area to convert"
+            "name": "max area to convert"
         },
         "focal_landcover_codes": {
             "validation_options": {
@@ -65,7 +65,7 @@ ARGS_SPEC = {
                 "A space separated string of landcover codes that are used "
                 "to determine the proximity when referring to 'towards' or "
                 "'away' from the base landcover codes"),
-            "name": "Focal Landcover Codes"
+            "name": "focal landcover codes"
         },
         "convertible_landcover_codes": {
             "validation_options": {
@@ -79,7 +79,7 @@ ARGS_SPEC = {
                 "A space separated string of landcover codes that can be "
                 "converted in the generation phase found in "
                 "`args['base_lulc_path']`."),
-            "name": "Convertible Landcover Codes"
+            "name": "convertible landcover codes"
         },
         "n_fragmentation_steps": {
             "validation_options": {
@@ -93,7 +93,7 @@ ARGS_SPEC = {
                 "sub-step the distance transform is recalculated from the "
                 "base landcover codes.  This can affect the final result "
                 "if the base types are also convertible types."),
-            "name": "Number of Steps in Conversion"
+            "name": "number of conversion steps"
         },
         "aoi_path": {
             "type": "vector",
@@ -104,7 +104,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a set of polygons that will be used to aggregate "
                 "carbon values at the end of the run if provided."),
-            "name": "Area of interest"
+            "name": "area of interest"
         },
         "convert_farthest_from_edge": {
             "type": "boolean",
@@ -113,7 +113,7 @@ ARGS_SPEC = {
                 "This scenario converts the convertible landcover codes "
                 "starting at the furthest pixel from the closest base "
                 "landcover codes and moves inward."),
-            "name": "Convert farthest from edge"
+            "name": "convert farthest from edge"
         },
         "convert_nearest_to_edge": {
             "type": "boolean",
@@ -122,7 +122,7 @@ ARGS_SPEC = {
                 "This scenario converts the convertible landcover codes "
                 "starting at the closest pixel in the base landcover codes "
                 "and moves outward."),
-            "name": "Convert nearest to edge"
+            "name": "convert nearest to edge"
         }
     }
 }

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -104,7 +104,7 @@ ARGS_SPEC = {
             "about": (
                 "This is a set of polygons that will be used to aggregate "
                 "carbon values at the end of the run if provided."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "convert_farthest_from_edge": {
             "type": "boolean",

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
         "results_suffix": validation.SUFFIX_SPEC,
         "n_workers": validation.N_WORKERS_SPEC,
         "aoi_path": {
-            "name": "area of interest",
+            "name": utils.AOI_ARG_NAME,
             "type": "vector",
             "required": True,
             "about": (
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "consistent with the project of the DEM input."),
         },
         "dem_path": {
-            "name": "digital elevation model",
+            "name": utils.DEM_ARG_NAME,
             "type": "raster",
             "required": True,
             "validation_options": {

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -57,7 +57,7 @@ ARGS_SPEC = {
         "results_suffix": validation.SUFFIX_SPEC,
         "n_workers": validation.N_WORKERS_SPEC,
         "aoi_path": {
-            "name": "Area of Interest",
+            "name": "area of interest",
             "type": "vector",
             "required": True,
             "about": (
@@ -68,7 +68,7 @@ ARGS_SPEC = {
                 "must intersect the Digital Elevation Model (DEM)."),
         },
         "structure_path": {
-            "name": "Features Impacted Scenic Quality",
+            "name": "features impacting scenic quality",
             "type": "vector",
             "required": True,
             "about": (
@@ -81,7 +81,7 @@ ARGS_SPEC = {
                 "consistent with the project of the DEM input."),
         },
         "dem_path": {
-            "name": "Digital Elevation Model",
+            "name": "digital elevation model",
             "type": "raster",
             "required": True,
             "validation_options": {
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "contributing to negative scenic quality are visible."),
         },
         "refraction": {
-            "name": "Refractivity Coefficient",
+            "name": "refractivity coefficient",
             "type": "number",
             "required": True,
             "validation_options": {
@@ -116,13 +116,13 @@ ARGS_SPEC = {
                 "coefficient to 0.13."),
         },
         "do_valuation": {
-            "name": "Valuation",
+            "name": "do valuation",
             "type": "boolean",
             "required": False,
             "about": "Enable or disable valuation."
         },
         "valuation_function": {
-            "name": "Valuation function",
+            "name": "valuation function",
             "type": "option_string",
             "required": "do_valuation",
             "validation_options": {
@@ -137,19 +137,19 @@ ARGS_SPEC = {
                 "viewpoint."),
         },
         "a_coef": {
-            "name": "'a' Coefficient",
+            "name": "coefficient a",
             "type": "number",
             "required": "do_valuation",
             "about": ("First coefficient used by the valuation function"),
         },
         "b_coef": {
-            "name": "'a' Coefficient",
+            "name": "coefficient b",
             "type": "number",
             "required": "do_valuation",
             "about": ("Second coefficient used by the valuation function"),
         },
         "max_valuation_radius": {
-            "name": "Maximum Valuation Radius",
+            "name": "maximum valuation radius",
             "type": "number",
             "required": False,
             "validation_options": {

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -49,7 +49,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the 'Working with the DEM' section of the "
                 "InVEST User's Guide for more information."),
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "erosivity_path": {
             "type": "raster",
@@ -90,7 +90,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "watersheds_path": {
             "validation_options": {

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -90,7 +90,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "land use/land cover"
+            "name": "landcover"
         },
         "watersheds_path": {
             "validation_options": {

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -49,7 +49,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the 'Working with the DEM' section of the "
                 "InVEST User's Guide for more information."),
-            "name": "Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "erosivity_path": {
             "type": "raster",
@@ -66,7 +66,7 @@ ARGS_SPEC = {
                 "but in case of its absence, there are methods and equations "
                 "to help generate a grid using climatic data.  The units are "
                 "MJ*mm/(ha*h*yr)."),
-            "name": "Rainfall Erosivity Index (R)"
+            "name": "rainfall erosivity index"
         },
         "erodibility_path": {
             "type": "raster",
@@ -79,7 +79,7 @@ ARGS_SPEC = {
                 "for each cell which is a measure of the susceptibility of "
                 "soil particles to detachment and transport by rainfall and "
                 "runoff.  Units are in T*ha*h/(ha*MJ*mm)."),
-            "name": "Soil Erodibility"
+            "name": "soil erodibility"
         },
         "lulc_path": {
             "type": "raster",
@@ -90,7 +90,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "Land-Use/Land-Cover"
+            "name": "land use/land cover"
         },
         "watersheds_path": {
             "validation_options": {
@@ -105,7 +105,7 @@ ARGS_SPEC = {
                 "where water quality will be analyzed.  It must have the "
                 "integer field 'ws_id' where the values uniquely identify "
                 "each watershed."),
-            "name": "Watersheds"
+            "name": "watersheds"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -119,7 +119,7 @@ ARGS_SPEC = {
                 "must contain the fields 'lucode', 'usle_c', and 'usle_p'.  "
                 "See the InVEST Sediment User's Guide for more information "
                 "about these fields."),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "threshold_flow_accumulation": {
             "validation_options": {
@@ -132,7 +132,7 @@ ARGS_SPEC = {
                 "before it's considered part of a stream such that retention "
                 "stops and the remaining export is exported to the stream.  "
                 "Used to define streams from the DEM."),
-            "name": "Threshold Flow Accumulation"
+            "name": "threshold flow accumulation"
         },
         "k_param": {
             "type": "number",
@@ -144,13 +144,13 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": "Maximum SDR value.",
-            "name": "Max SDR Value"
+            "name": "max SDR value"
         },
         "ic_0_param": {
             "type": "number",
             "required": True,
             "about": "Borselli IC0 parameter.",
-            "name": "Borselli IC0 Parameter"
+            "name": "Borselli IC0 parameter"
         },
         "drainage_path": {
             "type": "raster",
@@ -161,7 +161,7 @@ ARGS_SPEC = {
                 "indicate drainage areas and 0's or nodata indicate areas "
                 "with no additional drainage.  This model is most accurate "
                 "when the drainage raster aligns with the DEM."),
-            "name": "Drainages"
+            "name": "drainages"
         }
     }
 }

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -101,7 +101,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "land use/land cover"
+            "name": "landcover"
         },
         "soil_group_path": {
             "type": "raster",
@@ -113,7 +113,7 @@ ARGS_SPEC = {
                 "Map of SCS soil groups (A, B, C, or D) mapped to integer "
                 "values (1, 2, 3, or 4) used in combination of the LULC map "
                 "to compute the CN map."),
-            "name": "soil group"
+            "name": "soil groups"
         },
         "aoi_path": {
             "type": "vector",
@@ -125,7 +125,7 @@ ARGS_SPEC = {
                 "Path to a vector that indicates the area over which the "
                 "model should be run, as well as the area in which to "
                 "aggregate over when calculating the output Qb."),
-            "name": "AOI/watershed"
+            "name": "area of interest"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -187,7 +187,7 @@ ARGS_SPEC = {
             "about": (
                 "If True, indicates user will provide pre-defined local "
                 "recharge raster layer"),
-            "name": "user defined recharge layer"
+            "name": "user defined local recharge"
         },
         "l_path": {
             "type": "raster",

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -122,9 +122,9 @@ ARGS_SPEC = {
                 "projected": True,
             },
             "about": (
-                "Path to a vector that indicates the area over which the "
-                "model should be run, as well as the area in which to "
-                "aggregate over when calculating the output Qb."),
+                "Path to a vector (typically a watershed) that indicates the "
+                "area over which the model should be run, as well as the area "
+                "in which to aggregate over when calculating the output Qb."),
             "name": "area of interest"
         },
         "biophysical_table_path": {
@@ -163,15 +163,15 @@ ARGS_SPEC = {
                 "Required if args['monthly_alpha'] is false.  Is the "
                 "proportion of upslope annual available local recharge that "
                 "is available in month m."),
-            "name": "alpha_m parameter"
+            "name": "α_m parameter"
         },
         "beta_i": {
             "type": "number",
             "required": True,
             "about": (
-                "Is the fraction of the upgradient subsidy that is "
+                "The fraction of the upgradient subsidy that is "
                 "available for downgradient evapotranspiration."),
-            "name": "beta_i parameter"
+            "name": "β_i parameter"
         },
         "gamma": {
             "type": "number",

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -53,7 +53,7 @@ ARGS_SPEC = {
                 "before it's considered part of a stream such that retention "
                 "stops and the remaining export is exported to the stream.  "
                 "Used to define streams from the DEM."),
-            "name": "Threshold Flow Accumulation"
+            "name": "threshold flow accumulation"
         },
         "et0_dir": {
             "validation_options": {
@@ -64,7 +64,7 @@ ARGS_SPEC = {
             "about": (
                 "The selected folder has a list of ET0 files with a "
                 "specified format."),
-            "name": "ET0 Directory"
+            "name": "evapotranspiration data"
         },
         "precip_dir": {
             "validation_options": {
@@ -75,7 +75,7 @@ ARGS_SPEC = {
             "about": (
                 "The selected folder has a list of monthly precipitation "
                 "files with a specified format."),
-            "name": "Precipitation Directory"
+            "name": "precipitation data"
         },
         "dem_raster_path": {
             "type": "raster",
@@ -90,7 +90,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the 'Working with the DEM' section of the "
                 "InVEST User's Guide for more information."),
-            "name": "Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "lulc_raster_path": {
             "type": "raster",
@@ -101,7 +101,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "Land-Use/Land-Cover"
+            "name": "land use/land cover"
         },
         "soil_group_path": {
             "type": "raster",
@@ -113,7 +113,7 @@ ARGS_SPEC = {
                 "Map of SCS soil groups (A, B, C, or D) mapped to integer "
                 "values (1, 2, 3, or 4) used in combination of the LULC map "
                 "to compute the CN map."),
-            "name": "Soil Group"
+            "name": "soil group"
         },
         "aoi_path": {
             "type": "vector",
@@ -125,7 +125,7 @@ ARGS_SPEC = {
                 "Path to a vector that indicates the area over which the "
                 "model should be run, as well as the area in which to "
                 "aggregate over when calculating the output Qb."),
-            "name": "AOI/Watershed"
+            "name": "AOI/watershed"
         },
         "biophysical_table_path": {
             "validation_options": {
@@ -139,7 +139,7 @@ ARGS_SPEC = {
                 "each of the land use classes in the LULC raster input.  It "
                 "must contain the fields 'lucode', and one 'Kc_<int>' column "
                 "per season."),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "rain_events_table_path": {
             "validation_options": {
@@ -154,7 +154,7 @@ ARGS_SPEC = {
                 "CSV table that has headers 'month' (1-12) and 'events' "
                 "(int >= 0) that indicates the number of rain events per "
                 "month"),
-            "name": "Rain Events Table"
+            "name": "rain events table"
         },
         "alpha_m": {
             "type": "freestyle_string",
@@ -163,7 +163,7 @@ ARGS_SPEC = {
                 "Required if args['monthly_alpha'] is false.  Is the "
                 "proportion of upslope annual available local recharge that "
                 "is available in month m."),
-            "name": "alpha_m Parameter"
+            "name": "alpha_m parameter"
         },
         "beta_i": {
             "type": "number",
@@ -171,7 +171,7 @@ ARGS_SPEC = {
             "about": (
                 "Is the fraction of the upgradient subsidy that is "
                 "available for downgradient evapotranspiration."),
-            "name": "beta_i Parameter"
+            "name": "beta_i parameter"
         },
         "gamma": {
             "type": "number",
@@ -179,7 +179,7 @@ ARGS_SPEC = {
             "about": (
                 "The fraction of pixel local recharge that is available to "
                 "downgradient pixels."),
-            "name": "gamma Parameter"
+            "name": "gamma parameter"
         },
         "user_defined_local_recharge": {
             "type": "boolean",
@@ -187,7 +187,7 @@ ARGS_SPEC = {
             "about": (
                 "If True, indicates user will provide pre-defined local "
                 "recharge raster layer"),
-            "name": "User Defined Recharge Layer (Advanced)"
+            "name": "user defined recharge layer"
         },
         "l_path": {
             "type": "raster",
@@ -199,7 +199,7 @@ ARGS_SPEC = {
                 "A path to a GDAL-compatible raster.  Pixels indicate the "
                 "amount of local recharge in mm.  Required if "
                 "args['user_defined_local_recharge'] is True."),
-            "name": "Local Recharge ("
+            "name": "local recharge"
         },
         "user_defined_climate_zones": {
             "type": "boolean",
@@ -208,7 +208,7 @@ ARGS_SPEC = {
                 "If True, user provides a climate zone rain events table and "
                 "a climate zone raster map in lieu of a global rain events "
                 "table."),
-            "name": "Climate Zones (Advanced)"
+            "name": "define climate zones"
         },
         "climate_zone_table_path": {
             "validation_options": {
@@ -220,7 +220,7 @@ ARGS_SPEC = {
                 "Required if args['user_defined_climate_zones'] is True. "
                 "Contains monthly precipitation events per climate zone.  "
                 "Fields must be 'cz_id', %s." % ', '.join(MONTH_ID_TO_LABEL)),
-            "name": "Climate Zone Table"
+            "name": "climate zone table"
         },
         "climate_zone_raster_path": {
             "type": "raster",
@@ -232,19 +232,19 @@ ARGS_SPEC = {
                 "Map of climate zones that are found in the Climate Zone "
                 "Table input.  Pixel values correspond to values in the "
                 "cz_id column."),
-            "name": "Climate Zone"
+            "name": "climate zones"
         },
         "monthly_alpha": {
             "type": "boolean",
             "required": True,
             "about": "If True, use the monthly alpha table.",
-            "name": "Use Monthly Alpha Table (Advanced)"
+            "name": "use monthly alpha table"
         },
         "monthly_alpha_path": {
             "type": "csv",
             "required": "monthly_alpha",
             "about": "Required if args['monthly_alpha'] is True.",
-            "name": "Monthly Alpha Table"
+            "name": "monthly alpha table"
         }
     }
 }

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -90,7 +90,7 @@ ARGS_SPEC = {
                 "the elevation model (recommended when unusual streams are "
                 "observed.) See the 'Working with the DEM' section of the "
                 "InVEST User's Guide for more information."),
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "lulc_raster_path": {
             "type": "raster",
@@ -101,7 +101,7 @@ ARGS_SPEC = {
             "about": (
                 "A GDAL-supported raster file, with an integer LULC code "
                 "for each cell."),
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "soil_group_path": {
             "type": "raster",
@@ -125,7 +125,7 @@ ARGS_SPEC = {
                 "Path to a vector (typically a watershed) that indicates the "
                 "area over which the model should be run, as well as the area "
                 "in which to aggregate over when calculating the output Qb."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "biophysical_table_path": {
             "validation_options": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -38,7 +38,7 @@ ARGS_SPEC = {
         "results_suffix": validation.SUFFIX_SPEC,
         "n_workers": validation.N_WORKERS_SPEC,
         "lulc_raster_path": {
-            "name": "landcover",
+            "name": utils.LULC_ARG_NAME,
             "type": "raster",
             "required": True,
             "validation_options": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -67,7 +67,7 @@ ARGS_SPEC = {
             )
         },
         "aoi_vector_path": {
-            "name": "area of interest",
+            "name": utils.AOI_ARG_NAME,
             "type": "vector",
             "required": True,
             "about": (

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -38,7 +38,7 @@ ARGS_SPEC = {
         "results_suffix": validation.SUFFIX_SPEC,
         "n_workers": validation.N_WORKERS_SPEC,
         "lulc_raster_path": {
-            "name": "Land Use / Land Cover Raster",
+            "name": "landcover",
             "type": "raster",
             "required": True,
             "validation_options": {
@@ -57,7 +57,7 @@ ARGS_SPEC = {
             )
         },
         "ref_eto_raster_path": {
-            "name": "Reference Evapotranspiration Raster",
+            "name": "evapotranspiration",
             "type": "raster",
             "required": True,
             "about": (
@@ -67,7 +67,7 @@ ARGS_SPEC = {
             )
         },
         "aoi_vector_path": {
-            "name": "Area of Interest Vector",
+            "name": "area of interest",
             "type": "vector",
             "required": True,
             "about": (
@@ -77,7 +77,7 @@ ARGS_SPEC = {
             )
         },
         "biophysical_table_path": {
-            "name": "Biophysical Table",
+            "name": "biophysical table",
             "type": "csv",
             "required": True,
             "validation_options": {
@@ -91,7 +91,7 @@ ARGS_SPEC = {
             ),
         },
         "green_area_cooling_distance": {
-            "name": "Green area max cooling distance effect (m)",
+            "name": "max cooling distance",
             "type": "number",
             "required": True,
             "validation_options": {
@@ -103,18 +103,19 @@ ARGS_SPEC = {
             ),
         },
         "t_air_average_radius": {
-            "name": "T_air moving average radius (m)",
+            "name": "maximum blending distance",
             "type": "number",
             "required": True,
             "validation_options": {
                 "expression": "value > 0"
             },
             "about": (
-                "Radius of the averaging filter for turning T_air_nomix "
-                "into T_air")
+                "Radius in meters of the moving average filter that accounts "
+                "for air mixing."
+            )
         },
         "t_ref": {
-            "name": "Reference Air Temperature",
+            "name": "reference air temperature",
             "type": "number",
             "required": True,
             "about": (
@@ -125,7 +126,7 @@ ARGS_SPEC = {
                 "given for the same period of interest)"),
         },
         "uhi_max": {
-            "name": "Magnitude of the UHI effect",
+            "name": "magnitude of UHI effect",
             "type": "number",
             "required": True,
             "about": (
@@ -136,19 +137,19 @@ ARGS_SPEC = {
             ),
         },
         "do_energy_valuation": {
-            "name": "Run Energy Savings Valuation Model",
+            "name": "do energy savings valuation",
             "type": "boolean",
             "required": True,
             "about": "Select to run the energy savings valuation model."
         },
         "do_productivity_valuation": {
-            "name": "Run Work Productivity Valuation Model",
+            "name": "do work productivity valuation",
             "type": "boolean",
             "required": True,
             "about": "Select to run the work productivity valuation model."
         },
         "avg_rel_humidity": {
-            "name": "Average relative humidity (0-100%)",
+            "name": "average relative humidity",
             "type": "number",
             "required": "do_productivity_valuation",
             "validation_options": {
@@ -160,7 +161,7 @@ ARGS_SPEC = {
             ),
         },
         "building_vector_path": {
-            "name": "Buildings vector",
+            "name": "buildings",
             "type": "vector",
             "required": "do_energy_valuation",
             "validation_options": {
@@ -175,7 +176,7 @@ ARGS_SPEC = {
             ),
         },
         "energy_consumption_table_path": {
-            "name": "Energy consumption table",
+            "name": "energy consumption",
             "type": "csv",
             "required": "do_energy_valuation",
             "validation_options": {
@@ -187,7 +188,7 @@ ARGS_SPEC = {
             ),
         },
         "cc_method": {
-            "name": "Cooling capacity calculation method",
+            "name": "cooling capacity method",
             "type": "option_string",
             "required": True,
             "validation_options": {
@@ -205,7 +206,7 @@ ARGS_SPEC = {
             ),
         },
         "cc_weight_shade": {
-            "name": "Cooling capacity: adjust shade weight",
+            "name": "adjust shade weight",
             "type": "number",
             "required": False,
             "validation_options": {
@@ -217,7 +218,7 @@ ARGS_SPEC = {
             ),
         },
         "cc_weight_albedo": {
-            "name": "Cooling capacity: adjust albedo weight",
+            "name": "adjust albedo weight",
             "type": "number",
             "required": False,
             "validation_options": {
@@ -229,7 +230,7 @@ ARGS_SPEC = {
             ),
         },
         "cc_weight_eti": {
-            "name": "Cooling capacity: adjust evapotranspiration weight",
+            "name": "adjust evapotranspiration weight",
             "type": "number",
             "required": False,
             "validation_options": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -62,8 +62,8 @@ ARGS_SPEC = {
             "required": True,
             "about": (
                 "A GDAL-supported raster file containing numeric values "
-                "representing the evapotranspiration (in mm) for the period "
-                "of interest."
+                "representing the reference evapotranspiration (in mm) for "
+                "the period of interest."
             )
         },
         "aoi_vector_path": {
@@ -111,7 +111,7 @@ ARGS_SPEC = {
             },
             "about": (
                 "Radius in meters of the moving average filter that accounts "
-                "for air mixing."
+                "for air temperature mixing."
             )
         },
         "t_ref": {

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -38,7 +38,7 @@ ARGS_SPEC = {
             "about": (
                 "Path to a vector of (sub)watersheds or sewersheds used to "
                 "indicate spatial area of interest."),
-            "name": "Watershed Vector"
+            "name": "watersheds"
         },
         "rainfall_depth": {
             "validation_options": {
@@ -47,7 +47,7 @@ ARGS_SPEC = {
             "type": "number",
             "required": True,
             "about": "Depth of rainfall in mm.",
-            "name": "Depth of rainfall in mm"
+            "name": "rainfall depth"
         },
         "lulc_path": {
             "type": "raster",
@@ -56,7 +56,7 @@ ARGS_SPEC = {
             },
             "required": True,
             "about": "Path to a landcover raster",
-            "name": "Landcover Raster"
+            "name": "landcover"
         },
         "soils_hydrological_group_raster_path": {
             "type": "raster",
@@ -68,7 +68,7 @@ ARGS_SPEC = {
                 "Raster with values equal to 1, 2, 3, 4, corresponding to "
                 "soil hydrologic group A, B, C, or D, respectively (used to "
                 "derive the CN number)"),
-            "name": "Soils Hydrological Group Raster"
+            "name": "soils hydrological groups"
         },
         "curve_number_table_path": {
             "validation_options": {
@@ -80,7 +80,7 @@ ARGS_SPEC = {
                 "Path to a CSV table that to map landcover codes to curve "
                 "numbers and contains at least the headers 'lucode', "
                 "'CN_A', 'CN_B', 'CN_C', 'CN_D'"),
-            "name": "Biophysical Table"
+            "name": "biophysical table"
         },
         "built_infrastructure_vector_path": {
             "validation_options": {
@@ -92,7 +92,7 @@ ARGS_SPEC = {
                 "Path to a vector with built infrastructure footprints. "
                 "Attribute table contains a column 'Type' with integers "
                 "(e.g. 1=residential, 2=office, etc.)."),
-            "name": "Built Infrastructure Vector"
+            "name": "built infrastructure"
         },
         "infrastructure_damage_loss_table_path": {
             "validation_options": {
@@ -106,7 +106,7 @@ ARGS_SPEC = {
                 "in the 'Built Infrastructure Vector' and potential damage "
                 "loss (in $/m^2). Required if the built infrastructure vector "
                 "is provided."),
-            "name": "Built Infrastructure Damage Loss Table"
+            "name": "damage loss table"
         }
     }
 }

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -56,7 +56,7 @@ ARGS_SPEC = {
             },
             "required": True,
             "about": "Path to a landcover raster",
-            "name": "landcover"
+            "name": utils.LULC_ARG_NAME
         },
         "soils_hydrological_group_raster_path": {
             "type": "raster",

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -43,6 +43,10 @@ GDAL_ERROR_LEVELS = {
 # leaves Projected CRS alone
 DEFAULT_OSR_AXIS_MAPPING_STRATEGY = osr.OAMS_TRADITIONAL_GIS_ORDER
 
+# standard values for common ARGS_SPEC name attributes
+LULC_ARG_NAME = 'land use/land cover'
+DEM_ARG_NAME = 'digital elevation model'
+AOI_ARG_NAME = 'area of interest'
 
 @contextlib.contextmanager
 def capture_gdal_logging():

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -37,7 +37,7 @@ ARGS_SPEC = {
             "type": "directory",
             "required": True,
             "about": "Select the folder that has the packaged Wave Energy Data.",
-            "name": "Wave Base Data Folder"
+            "name": "base data"
         },
         "analysis_area_path": {
             "validation_options": {
@@ -56,7 +56,7 @@ ARGS_SPEC = {
                 "A list of analysis areas for which the model can currently "
                 "be run.  All the wave energy data needed for these areas "
                 "are pre-packaged in the WaveData folder."),
-            "name": "Analysis Area"
+            "name": "analysis area"
         },
         "aoi_path": {
             "validation_options": {
@@ -71,7 +71,7 @@ ARGS_SPEC = {
                 "for computing valuation and is recommended for biophysical "
                 "runs as well.  The AOI should be projected in linear units "
                 "of meters."),
-            "name": "Area of Interest"
+            "name": "area of interest"
         },
         "machine_perf_path": {
             "type": "csv",
@@ -79,7 +79,7 @@ ARGS_SPEC = {
             "about": (
                 "A CSV Table that has the performance of a particular wave "
                 "energy machine at certain sea state conditions."),
-            "name": "Machine Performance Table"
+            "name": "machine performance"
         },
         "machine_param_path": {
             "validation_options": {
@@ -92,7 +92,7 @@ ARGS_SPEC = {
                 "machine.  This includes information on the maximum "
                 "capacity of the device and the upper limits for wave height "
                 "and period."),
-            "name": "Machine Parameter Table"
+            "name": "machine parameters"
         },
         "dem_path": {
             "type": "raster",
@@ -101,13 +101,13 @@ ARGS_SPEC = {
                 "A GDAL-supported raster file containing a digital elevation "
                 "model dataset that has elevation values in meters.  Used to "
                 "get the cable distance for wave energy transmission."),
-            "name": "Global Digital Elevation Model"
+            "name": "digital elevation model"
         },
         "valuation_container": {
             "type": "boolean",
             "required": False,
             "about": "Indicates whether the model includes valuation",
-            "name": "Valuation"
+            "name": "do valuation"
         },
         "land_gridPts_path": {
             "validation_options": {
@@ -118,7 +118,7 @@ ARGS_SPEC = {
             "about": (
                 "A CSV Table that has the landing points and grid points "
                 "locations for computing cable distances."),
-            "name": "Grid Connection Points Table"
+            "name": "grid connection points"
         },
         "machine_econ_path": {
             "validation_options": {
@@ -129,7 +129,7 @@ ARGS_SPEC = {
             "about": (
                 "A CSV Table that has the economic parameters for the wave "
                 "energy machine."),
-            "name": "Machine Economic Table"
+            "name": "economic parameters"
         },
         "number_of_machines": {
             "validation_options": {
@@ -140,7 +140,7 @@ ARGS_SPEC = {
             "about": (
                 "An integer for how many wave energy machines will be in the "
                 "wave farm."),
-            "name": "Number of Machines"
+            "name": "number of machines"
         }
     }
 }

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -71,7 +71,7 @@ ARGS_SPEC = {
                 "for computing valuation and is recommended for biophysical "
                 "runs as well.  The AOI should be projected in linear units "
                 "of meters."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "machine_perf_path": {
             "type": "csv",
@@ -101,7 +101,7 @@ ARGS_SPEC = {
                 "A GDAL-supported raster file containing a digital elevation "
                 "model dataset that has elevation values in meters.  Used to "
                 "get the cable distance for wave energy transmission."),
-            "name": "digital elevation model"
+            "name": utils.DEM_ARG_NAME
         },
         "valuation_container": {
             "type": "boolean",

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -50,7 +50,7 @@ ARGS_SPEC = {
                 "A CSV file that represents the wind input data (Weibull "
                 "parameters). Please see the User's Guide for a more "
                 "detailed description of the parameters."),
-            "name": "Wind Data Points (CSV)"
+            "name": "wind data points"
         },
         "aoi_vector_path": {
             "validation_options": {
@@ -70,7 +70,7 @@ ARGS_SPEC = {
                 "AOI should also cover a portion of the land polygon to "
                 "calculate distances correctly.  An AOI is required for "
                 "valuation."),
-            "name": "Area Of Interest"
+            "name": "area of interest"
         },
         "bathymetry_path": {
             "validation_options": {},
@@ -82,7 +82,7 @@ ARGS_SPEC = {
                 "should cover at least the entire span of the area of "
                 "interest and if no AOI is provided then the default global "
                 "DEM should be used."),
-            "name": "Bathymetric Digital Elevation Model"
+            "name": "bathymetric DEM"
         },
         "land_polygon_vector_path": {
             "type": "vector",
@@ -96,7 +96,7 @@ ARGS_SPEC = {
                 "the AOI, form the basis for distance calculations for wind "
                 "farm electrical transmission.  This input is required for "
                 "masking by distance values and for valuation."),
-            "name": "Land Polygon for Distance Calculation"
+            "name": "land polygon"
         },
         "global_wind_parameters_path": {
             "type": "csv",
@@ -108,7 +108,7 @@ ARGS_SPEC = {
                 "User's Guide.  It is recommended that careful consideration "
                 "be taken before changing these values and to make a new CSV "
                 "file so that the default one always remains."),
-            "name": "Global Wind Energy Parameters"
+            "name": "wind energy parameters"
         },
         "turbine_parameters_path": {
             "validation_options": {},
@@ -123,7 +123,7 @@ ARGS_SPEC = {
                 "existing class may be modified according to the user's "
                 "needs.  It is recommended that the existing default CSV "
                 "files are not overwritten."),
-            "name": "Turbine Type Parameters File"
+            "name": "turbine parameters"
         },
         "number_of_turbines": {
             "validation_options": {
@@ -133,7 +133,7 @@ ARGS_SPEC = {
             "required": True,
             "about": "An integer value indicating the number of wind turbines"
                      " per wind farm.",
-            "name": "Number Of Turbines"
+            "name": "number of turbines"
         },
         "min_depth": {
             "type": "number",
@@ -142,7 +142,7 @@ ARGS_SPEC = {
                 "A floating point value in meters for the minimum depth of "
                 "the offshore wind farm installation."),
             "name": (
-                "Minimum Depth for Offshore Wind Farm Installation (meters)")
+                "minimum depth")
         },
         "max_depth": {
             "type": "number",
@@ -151,7 +151,7 @@ ARGS_SPEC = {
                 "A floating point value in meters for the maximum depth of "
                 "the offshore wind farm installation."),
             "name": (
-                "Maximum Depth for Offshore Wind Farm Installation (meters)")
+                "maximum depth")
         },
         "min_distance": {
             "type": "number",
@@ -161,8 +161,7 @@ ARGS_SPEC = {
                 "minimum distance from shore for offshore wind farm "
                 "installation.  Required for valuation."),
             "name": (
-                "Minimum Distance for Offshore Wind Farm Installation "
-                "(meters)")
+                "minimum distance")
         },
         "max_distance": {
             "type": "number",
@@ -172,26 +171,25 @@ ARGS_SPEC = {
                 "maximum distance from shore for offshore wind farm "
                 "installation.  Required for valuation."),
             "name": (
-                "Maximum Distance for Offshore Wind Farm Installation "
-                "(meters)")
+                "maximum distance")
         },
         "valuation_container": {
             "type": "boolean",
             "required": False,
             "about": "Indicates whether model includes valuation",
-            "name": "Valuation"
+            "name": "do valuation"
         },
         "foundation_cost": {
             "type": "number",
             "required": "valuation_container",
             "about": (
                 "A floating point number for the unit cost of the foundation "
-                "type (in millions of dollars). The cost of a foundation "
+                "type (in millions of US dollars). The cost of a foundation "
                 "will depend on the type selected, which itself depends on a "
                 "variety of factors including depth and turbine choice.  "
                 "Please see the User's Guide for guidance on properly "
                 "selecting this value."),
-            "name": "Cost of the Foundation Type (USD, in Millions)"
+            "name": "foundation cost"
         },
         "discount_rate": {
             "validation_options": {},
@@ -202,7 +200,7 @@ ARGS_SPEC = {
                 "benefits over future benefits (e.g., would an individual "
                 "rather receive $10 today or $10 five years from now?). See "
                 "the User's Guide for guidance on selecting this value."),
-            "name": "Discount Rate"
+            "name": "discount rate"
         },
         "grid_points_path": {
             "validation_options": {
@@ -221,7 +219,7 @@ ARGS_SPEC = {
                 "unique integer.  The shortest distance between respective "
                 "points is used for calculations.  See the User's Guide for "
                 "more information."),
-            "name": "Grid Connection Points"
+            "name": "grid connection points"
         },
         "avg_grid_distance": {
             "validation_options": {
@@ -237,7 +235,7 @@ ARGS_SPEC = {
                 "landing points instead of specific grid connection points.  "
                 "See the User's Guide for a description of the approach and "
                 "the method used to calculate the default value."),
-            "name": "Average Shore to Grid Distance (Kilometers)"
+            "name": "shore to grid distance"
         },
         "price_table": {
             "type": "boolean",
@@ -247,7 +245,7 @@ ARGS_SPEC = {
                 "energy table provided in the input below.  If not checked "
                 "the price per year will be determined using the price of "
                 "energy input and the annual rate of change."),
-            "name": "Use Price Table"
+            "name": "use price table"
         },
         "wind_schedule": {
             "validation_options": {
@@ -271,18 +269,18 @@ ARGS_SPEC = {
                 "example we have 6 years for the lifetime of the farm, "
                 "year 0 being a construction year and year 5 being the "
                 "last year."),
-            "name": "Wind Energy Price Table"
+            "name": "price table"
         },
         "wind_price": {
             "type": "number",
             "required": "valuation_container & (not price_table)",
             "about": (
-                "The price of energy per kilowatt hour.  This is the price "
+                "The price of energy ($/kilowatt-hour).  This is the price "
                 "that will be used for year or time step 0 and will then be "
                 "adjusted based on the rate of change percentage from the "
                 "input below.  See the User's Guide for guidance about "
                 "determining this value."),
-            "name": "Price of Energy per Kilowatt Hour ($/kWh)"
+            "name": "energy price"
         },
         "rate_change": {
             "validation_options": {
@@ -294,7 +292,7 @@ ARGS_SPEC = {
                 "The annual rate of change in the price of wind energy.  "
                 "This should be expressed as a decimal percentage.  For "
                 "example, 0.1 for a 10% annual price change."),
-            "name": "Annual Rate of Change in Price of Wind Energy"
+            "name": "rate of change"
         }
     }
 }

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -70,7 +70,7 @@ ARGS_SPEC = {
                 "AOI should also cover a portion of the land polygon to "
                 "calculate distances correctly.  An AOI is required for "
                 "valuation."),
-            "name": "area of interest"
+            "name": utils.AOI_ARG_NAME
         },
         "bathymetry_path": {
             "validation_options": {},


### PR DESCRIPTION
## Description
Fixes #128 
Since the workbench displays the `name` property from the `ARGS_SPEC`, it's more important now that these names are consistent in capitalization and style. 
### Proposal
* It's too difficult to maintain consistent capitalization in hundreds of names across a bunch of files, therefore
* values of the `name` property should be all lower-case (except for characters that should always be capitalized, such as proper nouns and acronyms)
* capitalization will be handled on the workbench side, as it's an aesthetic/UI issue
    * I think they look nice in all lower-case so no changes needed on the workbench side. 
    * But if people prefer a certain capitalization pattern (first word only, all words?), the workbench could apply whatever capitalization rules to `name` before rendering. That way it'll be standardized.
* The `name` property should not include the input type (vector, raster, CSV, etc) because that information is already in the `type` property.
    * Exception: in some cases it makes sense to include "table" in the `name` e.g. "biophysical table". These are ok to stay.
* Text wrapping is sometimes inevitable, but it looks best when the `name` is as short as possible. I moved some info out of the `name` and into the `about` (tooltip).
* Name all LULC inputs `"landcover"`. Name all biophysical tables `"biophysical table"`.
# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
