### PR TITLE
Fixes Datastack bug when saving Windows paths

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,8 @@ Unreleased Changes (3.9.1)
     * Fixed an issue on Mac OS when certain models would loop indefinitely and
       never complete.  This was addressed by bumping the ``taskgraph``
       requirement version to ``0.10.3``
+    * Fixed a bug where saving a datastack parameter set with relative paths
+      would not convert Windows separators to linux style.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -60,7 +60,6 @@ Unreleased Changes (3.9.1)
     * Fixed a bug where, if rate change and discount rate were set to 0, the
       valuation results were in $/year rather than $, too small by a factor of 
       ``lulc_fut_year - lulc_cur_year``.
->>>>>>> main
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -438,10 +438,10 @@ def extract_datastack_archive(datastack_path, dest_dir_path):
 
             # Archives always store linux-style paths.  os.path.normpath
             # converts forward slashes to backslashes if we're on Windows.
-            data_path = os.path.normpath(os.path.join(dest_dir_path,
-                                                      args_param))
+            data_path = os.path.normpath(
+                os.path.join(dest_dir_path, args_param))
             if os.path.exists(data_path):
-                return os.path.normpath(data_path)
+                return data_path
         return args_param
 
     new_args = _rewrite_paths(arguments_dict)
@@ -472,19 +472,23 @@ def build_parameter_set(args, model_name, paramset_path, relative=False):
         elif isinstance(args_param, list):
             return [_recurse(param) for param in args_param]
         elif isinstance(args_param, str):
-            possible_path = args_param.replace('\\', '/')
-            if os.path.exists(possible_path):
-                # Always save unix paths.
-                normalized_path = os.path.normpath(possible_path)
+            normalized_path = os.path.normpath(args_param)
+            if os.path.exists(normalized_path):
                 if relative:
                     # Handle special case where python assumes that '.'
                     # represents the CWD
                     if (normalized_path == '.' or
                             os.path.dirname(paramset_path) == normalized_path):
                         return '.'
-                    return os.path.relpath(normalized_path,
-                                           os.path.dirname(paramset_path))
-                return normalized_path
+                    temp_rel_path = os.path.relpath(
+                        normalized_path, os.path.dirname(paramset_path))
+                    # Always save unix paths.
+                    linux_style_path = temp_rel_path.replace('\\', '/')
+                else:
+                    # Always save unix paths.
+                    linux_style_path = normalized_path.replace('\\', '/')
+
+                return linux_style_path
         return args_param
     parameter_data = {
         'model_name': model_name,

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -472,8 +472,9 @@ def build_parameter_set(args, model_name, paramset_path, relative=False):
         elif isinstance(args_param, list):
             return [_recurse(param) for param in args_param]
         elif isinstance(args_param, str):
-            normalized_path = os.path.normpath(args_param)
-            if os.path.exists(normalized_path):
+            # If args_param is empty string '' os.path.exists will be False
+            if os.path.exists(args_param):
+                normalized_path = os.path.normpath(args_param)
                 if relative:
                     # Handle special case where python assumes that '.'
                     # represents the CWD

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -493,6 +493,8 @@ class DatastacksTest(unittest.TestCase):
                 self.workspace, 'inter_dir', 'inter_inter_dir', 'doh.txt'),
             'data_dir': os.path.join(self.workspace, 'data_dir'),
         }
+        os.makedirs(
+            os.path.join(self.workspace, 'inter_dir', 'inter_inter_dir'))
         modelname = 'natcap.invest.foo'
         paramset_filename = os.path.join(self.workspace, 'paramset.json')
 
@@ -509,8 +511,8 @@ class DatastacksTest(unittest.TestCase):
         raw_args = json.load(open(paramset_filename))['args']
         self.assertEqual(raw_args['foo'], 'foo.txt')
         # Expecting linux style path separators for Windows
-        self.assertEqual(raw_args['bar'], '../bar.txt')
-        self.assertEqual(raw_args['doh'], '../../doh.txt')
+        self.assertEqual(raw_args['bar'], 'inter_dir/bar.txt')
+        self.assertEqual(raw_args['doh'], 'inter_dir/inter_inter_dir/doh.txt')
         self.assertEqual(raw_args['data_dir'], 'data_dir')
 
         # Read back the parameter set and verify the returned paths are

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -657,7 +657,8 @@ class DatastacksTest(unittest.TestCase):
         self.assertEqual(stack_info, datastack.ParameterSet(
             expected_args, datastack.UNKNOWN, datastack.UNKNOWN))
 
-    def test_mixed_path_separators_in_paramset(self):
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_mixed_path_separators_in_paramset_windows(self):
         """Datastacks: parameter sets must handle windows and linux paths."""
         from natcap.invest import datastack
 
