### PR TITLE
Enhancement/remote copy duplicate artifact 511

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -58,9 +58,16 @@ Unreleased Changes (3.9.1)
       would not convert Windows separators to linux style.
     * Provide a better validation error message when an overview '.ovr' file
       is input instead of a valid raster.
+    * Removed internal references to ``TaskGraph``
+      ``copy_duplicate_artifact`` calls in anticipation from that feature
+      being removed from ``TaskGraph``. User facing changes include
+      slightly faster initial runtimes for the Coastal Vulnerability,
+      Coastal Blue Carbon, SDR, DelineateIt, and Seasonal Water Yield models.
+      These models will no longer attempt to copy intermediate artifacts that
+      could have been computed by previous runs.
 * Carbon
     * Fixed a bug where, if rate change and discount rate were set to 0, the
-      valuation results were in $/year rather than $, too small by a factor of 
+      valuation results were in $/year rather than $, too small by a factor of
       ``lulc_fut_year - lulc_cur_year``.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -399,8 +399,6 @@ def execute(args):
               [path for (year, path) in sorted(aligned_lulc_paths.items())],
               ['near']*len(aligned_lulc_paths),
               target_pixel_size, 'intersection'),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=aligned_lulc_paths.values(),
         task_name='Align input landcover rasters.')
 

--- a/src/natcap/invest/coastal_blue_carbon/preprocessor.py
+++ b/src/natcap/invest/coastal_blue_carbon/preprocessor.py
@@ -122,8 +122,6 @@ def execute(args):
               (min_pixel_size, -min_pixel_size),
               'intersection'),
         kwargs={'target_projection_wkt': baseline_srs_wkt},
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=aligned_snapshot_paths,
         task_name='Align input landcover rasters')
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -252,12 +252,12 @@ def execute(args):
             The radius in meters around each shore point in which to compute
             the average elevation.
         args['habitat_table_path'] (string): (required) path to a CSV file with
-            the following four fields: 
+            the following four fields:
             'id': unique string to represent each habitat;
             'path': absolute or relative path to a polygon vector;
-            'rank': integer from 1 to 5 representing the relative 
+            'rank': integer from 1 to 5 representing the relative
             protection offered by this habitat;
-            'protection distance (m)': integer or float used as a search 
+            'protection distance (m)': integer or float used as a search
             radius around each shore point.
         args['geomorphology_vector_path'] (string): (optional) path to a
             polyline vector that has a field called "RANK" with values from
@@ -348,8 +348,6 @@ def execute(args):
         args=(args['landmass_vector_path'], aoi_bounding_box,
               aoi_srs_wkt, tmp_clipped_path, clipped_landmass_path),
         target_path_list=[clipped_landmass_path, tmp_clipped_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[],
         task_name='clip landmass to aoi')
 
@@ -361,8 +359,6 @@ def execute(args):
               aoi_bounding_box, model_resolution, wind_wave_dir,
               file_suffix, target_bathy_raster_path),
         target_path_list=[target_bathy_raster_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[],
         task_name='prepare bathymetry')
 
@@ -385,8 +381,6 @@ def execute(args):
             shore_point_vector_path, target_polygon_pickle_path,
             target_lines_pickle_path],
         ignore_path_list=[target_rtree_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[clip_landmass_to_aoi_task],
         task_name='index landmass geometry and interpolate shore points')
 
@@ -409,8 +403,6 @@ def execute(args):
         args=(shore_point_vector_path, args['wwiii_vector_path'],
               target_wwiii_point_vector_path),
         target_path_list=[target_wwiii_point_vector_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[handle_landmass_geom_and_shore_points_task],
         priority=10,  # the longest running task is dependent on this one.
         task_name='interpolate wwiii to shore points')
@@ -435,8 +427,6 @@ def execute(args):
                           target_fetch_rays_path,
                           target_wind_exposure_pickle_path],
         ignore_path_list=[target_rtree_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[
             interpolate_wwiii_task, prepare_bathymetry_task],
         priority=10,  # start this long task as early as possible.
@@ -456,8 +446,6 @@ def execute(args):
               target_wave_exposure_path),
         target_path_list=[target_wave_exposure_path,
                           intermediate_wave_vector_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[wind_exposure_task],
         task_name='calculate wave exposure'))
 
