### PR TITLE
Bugfix/hra handle 0s for rating, dq, and weight in criteria tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,7 +83,7 @@ Unreleased Changes (3.9.1)
       This bug did not affect the output.
 * HRA
     * Fixed bugs that allowed zeros in DQ & Weight columns of criteria 
-    table to raise DivideByZero errors.
+      table to raise DivideByZero errors.
 * Seasonal Water Yield
     * Fixed a bug where ``qf.tif`` outputs weren't properly masking nodata 
       values and could show negative numbers.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -81,6 +81,9 @@ Unreleased Changes (3.9.1)
 * Fisheries Habitat Scenario Tool
     * Fixed divide-by-zero bug that was causing a RuntimeWarning in the logs.
       This bug did not affect the output.
+* HRA
+    * Fixed bugs that allowed zeros in DQ & Weight columns of criteria 
+    table to raise DivideByZero errors.
 * Seasonal Water Yield
     * Fixed a bug where ``qf.tif`` outputs weren't properly masking nodata 
       values and could show negative numbers.

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -827,7 +827,22 @@ class HraUnitTests(unittest.TestCase):
                 msg=f'for value: {r}')
         for r in invalid_ratings_to_raise:
             with self.assertRaises(ValueError, msg=f'for value: {r}'):
-                _validate_rating(r, 3, criteria_name, habitat),
+                _validate_rating(r, 3, criteria_name, habitat)
+
+    def test_validate_dq_weight(self):
+        """HRA: test _validate_dq_weight raises ValueErrors"""
+        from natcap.invest.hra import _validate_dq_weight
+        import numpy
+
+        habitat = 'bar'
+        invalid_vals = [0, '0', numpy.nan, 'foo']
+        for v in invalid_vals:
+            with self.assertRaises(ValueError, msg=f'for value: {v}'):
+                _validate_dq_weight(v, v, habitat)
+
+        valid_vals = [1, '1']
+        for v in valid_vals:
+            _validate_dq_weight(v, v, habitat)
 
 
 class HraRegressionTests(unittest.TestCase):

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -701,7 +701,7 @@ class HraUnitTests(unittest.TestCase):
                  'stressor_1': ['criteria 5', 'criteria 6']},
                 3, self.workspace_dir, self.workspace_dir, '')
 
-        expected_message = 'rating 99999.0 larger than the maximum rating 3'
+        expected_message = 'rating 99999 larger than the maximum rating 3'
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
 
@@ -803,6 +803,31 @@ class HraUnitTests(unittest.TestCase):
 
         _assert_vectors_equal(
             target_simplified_vector_path, base_lines_path)
+
+    def test_validate_rating(self):
+        """HRA: test _validate_rating with various inputs"""
+        from natcap.invest.hra import _validate_rating
+        import numpy
+
+        criteria_name = 'foo'
+        habitat = 'bar'
+        max_rating = 3
+        valid_ratings = [1, '1', 'some/file/path.gpkg']
+        invalid_ratings_to_ignore = [0, '0']
+        invalid_ratings_to_raise = [
+            max_rating + 1,  str(max_rating + 1), numpy.nan]
+
+        for r in valid_ratings:
+            self.assertTrue(
+                _validate_rating(r, max_rating, criteria_name, habitat),
+                msg=f'for value: {r}')
+        for r in invalid_ratings_to_ignore:
+            self.assertFalse(
+                _validate_rating(r, 3, criteria_name, habitat),
+                msg=f'for value: {r}')
+        for r in invalid_ratings_to_raise:
+            with self.assertRaises(ValueError, msg=f'for value: {r}'):
+                _validate_rating(r, 3, criteria_name, habitat),
 
 
 class HraRegressionTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #538 

There were a couple problems with the validation functions for these values. The DQ & Weight validator did not guard against 0s, but those values are used as denominators in divides. The ratings validator did not give the correct result for integer or float types, it always expected strings. When these values originate from a CSV, they are strings, but from an xlsx, they are read as floats/ints.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
