### PR TITLE
Handle validation message for accidental .ovr files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,8 @@ Unreleased Changes (3.9.1)
     * Fixed an issue on Mac OS when certain models would loop indefinitely and
       never complete.  This was addressed by bumping the ``taskgraph``
       requirement version to ``0.10.3``
+    * Provide a better validation error message when an overview '.ovr' file
+      is input instead of a valid raster.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -306,6 +306,9 @@ def check_raster(filepath, projected=False, projection_units=None):
 
     if gdal_dataset is None:
         return "File could not be opened as a GDAL raster"
+    # Check that an overview .ovr file wasn't opened.
+    if os.path.splitext(filepath)[1] == '.ovr':
+        return "File found to be an overview '.ovr' file."
 
     srs = osr.SpatialReference()
     srs.ImportFromWkt(gdal_dataset.GetProjection())


### PR DESCRIPTION
# Description
Overview `.ovr` files pose a validation glitch when input instead of a proper `.tif` raster. These files can be opened as a raster but ultimately is invalid and fails when checking projection, because it's empty. 

This PR adds a validation check specifically for `.ovr` files and provides a more useful validation error message.

Fixes #50 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

~~- [ ] Updated the user's guide (if needed)~~
