### PR TITLE
Fixes nodata masking for SWY qf.tif output

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -72,6 +72,9 @@ Unreleased Changes (3.9.1)
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.
+* Seasonal Water Yield
+    * Fixed a bug where ``qf.tif`` outputs weren't properly masking nodata 
+      values and could show negative numbers.
 * SDR
     * Fixed a bug in validation that did not warn against different coordinate
       systems (all SDR inputs must share a common coordinate system).

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -916,6 +916,10 @@ def _calculate_monthly_quick_flow(
             valid_mask &= ~numpy.isclose(p_im, p_nodata)
         if n_events_nodata is not None:
             valid_mask &= ~numpy.isclose(n_events, n_events_nodata)
+        # stream_nodata is the only input that carry over nodata values from
+        # the aligned DEM.
+        if stream_nodata is not None:
+            valid_mask &= ~numpy.isclose(stream_array, stream_nodata)
 
         valid_n_events = n_events[valid_mask]
         valid_si = s_i[valid_mask]


### PR DESCRIPTION
# Description
A user was seeing some negative values (-11) in their `qf.tif` output. On examining it looked like these values were on the edges where the DEM was `nodata`. This PR fixes a nodata masking issue where during `qf` computation `streams` were not being used to mask out nodata values. In this case `streams` was the only input that would have had the DEM nodata values. So, we don't want values where the DEM didn't exist.

Fixes #470 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

~~- [ ] Updated the user's guide (if needed)~~