@@ -693,6 +694,48 @@ class DatastacksTest(unittest.TestCase):
 
         expected_args = {
             'windows_path': os.path.join(
+                self.workspace, 'dir1', 'filepath1.txt'),
+            'linux_path': os.path.join(
+                self.workspace, 'dir2', 'filepath2.txt'),
+        }
+
+        extracted_paramset = datastack.extract_parameter_set(paramset_path)
+        self.assertEqual(extracted_paramset.args, expected_args)
+
+    @unittest.skipUnless(sys.platform.startswith("darwin"), "requires macOS")
+    def test_mixed_path_separators_in_paramset_mac(self):
+        """Datastacks: parameter sets must handle mac and linux paths."""
+        from natcap.invest import datastack
+
+        args = {
+            'mac_path': os.path.join(
+                self.workspace, 'dir1/filepath1.txt'),
+            'linux_path': os.path.join(
+                self.workspace, 'dir2/filepath2.txt'),
+        }
+        for filepath in args.values():
+            try:
+                os.makedirs(os.path.dirname(filepath))
+            except OSError:
+                pass
+
+            with open(filepath, 'w') as open_file:
+                open_file.write('the contents of this file do not matter.')
+
+        paramset_path = os.path.join(self.workspace, 'paramset.invest.json')
+        datastack.build_parameter_set(
+            args, 'sample_model', paramset_path, relative=True)
+
+        with open(paramset_path) as saved_parameters:
+            args = json.loads(saved_parameters.read())['args']
+            expected_args = {
+                'mac_path': 'dir1/filepath1.txt',
+                'linux_path': 'dir2/filepath2.txt',
+            }
+            self.assertEqual(expected_args, args)
+
+        expected_args = {
+            'mac_path': os.path.join(
                 self.workspace, 'dir1', 'filepath1.txt'),
             'linux_path': os.path.join(
                 self.workspace, 'dir2', 'filepath2.txt'),

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -604,7 +604,9 @@ class DatastacksTest(unittest.TestCase):
         stack_type, stack_info = datastack.get_datastack_info(json_path)
         self.assertEqual(stack_type, 'json')
         self.assertEqual(stack_info, datastack.ParameterSet(
-            params, 'sample_model', natcap.invest.__version__))
+            params, 'sample_model', natcap.invest.__version__),
+            f"stack_info: {stack_info} v. datastack.ParameterSet : "
+            f"{datastack.ParameterSet(params, 'sample_model', natcap.invest.__version__)}")
 
     def test_get_datastack_info_logfile_new_style(self):
         """Datastack: test get datastack info logfile new style."""
@@ -660,10 +662,10 @@ class DatastacksTest(unittest.TestCase):
         from natcap.invest import datastack
 
         args = {
-            'windows_path': os.path.join(self.workspace,
-                                         'dir1\\filepath1.txt'),
-            'linux_path': os.path.join(self.workspace,
-                                       'dir2/filepath2.txt'),
+            'windows_path': os.path.join(
+                self.workspace, 'dir1\\filepath1.txt'),
+            'linux_path': os.path.join(
+                self.workspace, 'dir2/filepath2.txt'),
         }
         for filepath in args.values():
             normalized_path = os.path.normpath(filepath.replace('\\', os.sep))
@@ -676,22 +678,24 @@ class DatastacksTest(unittest.TestCase):
                 open_file.write('the contents of this file do not matter.')
 
         paramset_path = os.path.join(self.workspace, 'paramset.invest.json')
-        datastack.build_parameter_set(args, 'sample_model', paramset_path,
-                                      relative=True)
+        # Windows paths should be saved with linux-style separators
+        datastack.build_parameter_set(
+            args, 'sample_model', paramset_path, relative=True)
 
         with open(paramset_path) as saved_parameters:
             args = json.loads(saved_parameters.read())['args']
+            # Expecting window_path to have linux style line seps
             expected_args = {
-                'windows_path': os.path.join('dir1', 'filepath1.txt'),
-                'linux_path': os.path.join('dir2', 'filepath2.txt'),
+                'windows_path': 'dir1/filepath1.txt',
+                'linux_path': 'dir2/filepath2.txt',
             }
             self.assertEqual(expected_args, args)
 
         expected_args = {
-            'windows_path': os.path.join(self.workspace, 'dir1',
-                                         'filepath1.txt'),
-            'linux_path': os.path.join(self.workspace, 'dir2',
-                                       'filepath2.txt'),
+            'windows_path': os.path.join(
+                self.workspace, 'dir1', 'filepath1.txt'),
+            'linux_path': os.path.join(
+                self.workspace, 'dir2', 'filepath2.txt'),
         }
 
         extracted_paramset = datastack.extract_parameter_set(paramset_path)


### PR DESCRIPTION
# Description
This PR fixes a bug related to saving a Datastack as a parameter set with relative paths under Windows. Windows paths were not being saved using Linux like path separators `/` but were instead saving with the Windows form `\\`. 

Windows paths are now saved with Linux like separators and testing has been updated to check for this change. In particular this PR introduces `@unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")` syntax to the tests. This helps test that Windows path are being saved like we expect, while allowing macOS or `darwin` OS to ignore and run its own version of the test.

Fixes #52

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

~~- [ ] Updated the user's guide (if needed)~~
