### PR TITLE
Bugfix/carbon lulc year inputs should be tied to valuation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -69,6 +69,8 @@ Unreleased Changes (3.9.1)
     * Fixed a bug where, if rate change and discount rate were set to 0, the
       valuation results were in $/year rather than $, too small by a factor of
       ``lulc_fut_year - lulc_cur_year``.
+    * Improved UI to indicate that Calendar Year inputs are only required for
+      valuation, not also for sequestration.
 * DelineateIt:
     * The DelineateIt UI has been updated so that the point-snapping options
       will always be interactive.

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -216,17 +216,15 @@ def execute(args):
             storage density to lulc codes. (required if 'do_uncertainty' is
             false)
         args['lulc_cur_year'] (int/string): an integer representing the year
-            of `args['lulc_cur_path']` used if `args['calc_sequestration']`
+            of `args['lulc_cur_path']` used if `args['do_valuation']`
             is True.
         args['lulc_fut_year'](int/string): an integer representing the year
             of `args['lulc_fut_path']` used in valuation if it exists.
             Required if  `args['do_valuation']` is True and
             `args['lulc_fut_path']` is present and well defined.
         args['do_valuation'] (bool): if true then run the valuation model on
-            available outputs.  At a minimum will run on carbon stocks, if
-            sequestration with a future scenario is done and/or a REDD
-            scenario calculate NPV for either and report in final HTML
-            document.
+            available outputs. Calculate NPV for a future scenario or a REDD
+            scenario and report in final HTML document.
         args['price_per_metric_ton_of_c'] (float): Is the present value of
             carbon per metric ton. Used if `args['do_valuation']` is present
             and True.

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -103,7 +103,7 @@ ARGS_SPEC = {
                 "expression": "int(value)"
             },
             "type": "number",
-            "required": "calc_sequestration",
+            "required": "do_valuation",
             "about": "The calendar year of the current scenario.",
             "name": "Current Landcover Calendar Year"
         },
@@ -112,7 +112,7 @@ ARGS_SPEC = {
                 "expression": "int(value)"
             },
             "type": "number",
