### PR TITLE
sampledata json files no longer part of nsis installer

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -76,19 +76,6 @@ jobs:
                   $env:PYTHON = python -c "import sys, os; print(os.path.dirname(sys.executable))"
                   ./ci/windows-ci-binary-install.ps1
 
-            - name: Clone sample data repo (non-lfs)
-              shell: bash -l {0}
-              run: |
-                  GIT_URL=$(make jprint-GIT_SAMPLE_DATA_REPO)
-                  LOCALPATH=$(make jprint-GIT_SAMPLE_DATA_REPO_PATH)
-                  GIT_REV=$(make jprint-GIT_SAMPLE_DATA_REPO_REV)
-
-                  # Only clone the files ... deliberately not cloning LFS data
-                  # Installer needs .invest.json files only, and these are not
-                  # stored in LFS.
-                  GIT_LFS_SKIP_SMUDGE=1 git clone $GIT_URL $LOCALPATH
-                  git -C $LOCALPATH checkout $GIT_REV
-
             - name: Build userguide, binaries, installer
               shell: bash -l {0}
               run: |

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,8 @@
 Unreleased Changes (3.9.1)
 --------------------------
 * General:
+    * Moved the sample data JSON files out of the root sample_data folder and
+      into their respective model folders.
     * Updated documentation on installing InVEST from source.
     * Restructured API reference docs and removed outdated and redundant pages.
     * Include logger name in the logging format. This is helpful for the cython

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := b7a51f189315e08484b5ba997a5c1de88ab7f06d
+GIT_SAMPLE_DATA_REPO_REV    := 406144e9049ec070ebe4738f9372313a26912952
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -478,11 +478,6 @@ Section "InVEST Tools" Section_InVEST_Tools
     File ..\..\LICENSE.txt
     file ..\..\HISTORY.rst
 
-    SetOutPath "${SAMPLEDATADIR}"
-    ; Copy over all the sample parameter files
-    File ..\..\data\invest-sample-data\*.invs.json
-    File ..\..\data\invest-sample-data\*.invest.json
-
     SetOutPath "${INVEST_BINARIES}"
     File /r /x *.hg* /x *.svn* ..\..\${BINDIR}\*
     ; invest-autotest.bat is here to help automate testing the UIs.

--- a/scripts/invest-autovalidate.py
+++ b/scripts/invest-autovalidate.py
@@ -62,8 +62,11 @@ def main(sampledatadir):
         ValueError if any module's `validate` function issued warnings.
     """
     validation_messages = ''
-    for datastack_path in glob.glob(os.path.join(sampledatadir, '*.json')):
+    datastacks = glob.glob(os.path.join(sampledatadir, '**/*.json'))
+    if not datastacks:
+        raise ValueError(f'no json files found in {sampledatadir}')
 
+    for datastack_path in datastacks:
         paramset = datastack.extract_parameter_set(datastack_path)
         if 'workspace_dir' in paramset.args and \
                 paramset.args['workspace_dir'] != '':


### PR DESCRIPTION
Fixes #525 
This PR depends on the changes in https://bitbucket.org/natcap/invest-sample-data/pull-requests/19/moved-json-files-into-their-respective

Sampledata json files were moved into their respective folders in that repo. This means they will be included for any user that chooses to download the sampledata as part of the Windows install process. And that means we no longer need to manage them with the NSIS script. 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed) - I don't think we describe the location of these files in the UG, but not completely certain.
