### PR TITLE
Bugfix/479 delineateit fix optional inputs interactivity

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,7 @@ Unreleased Changes (3.9.1)
       ``POINT`` geometries.  All other geometric types will not be snapped.
       When a geometry cannot be snapped, a log message is now recorded with the
       feature ID, the geometry type and the number of component geometries.
+      Features with empty geometries are now also skipped.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@
   - Coastal Blue Carbon
   - Coastal Vulnerability
   - Crop Production
-  - Delineateit
+  - DelineateIt
   - Finfish
   - Fisheries
   - Forest Carbon Edge Effects
@@ -60,8 +60,16 @@ Unreleased Changes (3.9.1)
       is input instead of a valid raster.
 * Carbon
     * Fixed a bug where, if rate change and discount rate were set to 0, the
-      valuation results were in $/year rather than $, too small by a factor of 
+      valuation results were in $/year rather than $, too small by a factor of
       ``lulc_fut_year - lulc_cur_year``.
+* DelineateIt:
+    * The DelineateIt UI has been updated so that the point-snapping options
+      will always be interactive.
+    * DelineateIt's point-snapping routine has been updated to snap
+      ``MULTIPOINT`` geometries with 1 component point as well as primitive
+      ``POINT`` geometries.  All other geometric types will not be snapped.
+      When a geometry cannot be snapped, a log message is now recorded with the
+      feature ID, the geometry type and the number of component geometries.
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 69ea5fc56906c029bc745e5531b7a4d4e4c13237
 
 GIT_UG_REPO                  := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH             := doc/users-guide
-GIT_UG_REPO_REV              := bbfa26dc0c9158d13d209c1bc61448a9166708da
+GIT_UG_REPO_REV              := 69993168d50422593a39ea5b47cc87e8b94122a1
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)
@@ -162,10 +162,10 @@ $(BUILD_DIR) $(DATA_DIR) $(DIST_DIR) $(DIST_DATA_DIR):
 
 test: $(GIT_TEST_DATA_REPO_PATH)
 	$(TESTRUNNER) tests
-	
+
 test_ui: $(GIT_TEST_DATA_REPO_PATH)
 	$(TESTRUNNER) ui_tests
-	
+
 validate_sampledata: $(GIT_SAMPLE_DATA_REPO_PATH)
 	$(TEST_DATAVALIDATOR)
 	$(DATAVALIDATOR)

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -564,7 +564,7 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
 
         # If the geometry is not a primitive point, just create the new feature
         # as it is now in the new vector.