@@ -470,8 +458,6 @@ def execute(args):
         args=(shore_point_vector_path, args['shelf_contour_vector_path'],
               target_surge_exposure_path),
         target_path_list=[target_surge_exposure_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[handle_landmass_geom_and_shore_points_task],
         task_name='calculate surge exposure'))
 
@@ -485,8 +471,6 @@ def execute(args):
               float(args['dem_averaging_radius']), model_resolution,
               relief_dir, file_suffix, relief_point_pickle_path),
         target_path_list=[relief_point_pickle_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[handle_landmass_geom_and_shore_points_task],
         task_name='calculate relief exposure'))
 
@@ -504,8 +488,6 @@ def execute(args):
         args=(hab_targets_list,
               target_habitat_protection_path),
         target_path_list=[target_habitat_protection_path],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=hab_tasks_list,
         task_name='calculate habitat protection'))
 
@@ -520,8 +502,6 @@ def execute(args):
             args=(args['geomorphology_vector_path'], target_srs_wkt,
                   projected_geomorphology_vector_path),
             target_path_list=[projected_geomorphology_vector_path],
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             task_name='project geomorphology input')
 
         target_geomorphology_pickle_path = os.path.join(
@@ -538,8 +518,6 @@ def execute(args):
                   target_geomorphology_pickle_path, target_missing_data_path),
             target_path_list=[
                 target_geomorphology_pickle_path],
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             dependent_task_list=[handle_landmass_geom_and_shore_points_task, project_geomorph_task],
             task_name='calculate geomorphology exposure'))
 
@@ -553,8 +531,6 @@ def execute(args):
             args=(shore_point_vector_path, args['slr_vector_path'],
                   args['slr_field'], target_slr_pickle_path),
             target_path_list=[target_slr_pickle_path],
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             dependent_task_list=[handle_landmass_geom_and_shore_points_task],
             task_name='interpolate sea-level rise values'))
 
@@ -570,8 +546,6 @@ def execute(args):
                   float(args['population_radius']), model_resolution,
                   population_dir, file_suffix, target_population_pickle_path),
             target_path_list=[target_population_pickle_path],
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             dependent_task_list=[handle_landmass_geom_and_shore_points_task],
             task_name='aggregate population raster'))
 
@@ -1829,8 +1803,6 @@ def _schedule_habitat_tasks(
                   base_habitat_path,
                   target_habitat_pickle_path),
             target_path_list=[target_habitat_pickle_path],
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             task_name='searching for %s' % habitat_row.id))
 
     return habitat_task_list, habitat_pickles_list
@@ -1983,7 +1955,7 @@ def calculate_habitat_rank(
         habitat_pickle_list (list): list of file paths to pickled dictionaries
             in the form of: {'habitat_id': {<id0>: 5, <id1>.: 5, <id2>: 5}}
         target_habitat_protection_path (string): path to a csv file with a row
-            for each shore point, and a header like: 
+            for each shore point, and a header like:
             'fid','kelp','eelgrass','coral','R_hab'
 
     Returns:
@@ -2167,7 +2139,7 @@ def assemble_results_and_calculate_exposure(
                 1. string: path to pickle with intermediate
                     exposure values for a single variable
                 2. bool: if True, variable contains values that need binning
-                    by percentile to convert to 1-5 ranks. If False, variable 
+                    by percentile to convert to 1-5 ranks. If False, variable
                     is already on the 1-5 rank scale.
                 3. string: This variable is used as the fieldname in
                     target_output_vector_path. And if the string includes

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -155,7 +155,7 @@ def execute(args):
             'Working with the DEM' section of the InVEST User's Guide for more
             information. (required)
         args['outlet_vector_path'] (string):  This is a vector representing
-            geometries that the watersheds should be built around. Required if 
+            geometries that the watersheds should be built around. Required if
             ``args['detect_pour_points']`` is False; not used otherwise.
         args['snap_points'] (bool): Whether to snap point geometries to the
             nearest stream pixel.  If ``True``, ``args['flow_threshold']``
@@ -172,7 +172,7 @@ def execute(args):
             found.  If ``True``, invalid geometries will be left out of
             the vector to be delineated.  Default: True
         args['detect_pour_points'] (bool): Whether to run the pour point
-            detection algorithm. If True, detected pour points are used instead 
+            detection algorithm. If True, detected pour points are used instead
             of outlet_vector_path geometries. Default: False
         args['n_workers'] (int): The number of worker processes to use with
             taskgraph. Defaults to -1 (no parallelism).
@@ -207,9 +207,7 @@ def execute(args):
               file_registry['filled_dem']),
         kwargs={'working_dir': output_directory},
         target_path_list=[file_registry['filled_dem']],
-        task_name='fill_pits',
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True)
+        task_name='fill_pits')
 
     flow_dir_task = graph.add_task(
         pygeoprocessing.routing.flow_dir_d8,
@@ -218,9 +216,7 @@ def execute(args):
         kwargs={'working_dir': output_directory},
         target_path_list=[file_registry['flow_dir_d8']],
         dependent_task_list=[fill_pits_task],
-        task_name='flow_direction',
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True)
+        task_name='flow_direction')
 
     if 'detect_pour_points' in args and args['detect_pour_points']:
         # Detect pour points automatically and use them instead of