-            "required": "calc_sequestration",
+            "required": "do_valuation",
             "about": "The calendar year of the future scenario.",
             "name": "Future Landcover Calendar Year"
         },

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -94,7 +94,7 @@ ARGS_SPEC = {
                 "A table that maps each land cover class to its respective "
                 "carbon pools. The table must contain columns of 'lucode', "
                 "'C_above', 'C_below', 'C_soil', 'C_dead' as described in the "
-                "User's Guide. The 'lucode' column must include all the pixel
+                "User's Guide. The 'lucode' column must include all the pixel "
                 "values present in the land cover maps."),
             "name": "Carbon Pools"
         },

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -94,8 +94,8 @@ ARGS_SPEC = {
                 "A table that maps the land-cover IDs to carbon pools.  "
                 "The table must contain columns of 'LULC', 'C_above', "
                 "'C_Below', 'C_Soil', 'C_Dead' as described in the User's "
-                "Guide.  The values in LULC must at least include the LULC "
-                "IDs in the land cover maps."),
+                "Guide.  The LULC column must include all the pixel values "
+                "present in the land cover maps."),
             "name": "Carbon Pools"
         },
         "lulc_cur_year": {
@@ -120,19 +120,15 @@ ARGS_SPEC = {
             "type": "boolean",
             "required": False,
             "about": (
-                "if true then run the valuation model on available outputs.  "
-                "At a minimum will run on carbon stocks, if sequestration "
-                "with a future scenario is done and/or a REDD scenario "
-                "calculate NPV for either and report in final HTML "
-                "document."),
+                "Calculate NPV for a future scenario or a REDD scenario "
+                "and report in final HTML document."),
             "name": "Run Valuation Model"
         },
         "price_per_metric_ton_of_c": {
             "type": "number",
             "required": "do_valuation",
             "about": (
-                "Is the present value of carbon per metric ton. Used if "
-                "``args['do_valuation']`` is present and True."),
+                "The present value of carbon per metric ton."),
             "name": "Price/Metric ton of carbon"
         },
         "discount_rate": {

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -85,21 +85,17 @@ ARGS_SPEC = {
         },
         "carbon_pools_path": {
             "validation_options": {
-                "required_fields": ["LUCODE", "C_above", "C_below", "C_soil",
+                "required_fields": ["lucode", "C_above", "C_below", "C_soil",
                                     "C_dead"],
             },
             "type": "csv",
             "required": True,
             "about": (
-                "A table that maps each land cover class to its respective carbon pools.  "
-
-                "The table must contain columns of 'lucode', 'C_above', "
-
-                "'C_below', 'C_soil', 'C_dead' as described in the User's "
-
-                "Guide. The 'lucode' column must include all the pixel values "
-
-                "present in the land cover maps."),
+                "A table that maps each land cover class to its respective "
+                "carbon pools. The table must contain columns of 'lucode', "
+                "'C_above', 'C_below', 'C_soil', 'C_dead' as described in the "
+                "User's Guide. The 'lucode' column must include all the pixel
+                "values present in the land cover maps."),
             "name": "Carbon Pools"
         },
         "lulc_cur_year": {
@@ -110,7 +106,6 @@ ARGS_SPEC = {
             "required": "do_valuation",
             "about": "The calendar year of the current scenario.",
             "name": "Current Land Cover Calendar Year"
-
         },
         "lulc_fut_year": {
             "validation_options": {
@@ -120,22 +115,19 @@ ARGS_SPEC = {
             "required": "do_valuation",
             "about": "The calendar year of the future scenario.",
             "name": "Future Land Cover Calendar Year"
-
         },
         "do_valuation": {
             "type": "boolean",
             "required": False,
             "about": (
                 "Calculate NPV for a future or REDD scenario "
-
                 "and report in final HTML document."),
             "name": "Run Valuation Model"
         },
         "price_per_metric_ton_of_c": {
             "type": "number",
             "required": "do_valuation",
-            "about": (
-                "The present value of carbon per metric ton."),
+            "about": "The present value of carbon per metric ton.",
             "name": "Price/Metric ton of carbon"
         },
         "discount_rate": {

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -91,10 +91,14 @@ ARGS_SPEC = {
             "type": "csv",
             "required": True,
             "about": (
-                "A table that maps the land-cover IDs to carbon pools.  "
-                "The table must contain columns of 'LULC', 'C_above', "
-                "'C_Below', 'C_Soil', 'C_Dead' as described in the User's "
-                "Guide.  The LULC column must include all the pixel values "
+                "A table that maps each land cover class to its respective carbon pools.  "
+
+                "The table must contain columns of 'lucode', 'C_above', "
+
+                "'C_below', 'C_soil', 'C_dead' as described in the User's "
+
+                "Guide. The 'lucode' column must include all the pixel values "
+
                 "present in the land cover maps."),
             "name": "Carbon Pools"
         },
@@ -105,7 +109,8 @@ ARGS_SPEC = {
             "type": "number",
             "required": "do_valuation",
             "about": "The calendar year of the current scenario.",
-            "name": "Current Landcover Calendar Year"
+            "name": "Current Land Cover Calendar Year"
+
         },
         "lulc_fut_year": {
             "validation_options": {
@@ -114,13 +119,15 @@ ARGS_SPEC = {
             "type": "number",
             "required": "do_valuation",
             "about": "The calendar year of the future scenario.",
-            "name": "Future Landcover Calendar Year"
+            "name": "Future Land Cover Calendar Year"
+
         },
         "do_valuation": {
             "type": "boolean",
             "required": False,
             "about": (
-                "Calculate NPV for a future scenario or a REDD scenario "
+                "Calculate NPV for a future or REDD scenario "
+
                 "and report in final HTML document."),
             "name": "Run Valuation Model"
         },

--- a/src/natcap/invest/ui/carbon.py
+++ b/src/natcap/invest/ui/carbon.py
@@ -114,12 +114,8 @@ class Carbon(model.InVESTModel):
         self.valuation_container.add_input(self.rate_change)
 
         # Set interactivity, requirement as input sufficiency changes
-        # self.calc_sequestration.sufficiency_changed.connect(
-        #     self.cur_lulc_year.set_interactive)
         self.calc_sequestration.sufficiency_changed.connect(
             self.fut_lulc_raster.set_interactive)
-        # self.calc_sequestration.sufficiency_changed.connect(
-        #     self.fut_lulc_year.set_interactive)
         self.calc_sequestration.sufficiency_changed.connect(
             self.redd.set_interactive)
         self.redd.sufficiency_changed.connect(

--- a/src/natcap/invest/ui/carbon.py
+++ b/src/natcap/invest/ui/carbon.py
@@ -31,13 +31,6 @@ class Carbon(model.InVESTModel):
             label='Carbon Pools',
             validator=self.validator)
         self.add_input(self.carbon_pools_path)
-        self.cur_lulc_year = inputs.Text(
-            args_key='lulc_cur_year',
-            helptext='The calendar year of the current scenario.',
-            interactive=False,
-            label='Current Landcover Calendar Year',
-            validator=self.validator)
-        self.add_input(self.cur_lulc_year)
         self.calc_sequestration = inputs.Checkbox(
             helptext=(
                 "Check to enable sequestration analysis.  This "
@@ -58,13 +51,6 @@ class Carbon(model.InVESTModel):
             label='Future Landcover (Raster)',
             validator=self.validator)
         self.add_input(self.fut_lulc_raster)
-        self.fut_lulc_year = inputs.Text(
-            args_key='lulc_fut_year',
-            helptext='The calendar year of the future scenario.',
-            interactive=False,
-            label='Future Landcover Calendar Year',
-            validator=self.validator)
-        self.add_input(self.fut_lulc_year)
         self.redd = inputs.Checkbox(
             helptext=(
                 "Check to enable REDD scenario analysis.  This "
@@ -93,6 +79,20 @@ class Carbon(model.InVESTModel):
             interactive=False,
             label='Run Valuation Model')
         self.add_input(self.valuation_container)
+        self.cur_lulc_year = inputs.Text(
+            args_key='lulc_cur_year',
+            helptext='The calendar year of the current scenario.',
+            interactive=False,
+            label='Current Landcover Calendar Year',
+            validator=self.validator)
+        self.valuation_container.add_input(self.cur_lulc_year)
+        self.fut_lulc_year = inputs.Text(
+            args_key='lulc_fut_year',
+            helptext='The calendar year of the future scenario.',
+            interactive=False,
+            label='Future Landcover Calendar Year',
+            validator=self.validator)
+        self.valuation_container.add_input(self.fut_lulc_year)
         self.price_per_metric_ton_of_c = inputs.Text(
             args_key='price_per_metric_ton_of_c',
             label='Price/Metric ton of carbon',
@@ -114,12 +114,12 @@ class Carbon(model.InVESTModel):
         self.valuation_container.add_input(self.rate_change)
 
         # Set interactivity, requirement as input sufficiency changes
-        self.calc_sequestration.sufficiency_changed.connect(
-            self.cur_lulc_year.set_interactive)
+        # self.calc_sequestration.sufficiency_changed.connect(
+        #     self.cur_lulc_year.set_interactive)
         self.calc_sequestration.sufficiency_changed.connect(
             self.fut_lulc_raster.set_interactive)
-        self.calc_sequestration.sufficiency_changed.connect(
-            self.fut_lulc_year.set_interactive)
+        # self.calc_sequestration.sufficiency_changed.connect(
+        #     self.fut_lulc_year.set_interactive)
         self.calc_sequestration.sufficiency_changed.connect(
             self.redd.set_interactive)
         self.redd.sufficiency_changed.connect(

--- a/src/natcap/invest/ui/carbon.py
+++ b/src/natcap/invest/ui/carbon.py
@@ -33,7 +33,7 @@ class Carbon(model.InVESTModel):
         self.add_input(self.carbon_pools_path)
         self.calc_sequestration = inputs.Checkbox(
             helptext=(
-                "Check to enable sequestration analysis.  This "
+                "Check to enable sequestration analysis. This "
                 "requires inputs of Land Use/Land Cover maps for both "
                 "current and future scenarios."),
             args_key='calc_sequestration',
@@ -48,7 +48,7 @@ class Carbon(model.InVESTModel):
                 "baseline, future scenario against which to compare "
                 "the REDD policy scenario."),
             interactive=False,
-            label='Future Landcover (Raster)',
+            label='Future Land Cover (Raster)',
             validator=self.validator)
         self.add_input(self.fut_lulc_raster)
         self.redd = inputs.Checkbox(
@@ -83,19 +83,19 @@ class Carbon(model.InVESTModel):
             args_key='lulc_cur_year',
             helptext='The calendar year of the current scenario.',
             interactive=False,
-            label='Current Landcover Calendar Year',
+            label='Current Land Cover Calendar Year',
             validator=self.validator)
         self.valuation_container.add_input(self.cur_lulc_year)
         self.fut_lulc_year = inputs.Text(
             args_key='lulc_fut_year',
             helptext='The calendar year of the future scenario.',
             interactive=False,
-            label='Future Landcover Calendar Year',
+            label='Future Land Cover Calendar Year',
             validator=self.validator)
         self.valuation_container.add_input(self.fut_lulc_year)
         self.price_per_metric_ton_of_c = inputs.Text(
             args_key='price_per_metric_ton_of_c',
-            label='Price/Metric ton of carbon',
+            label='Price/Metric Ton of Carbon',
             validator=self.validator)
         self.valuation_container.add_input(self.price_per_metric_ton_of_c)
         self.discount_rate = inputs.Text(

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -301,9 +301,7 @@ class CarbonValidationTests(unittest.TestCase):
         invalid_keys = validation.get_invalid_keys(validation_errors)
         expected_missing_keys = set(
             self.base_required_keys +
-            ['lulc_cur_year',
-             'lulc_fut_year',
-             'lulc_fut_path'])
+            ['lulc_fut_path'])
         self.assertEqual(invalid_keys, expected_missing_keys)
 
     def test_missing_keys_redd(self):
@@ -333,5 +331,7 @@ class CarbonValidationTests(unittest.TestCase):
             ['calc_sequestration',
              'price_per_metric_ton_of_c',
              'discount_rate',
-             'rate_change'])
+             'rate_change',
+             'lulc_cur_year',
+             'lulc_fut_year'])
         self.assertEqual(invalid_keys, expected_missing_keys)


### PR DESCRIPTION
Fixes #541 

This PR moves the two Calendar Year inputs into the Valuation Container of the UI. Now, these inputs are required to "do valuation", but not required to "calc sequestration". The User's Guide and the model's execute function confirmed these args are only used when calculating valuation.

Also some small updates to 'ARGS_SPEC' "About" text for some other inputs.

Here's the new UI
![CarbonQtUI](https://user-images.githubusercontent.com/4071255/116752176-22161c00-a9d3-11eb-8e1d-f07a2a4c15da.PNG)


# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)

The UG changes are in a PR also, just in case we don't go with this.  https://github.com/natcap/invest.users-guide/pull/26