### PR TITLE
CV tests sensitive to GEOS changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := b7a51f189315e08484b5ba997a5c1de88ab7f06d
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 6fd5fa39cd9d81080caa7581f9acca7b9fadb7c8
+GIT_TEST_DATA_REPO_REV      := 69ea5fc56906c029bc745e5531b7a4d4e4c13237
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -929,7 +929,6 @@ class CoastalVulnerabilityTests(unittest.TestCase):
                 if 'Must be a polyline vector' in err_strings:
                     raise ValueError(err_list)
 
-    @unittest.skip("Skipping for GEOS 3.9.0 bug.")
     def test_shore_points_on_single_polygon(self):
         """CV: test shore point creation with single polygon landmass."""
         aoi_path = os.path.join(self.workspace_dir, 'aoi.geojson')
@@ -1208,7 +1207,6 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         layer = None
         vector = None
 
-    @unittest.skip("Skipping for GEOS 3.9.0 bug.")
     def test_prepare_landmass_invalid_geometry(self):
         """CV: test handling invalid geometries in landmass vector."""
         aoi_path = os.path.join(self.workspace_dir, 'aoi.geojson')


### PR DESCRIPTION
This PR un-skips some CV tests now that geos has released a patch for a bug that was failing those tests. And our CV regression data is updated to accommodate other geos changes that happened to change the order that CV point features were created. This does not impact the geometry or data, just the order of the features in the layer.

Here's the test data PR: https://bitbucket.org/natcap/invest-test-data/pull-requests/20/updated-regression-data-for-the-complete

Addresses #476 - we should leave this open though, because the geos bugfix did not resolve the failing wave energy tests mentioned in that issue.

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