@@ -231,9 +227,7 @@ def execute(args):
                   file_registry['pour_points']),
             dependent_task_list=[flow_dir_task],
             target_path_list=[file_registry['pour_points']],
-            task_name='detect_pour_points',
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True)
+            task_name='detect_pour_points')
         outlet_vector_path = file_registry['pour_points']
         geometry_task = pour_points_task
     else:
@@ -245,9 +239,7 @@ def execute(args):
                   args.get('skip_invalid_geometry', True)),
             dependent_task_list=[fill_pits_task],
             target_path_list=[file_registry['preprocessed_geometries']],
-            task_name='check_geometries',
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True)
+            task_name='check_geometries')
         outlet_vector_path = file_registry['preprocessed_geometries']
         geometry_task = check_geometries_task
 
@@ -281,9 +273,7 @@ def execute(args):
                   out_nodata),
             target_path_list=[file_registry['streams']],
             dependent_task_list=[flow_accumulation_task],
-            task_name='threshold_streams',
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True)
+            task_name='threshold_streams')
 
         snapped_outflow_points_task = graph.add_task(
             snap_points_to_nearest_stream,
@@ -293,9 +283,7 @@ def execute(args):
                   file_registry['snapped_outlets']),
             target_path_list=[file_registry['snapped_outlets']],
             dependent_task_list=[streams_task, geometry_task],
-            task_name='snapped_outflow_points',
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True)
+            task_name='snapped_outflow_points')
         delineation_dependent_tasks.append(snapped_outflow_points_task)
         outlet_vector_path = file_registry['snapped_outlets']
 
@@ -310,9 +298,7 @@ def execute(args):
                         os.path.basename(file_registry['watersheds']))[0]},
         target_path_list=[file_registry['watersheds']],
         dependent_task_list=delineation_dependent_tasks,
-        task_name='delineate_watersheds_single_worker',
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True)
+        task_name='delineate_watersheds_single_worker')
 
     graph.close()
     graph.join()
@@ -647,7 +633,7 @@ def detect_pour_points(flow_dir_raster_path_band, target_vector_path):
                 321
                 4x0
                 567
-                
+
         target_vector_path (string): path to save pour point vector to.
 
     Returns:
@@ -692,7 +678,7 @@ def detect_pour_points(flow_dir_raster_path_band, target_vector_path):
 def _find_raster_pour_points(flow_dir_raster_path_band):
     """
     Memory-safe pour point calculation from a flow direction raster.
-    
+
     Args:
         flow_dir_raster_path_band (tuple): tuple of (raster path, band index)
             indicating the flow direction raster to use.
@@ -714,9 +700,9 @@ def _find_raster_pour_points(flow_dir_raster_path_band):
     pour_points = set()
     # Read in flow direction data and find pour points one block at a time
     for offsets in pygeoprocessing.iterblocks((flow_dir_raster_path, band_index),
-                                               offset_only=True): 
-        # Expand each block by a one-pixel-wide margin, if possible. 
-        # This way the blocks will overlap so the watershed 
+                                               offset_only=True):
+        # Expand each block by a one-pixel-wide margin, if possible.
+        # This way the blocks will overlap so the watershed
         # calculation will be continuous.
         if offsets['xoff'] > 0:
             offsets['xoff'] -= 1
@@ -740,17 +726,17 @@ def _find_raster_pour_points(flow_dir_raster_path_band):
         flow_dir_block = band.ReadAsArray(**offsets)
         pour_points = pour_points.union(
             delineateit_core.calculate_pour_point_array(
-                # numpy.intc is equivalent to an int in C (normally int32 or 
-                # int64). This way it can be passed directly into a memoryview 
+                # numpy.intc is equivalent to an int in C (normally int32 or
+                # int64). This way it can be passed directly into a memoryview
                 # (int[:, :]) in the Cython function.
-                flow_dir_block.astype(numpy.intc), 
-                edges, 
+                flow_dir_block.astype(numpy.intc),
+                edges,
                 nodata=raster_info['nodata'][band_index - 1],
                 offset=(offsets['xoff'], offsets['yoff']),
-                origin=(raster_info['geotransform'][0], 
+                origin=(raster_info['geotransform'][0],
                         raster_info['geotransform'][3]),
                 pixel_size=raster_info['pixel_size']))
-            
+
     raster = None
     band = None
 

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -340,8 +340,6 @@ def execute(args):
             'raster_align_index': 0,
             'vector_mask_options': vector_mask_options,
             },
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=aligned_list,
         task_name='align input rasters')
 
@@ -350,8 +348,6 @@ def execute(args):
         args=(
             (f_reg['aligned_dem_path'], 1),
             f_reg['pit_filled_dem_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['pit_filled_dem_path']],
         dependent_task_list=[align_task],
         task_name='fill pits')
@@ -361,8 +357,6 @@ def execute(args):
         args=(
             (f_reg['pit_filled_dem_path'], 1),
             f_reg['slope_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[pit_fill_task],
         target_path_list=[f_reg['slope_path']],
         task_name='calculate slope')
@@ -370,8 +364,6 @@ def execute(args):
     threshold_slope_task = task_graph.add_task(
         func=_threshold_slope,
         args=(f_reg['slope_path'], f_reg['thresholded_slope_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['thresholded_slope_path']],
         dependent_task_list=[slope_task],
         task_name='threshold slope')
@@ -381,8 +373,6 @@ def execute(args):
         args=(
             (f_reg['pit_filled_dem_path'], 1),
             f_reg['flow_direction_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['flow_direction_path']],
         dependent_task_list=[pit_fill_task],
         task_name='flow direction calculation')
@@ -391,8 +381,6 @@ def execute(args):
         func=sdr_core.calculate_average_aspect,
         args=(f_reg['flow_direction_path'],
               f_reg['weighted_avg_aspect_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['weighted_avg_aspect_path']],
         dependent_task_list=[flow_dir_task],
         task_name='weighted average of multiple-flow aspects')
@@ -402,8 +390,6 @@ def execute(args):
         args=(
             (f_reg['flow_direction_path'], 1),
             f_reg['flow_accumulation_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['flow_accumulation_path']],
         dependent_task_list=[flow_dir_task],
         task_name='flow accumulation calculation')
@@ -415,8 +401,6 @@ def execute(args):
             f_reg['slope_path'],
             f_reg['weighted_avg_aspect_path'],
             f_reg['ls_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['ls_path']],
         dependent_task_list=[
             flow_accumulation_task, slope_task,
@@ -430,8 +414,6 @@ def execute(args):
             (f_reg['flow_direction_path'], 1),
             float(args['threshold_flow_accumulation']),
             f_reg['stream_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         kwargs={'trace_threshold_proportion': 0.7},
         target_path_list=[f_reg['stream_path']],
         dependent_task_list=[flow_accumulation_task],
@@ -443,8 +425,6 @@ def execute(args):
                 f_reg['stream_path'],
                 f_reg['aligned_drainage_path'],
                 f_reg['stream_and_drainage_path']),
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             target_path_list=[f_reg['stream_and_drainage_path']],
             dependent_task_list=[stream_task, align_task],
             task_name='add drainage')
@@ -458,8 +438,6 @@ def execute(args):
         args=(
             biophysical_table, f_reg['aligned_lulc_path'], f_reg['w_path'],
             f_reg['thresholded_w_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['w_path'], f_reg['thresholded_w_path']],
         dependent_task_list=[align_task],
         task_name='calculate W')
@@ -469,8 +447,6 @@ def execute(args):
         args=(
             biophysical_table, f_reg['aligned_lulc_path'],
             f_reg['cp_factor_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['cp_factor_path']],
         dependent_task_list=[align_task],
         task_name='calculate CP')
@@ -483,8 +459,6 @@ def execute(args):
             f_reg['aligned_erodibility_path'],
             drainage_raster_path_task[0],
             f_reg['rkls_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['rkls_path']],
         dependent_task_list=[
             align_task, drainage_raster_path_task[1], ls_factor_task],
@@ -497,8 +471,6 @@ def execute(args):
             f_reg['cp_factor_path'],
             drainage_raster_path_task[0],
             f_reg['usle_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['usle_path']],
         dependent_task_list=[
             rkls_task, cp_task, drainage_raster_path_task[1]],
@@ -520,8 +492,6 @@ def execute(args):
                 f_reg['flow_direction_path'], factor_path,
                 f_reg['flow_accumulation_path'],
                 accumulation_path, out_bar_path),
-            hash_algorithm='md5',
-            copy_duplicate_artifact=True,
             target_path_list=[accumulation_path, out_bar_path],
             dependent_task_list=[
                 align_task, factor_task, flow_accumulation_task,
@@ -535,8 +505,6 @@ def execute(args):
             f_reg['w_bar_path'], f_reg['s_bar_path'],
             f_reg['flow_accumulation_path'], f_reg['d_up_path']),
         target_path_list=[f_reg['d_up_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[
             bar_task_map['s_bar'], bar_task_map['w_bar'],
             flow_accumulation_task],
@@ -548,8 +516,6 @@ def execute(args):
             f_reg['thresholded_slope_path'], f_reg['thresholded_w_path'],
             f_reg['ws_inverse_path']),
         target_path_list=[f_reg['ws_inverse_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[threshold_slope_task, threshold_w_task],
         task_name='calculate inverse ws factor')
 
@@ -561,8 +527,6 @@ def execute(args):
             f_reg['d_dn_path']),
         kwargs={'weight_raster_path_band': (f_reg['ws_inverse_path'], 1)},
         target_path_list=[f_reg['d_dn_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[
             flow_dir_task, drainage_raster_path_task[1],
             inverse_ws_factor_task],
@@ -573,8 +537,6 @@ def execute(args):
         args=(
             f_reg['d_up_path'], f_reg['d_dn_path'], f_reg['ic_path']),
         target_path_list=[f_reg['ic_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[d_up_task, d_dn_task],
         task_name='calculate ic')
 
@@ -584,8 +546,6 @@ def execute(args):
             float(args['k_param']), float(args['ic_0_param']),
             float(args['sdr_max']), f_reg['ic_path'],
             drainage_raster_path_task[0], f_reg['sdr_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['sdr_path']],
         dependent_task_list=[ic_task],
         task_name='calculate sdr')
@@ -594,8 +554,6 @@ def execute(args):
         func=_calculate_sed_export,
         args=(
             f_reg['usle_path'], f_reg['sdr_path'], f_reg['sed_export_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['sed_export_path']],
         dependent_task_list=[usle_task, sdr_task],
         task_name='calculate sed export')
@@ -604,8 +562,6 @@ def execute(args):
         func=_calculate_e_prime,
         args=(
             f_reg['usle_path'], f_reg['sdr_path'], f_reg['e_prime_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['e_prime_path']],
         dependent_task_list=[usle_task, sdr_task],
         task_name='calculate export prime')
@@ -617,8 +573,6 @@ def execute(args):
             f_reg['f_path'], f_reg['sdr_path'],
             f_reg['sed_deposition_path']),
         dependent_task_list=[e_prime_task, sdr_task, flow_dir_task],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['sed_deposition_path']],
         task_name='sediment deposition')
 
@@ -627,8 +581,6 @@ def execute(args):
         args=(
             f_reg['rkls_path'], f_reg['usle_path'], f_reg['sdr_path'],
             float(args['sdr_max']), f_reg['sed_retention_index_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['sed_retention_index_path']],
         dependent_task_list=[rkls_task, usle_task, sdr_task],
         task_name='calculate sediment retention index')
@@ -637,8 +589,6 @@ def execute(args):
     s_inverse_task = task_graph.add_task(
         func=_calculate_inverse_s_factor,
         args=(f_reg['thresholded_slope_path'], f_reg['s_inverse_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['s_inverse_path']],
         dependent_task_list=[threshold_slope_task],
         task_name='calculate S factor')
@@ -650,8 +600,6 @@ def execute(args):
             (drainage_raster_path_task[0], 1),
             f_reg['d_dn_bare_soil_path']),
         kwargs={'weight_raster_path_band': (f_reg['s_inverse_path'], 1)},
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['d_dn_bare_soil_path']],
         dependent_task_list=[
             flow_dir_task, drainage_raster_path_task[1], s_inverse_task],
@@ -663,8 +611,6 @@ def execute(args):
             f_reg['s_bar_path'], f_reg['flow_accumulation_path'],
             f_reg['d_up_bare_soil_path']),
         target_path_list=[f_reg['d_up_bare_soil_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[bar_task_map['s_bar'], flow_accumulation_task],
         task_name='calculating d_up bare soil')
 
@@ -674,8 +620,6 @@ def execute(args):
             f_reg['d_up_bare_soil_path'], f_reg['d_dn_bare_soil_path'],
             f_reg['ic_bare_soil_path']),
         target_path_list=[f_reg['ic_bare_soil_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[d_up_bare_task, d_dn_bare_task],
         task_name='calculate bare soil ic')
 
@@ -686,8 +630,6 @@ def execute(args):
             float(args['sdr_max']), f_reg['ic_bare_soil_path'],
             drainage_raster_path_task[0], f_reg['sdr_bare_soil_path']),
         target_path_list=[f_reg['sdr_bare_soil_path']],
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         dependent_task_list=[ic_bare_task, drainage_raster_path_task[1]],
         task_name='calculate bare SDR')
 
@@ -697,8 +639,6 @@ def execute(args):
             f_reg['rkls_path'], f_reg['usle_path'],
             drainage_raster_path_task[0], f_reg['sdr_path'],
             f_reg['sdr_bare_soil_path'], f_reg['sed_retention_path']),
-        hash_algorithm='md5',
-        copy_duplicate_artifact=True,
         target_path_list=[f_reg['sed_retention_path']],
         dependent_task_list=[
             rkls_task, usle_task, drainage_raster_path_task[1], sdr_task,

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -627,8 +627,6 @@ def _execute(args):
                     target_path_list=[
                         file_registry['n_events_path_list'][month_id]],
                     dependent_task_list=[align_task],
-                    hash_algorithm='md5',
-                    copy_duplicate_artifact=True,
                     task_name=(
                         'n_events as a constant raster month %d' % month_id))
                 reclassify_n_events_task_list.append(n_events_task)
@@ -670,8 +668,6 @@ def _execute(args):
                 dependent_task_list=[
                     align_task, reclassify_n_events_task_list[month_index],
                     si_task, stream_threshold_task],
-                hash_algorithm='md5',
-                copy_duplicate_artifact=True,
                 task_name='calculate quick flow for month %d' % (
                     month_index+1))
             quick_flow_task_list.append(monthly_quick_flow_task)
@@ -701,8 +697,6 @@ def _execute(args):
                     gdal.GDT_Float32, kc_nodata, reclass_error_details),
                 target_path_list=[file_registry['kc_path_list'][month_index]],
                 dependent_task_list=[align_task],
-                hash_algorithm='md5',
-                copy_duplicate_artifact=True,
                 task_name='classify kc month %d' % month_index)
             kc_task_list.append(kc_task)
 


### PR DESCRIPTION
# Removes references to ``copy_duplicate_artifact`` when invoking TaskGraph ``add_task`` calls. This is to prepare for the removal of that functionality in a future TaskGraph release.

Fixes #511 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) (not needed)