-        if ((geom_name != 'POINT') or
+        if ((geom_name not in ('POINT', 'MULTIPOINT')) or
                 (geom_name == 'MULTIPOINT' and geom_count > 1)):
             LOGGER.debug(f"Feature {point_feature.GetFID()} is of type "
                          "{geom_name} and cannot be snapped to a stream.")

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -687,9 +687,6 @@ def _find_raster_pour_points(flow_dir_raster_path_band):
     raster_info = pygeoprocessing.get_raster_info(flow_dir_raster_path)
     # Open the flow direction raster band
     raster = gdal.OpenEx(flow_dir_raster_path, gdal.OF_RASTER)
-    if raster is None:
-        raise ValueError(
-            "Raster at %s could not be opened." % flow_dir_raster_path)
     band = raster.GetRasterBand(band_index)
     width, height = raster_info['raster_size']
 

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -566,8 +566,9 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         # as it is now in the new vector.
         if ((geom_name not in ('POINT', 'MULTIPOINT')) or
                 (geom_name == 'MULTIPOINT' and geom_count > 1)):
-            LOGGER.debug(f"Feature {point_feature.GetFID()} is of type "
-                         "{geom_name} and cannot be snapped to a stream.")
+            LOGGER.debug(
+                f"FID {point_feature.GetFID()} ({geom_name}, n={geom_count}) "
+                "only primitive points can be snapped to a stream.")
             new_feature = ogr.Feature(snapped_layer.GetLayerDefn())
             new_feature.SetGeometry(source_geometry)
             for field_name, field_value in point_feature.items().items():
@@ -583,9 +584,9 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         y_index = (point.y - geotransform[3]) // geotransform[5]
         if (x_index < 0 or x_index > n_cols or
                 y_index < 0 or y_index > n_rows):
-            LOGGER.warning('Encountered a point that was outside the bounds of '
-                        'the stream raster.  FID:%s at %s',
-                        point_feature.GetFID(), point)
+            LOGGER.warning(
+                'Encountered a point that was outside the bounds of the '
+                f'stream raster.  FID:{point_feature.GetFID()} at {point}')
             continue
 
         x_center = x_index

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -318,33 +318,6 @@ def execute(args):
     graph.join()
 
 
-def _vector_may_contain_points(vector_path, layer_id=0):
-    """Test if a vector layer may contain points.
-
-    This function is intended to be used by the InVEST UI only.
-
-    Args:
-        vector_path (string): The path to a vector on disk.
-        layer_id=0 (int or string): The ID or name of the layer to check.
-
-    Returns:
-        A ``bool`` indicating whether a vector contains points.  ``False`` if
-        the vector cannot be opened at all or if the layer is invalid.
-
-    """
-    vector = gdal.OpenEx(vector_path, gdal.OF_VECTOR)
-    if vector is None:
-        return False
-
-    layer = vector.GetLayer(layer_id)
-    if layer is None:
-        return False
-
-    if layer.GetGeomType() in (ogr.wkbPoint, ogr.wkbUnknown):
-        return True
-    return False
-
-
 def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
     """Identify stream pixels based on a user-defined threshold.
 

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -547,7 +547,8 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
 
         point = shapely.wkb.loads(source_geometry.ExportToWkb())
         if geom_name == 'MULTIPOINT':
-            point = point.geoms[0]  # take the first geometry of the multipoint
+            # We already checked (above) that there's only one component point
+            point = point.geoms[0]
 
         x_index = (point.x - geotransform[0]) // geotransform[1]
         y_index = (point.y - geotransform[3]) // geotransform[5]

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -542,7 +542,7 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         # OGR's wkbMultiPoint, wkbMultiPointM, wkbMultiPointZM and
         # wkbMultiPoint25D all use the MULTIPOINT geometry name.
         if ((geom_name not in ('POINT', 'MULTIPOINT')) or
-                (geom_name == 'MULTIPOINT' and geom_count > 1)):
+                (geom_name == 'MULTIPOINT' and geom_count != 1)):
             LOGGER.debug(
                 f"FID {point_feature.GetFID()} ({geom_name}, n={geom_count}) "
                 "only primitive points can be snapped to a stream.")

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -442,13 +442,14 @@ def check_geometries(outlet_vector_path, dem_path, target_vector_path,
                 continue
 
         if shapely_geom.is_empty:
-            LOGGER.warning('Feature %s has no geometry. Skipping', feature.GetFID())
+            LOGGER.warning(
+                'Feature %s has no geometry. Skipping', feature.GetFID())
             continue
 
         shapely_bbox = shapely.geometry.box(*shapely_geom.bounds)
         if not dem_bbox.intersects(shapely_bbox):
             LOGGER.warning('Feature %s does not intersect the DEM. Skipping.',
-                         feature.GetFID())
+                           feature.GetFID())
             continue
 
         simplified_geometry = shapely_geom.simplify(nyquist_limit)
@@ -536,7 +537,10 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         geom_count = source_geometry.GetGeometryCount()
 
         # If the geometry is not a primitive point, just create the new feature
-        # as it is now in the new vector.
+        # as it is now in the new vector. MULTIPOINT geometries with a single
+        # component point count as primitive points.
+        # OGR's wkbMultiPoint, wkbMultiPointM, wkbMultiPointZM and
+        # wkbMultiPoint25D all use the MULTIPOINT geometry name.
         if ((geom_name not in ('POINT', 'MULTIPOINT')) or
                 (geom_name == 'MULTIPOINT' and geom_count > 1)):
             LOGGER.debug(
@@ -693,7 +697,7 @@ def _find_raster_pour_points(flow_dir_raster_path_band):
     pour_points = set()
     # Read in flow direction data and find pour points one block at a time
     for offsets in pygeoprocessing.iterblocks((flow_dir_raster_path, band_index),
-                                               offset_only=True):
+                                              offset_only=True):
         # Expand each block by a one-pixel-wide margin, if possible.
         # This way the blocks will overlap so the watershed
         # calculation will be continuous.

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -535,9 +535,9 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         # wkbMultiPoint25D all use the MULTIPOINT geometry name.
         if ((geom_name not in ('POINT', 'MULTIPOINT')) or
                 (geom_name == 'MULTIPOINT' and geom_count > 1)):
-            LOGGER.debug(
+            LOGGER.warning(
                 f"FID {point_feature.GetFID()} ({geom_name}, n={geom_count}) "
-                "only primitive points can be snapped to a stream.")
+                "Geometry cannot be snapped.")
             new_feature = ogr.Feature(snapped_layer.GetLayerDefn())
             new_feature.SetGeometry(source_geometry)
             for field_name, field_value in point_feature.items().items():

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -536,13 +536,19 @@ def snap_points_to_nearest_stream(points_vector_path, stream_raster_path_band,
         geom_name = source_geometry.GetGeometryName()
         geom_count = source_geometry.GetGeometryCount()
 
+        if source_geometry.IsEmpty():
+            LOGGER.warning(
+                f"FID {point_feature.GetFID()} is missing a defined geometry. "
+                "Skipping.")
+            continue
+
         # If the geometry is not a primitive point, just create the new feature
         # as it is now in the new vector. MULTIPOINT geometries with a single
         # component point count as primitive points.
         # OGR's wkbMultiPoint, wkbMultiPointM, wkbMultiPointZM and
         # wkbMultiPoint25D all use the MULTIPOINT geometry name.
         if ((geom_name not in ('POINT', 'MULTIPOINT')) or
-                (geom_name == 'MULTIPOINT' and geom_count != 1)):
+                (geom_name == 'MULTIPOINT' and geom_count > 1)):
             LOGGER.debug(
                 f"FID {point_feature.GetFID()} ({geom_name}, n={geom_count}) "
                 "only primitive points can be snapped to a stream.")

--- a/src/natcap/invest/ui/delineateit.py
+++ b/src/natcap/invest/ui/delineateit.py
@@ -41,8 +41,6 @@ class Delineateit(model.InVESTModel):
             label='Outlet Features (Vector)',
             validator=self.validator)
         self.add_input(self.outlet_vector_path)
-        self.outlet_vector_path.value_changed.connect(
-            self._enable_point_snapping_container)
         self.skip_invalid_geometry = inputs.Checkbox(
             args_key='skip_invalid_geometry',
             helptext=(
@@ -58,7 +56,6 @@ class Delineateit(model.InVESTModel):
             label='Snap points to the nearest stream',
             expandable=True,
             expanded=False,
-            interactive=False,
             args_key='snap_points')
         self.add_input(self.snap_points_container)
         self.flow_threshold = inputs.Text(
@@ -89,15 +86,6 @@ class Delineateit(model.InVESTModel):
         """Change interactivity of other inputs given boolean signal value"""
         self.outlet_vector_path.set_interactive(not value)
         self.skip_invalid_geometry.set_interactive(not value)
-        self.snap_points_container.set_interactive(value)
-
-    def _enable_point_snapping_container(self, input_valid):
-        outlet_vector_path = self.outlet_vector_path.value()
-        if delineateit._vector_may_contain_points(outlet_vector_path):
-            self.snap_points_container.set_interactive(True)
-        else:
-            self.snap_points_container.set_interactive(False)
-            self.snap_points_container.expanded = False
 
     def assemble_args(self):
         args = {
@@ -117,6 +105,5 @@ class Delineateit(model.InVESTModel):
         # To avoid this, only include it if it's going to be used.
         if self.detect_pour_points.value() == False:
             args[self.outlet_vector_path.args_key] = self.outlet_vector_path.value()
-
 
         return args

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -346,6 +346,7 @@ class DelineateItTests(unittest.TestCase):
         self.assertTrue(numpy.isclose(points[1][1], expected_points[1][1]))
 
     def test_calculate_pour_point_array(self):
+        """DelineateIt: Extract pour points."""
         from natcap.invest.delineateit import delineateit, delineateit_core
 
         a = 100  # nodata value

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -356,6 +356,7 @@ class DelineateItTests(unittest.TestCase):
         target_vector = None
 
     def test_detect_pour_points(self):
+        """DelineateIt: low-level test for pour point detection."""
         from natcap.invest.delineateit import delineateit
 
         # create a flow direction raster from the sample DEM
@@ -415,6 +416,7 @@ class DelineateItTests(unittest.TestCase):
             expected_pour_points))
 
     def test_find_pour_points_by_block(self):
+        """DelineateIt: test pour point detection against block edges."""
         from natcap.invest.delineateit import delineateit
 
         a = 100  # nodata value

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -208,44 +208,6 @@ class DelineateItTests(unittest.TestCase):
             self.assertTrue(shapely_feature.equals(expected_geom))
             self.assertEqual(expected_fields, feature.items())
 
-    def test_vector_may_contain_points(self):
-        """DelineateIt: Check whether a layer contains points."""
-        from natcap.invest.delineateit import delineateit
-
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
-
-        # Verify invalid filepath returns False.
-        invalid_filepath = os.path.join(self.workspace_dir, 'nope.foo')
-        self.assertFalse(
-            delineateit._vector_may_contain_points(invalid_filepath))
-
-        # Verify invalid layer ID returns False
-        gpkg_driver = gdal.GetDriverByName('GPKG')
-        new_vector_path = os.path.join(self.workspace_dir, 'vector.gpkg')
-        new_vector = gpkg_driver.Create(
-            new_vector_path, 0, 0, 0, gdal.GDT_Unknown)
-        point_layer = new_vector.CreateLayer(
-            'point_layer', srs, ogr.wkbPoint)
-        polygon_layer = new_vector.CreateLayer(
-            'polygon_layer', srs, ogr.wkbPolygon)
-        unknown_layer = new_vector.CreateLayer(
-            'unknown_type_layer', srs, ogr.wkbUnknown)
-
-        unknown_layer = None
-        polygon_layer = None
-        point_layer = None
-        new_vector = None
-
-        self.assertTrue(delineateit._vector_may_contain_points(
-                        new_vector_path, 'point_layer'))
-        self.assertFalse(delineateit._vector_may_contain_points(
-                         new_vector_path, 'polygon_layer'))
-        self.assertTrue(delineateit._vector_may_contain_points(
-                        new_vector_path, 'unknown_type_layer'))
-        self.assertFalse(delineateit._vector_may_contain_points(
-                         new_vector_path, 'NOT A LAYER'))
-
     def test_check_geometries(self):
         """DelineateIt: Check that we can reasonably repair geometries."""
         from natcap.invest.delineateit import delineateit

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -288,7 +288,13 @@ class DelineateItTests(unittest.TestCase):
             component_point.AddPoint(3, -5)
             new_geom.AddGeometry(component_point)
             new_feature.SetGeometry(new_geom)
-            print(new_geom.ExportToWkt())
+            points_layer.CreateFeature(new_feature)
+
+        # Verify point snapping will run if we give it empty multipoints.
+        for point_type in (ogr.wkbPoint, ogr.wkbMultiPoint):
+            new_feature = ogr.Feature(points_layer.GetLayerDefn())
+            new_geom = ogr.Geometry(point_type)
+            new_feature.SetGeometry(new_geom)
             points_layer.CreateFeature(new_feature)
 
         points_layer.CommitTransaction()

--- a/tests/test_delineateit.py
+++ b/tests/test_delineateit.py
@@ -199,12 +199,12 @@ class DelineateItTests(unittest.TestCase):
         ]
         fields = {'foo': ogr.OFTInteger, 'bar': ogr.OFTString}
         attributes = [
-            {'foo': 0, 'bar': 0.1},
-            {'foo': 1, 'bar': 1.1},
-            {'foo': 2, 'bar': 2.1},
-            {'foo': 3, 'bar': 3.1},
-            {'foo': 3, 'bar': 3.1},  # intentional duplicate fields
-            {'foo': 4, 'bar': 4.1}]
+            {'foo': 0, 'bar': '0.1'},
+            {'foo': 1, 'bar': '1.1'},
+            {'foo': 2, 'bar': '2.1'},
+            {'foo': 3, 'bar': '3.1'},
+            {'foo': 3, 'bar': '3.1'},  # intentional duplicate fields
+            {'foo': 4, 'bar': '4.1'}]
         pygeoprocessing.shapely_geometry_to_vector(
             source_features, source_points_path, wkt, 'GeoJSON',
             fields=fields, attribute_list=attributes,
@@ -229,7 +229,7 @@ class DelineateItTests(unittest.TestCase):
                                             gdal.OF_VECTOR)
         snapped_points_layer = snapped_points_vector.GetLayer()
 
-        # snapped layer will include 3 valid points and one polygon.
+        # snapped layer will include 4 valid points and 1 polygon.
         self.assertEqual(5, snapped_points_layer.GetFeatureCount())
 
         expected_geometries_and_fields = [
@@ -237,6 +237,7 @@ class DelineateItTests(unittest.TestCase):
             (Point(5, -9), {'foo': 2, 'bar': '2.1'}),
             (Point(13, -11), {'foo': 3, 'bar': '3.1'}),
             (Point(13, -11), {'foo': 3, 'bar': '3.1'}),  # Multipoint now point
+            (box(-2, -2, -1, -1), {'foo': 4, 'bar': '4.1'}),  # unchanged
         ]
         for feature, (expected_geom, expected_fields) in zip(
                 snapped_points_layer, expected_geometries_and_fields):


### PR DESCRIPTION
This PR updates DelineateIt in three ways:

1. The UI container relating to point snapping is now always interactive.  The cheapo layer type checking as a proxy for trying to detect whether the vector might contain points has been removed.  Workbench PR related to this forthcoming.
2. DelineateIt will now snap `MULTIPOINT` geometries so long as they contain only 1 component point.  OGR uses the WKT string `MULTIPOINT` to refer to `wkbMultiPoint`, `wkbMultiPointM`, `wkbMultiPointZM` and `wkbMultiPoint25D`, so all of these cases are covered, and these cases are now asserted in the tests.
3. When a feature is not able to be snapped (it's not a point/multipoint geometry, has >1 component point or has no geometry at all), a log message is recorded and the original geometry is preserved.  If there's no geometry to preserve, the feature is skipped.  These cases are now asserted.

Fixes #479

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
