### PR TITLE
Better precision in carbon report

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -73,6 +73,8 @@ Unreleased Changes (3.9.1)
       ``lulc_fut_year - lulc_cur_year``.
     * Improved UI to indicate that Calendar Year inputs are only required for
       valuation, not also for sequestration.
+    * Increasing the precision of ``numpy.sum`` from Float32 to Float64 when
+      aggregating raster values for the HTML report.
 * DelineateIt:
     * The DelineateIt UI has been updated so that the point-snapping options
       will always be interactive.

--- a/exe/hooks/rthook.py
+++ b/exe/hooks/rthook.py
@@ -20,4 +20,8 @@ if platform.system() == 'Windows':
     # PATH.  If gdalXXX.dll is in the PATH, then set the
     # USE_PATH_FOR_GDAL_PYTHON=YES environment variable to feed the PATH into
     # os.add_dll_directory().
-    os.environ['USE_PATH_FOR_GDAL_PYTHON'] = 'YES'
+    #
+    # Note that GDAL will try adding all sorts of directories to the PATH that
+    # might not exist, which will then raise FileNotFound.  Adding the DLL
+    # directory directly gets around this.
+    os.add_dll_directory(sys._MEIPASS)

--- a/exe/hooks/rthook.py
+++ b/exe/hooks/rthook.py
@@ -12,16 +12,3 @@ if platform.system() == 'Darwin':
     # See https://bugreports.qt.io/browse/QTBUG-87014
     # and https://github.com/natcap/invest/issues/384
     os.environ['QT_MAC_WANTS_LAYER'] = '1'
-
-if platform.system() == 'Windows':
-    # Encountered with the GDAL 3.3.0 release.  Specific exception below.
-    #
-    # On Windows, with Python >= 3.8, DLLs are no longer imported from the
-    # PATH.  If gdalXXX.dll is in the PATH, then set the
-    # USE_PATH_FOR_GDAL_PYTHON=YES environment variable to feed the PATH into
-    # os.add_dll_directory().
-    #
-    # Note that GDAL will try adding all sorts of directories to the PATH that
-    # might not exist, which will then raise FileNotFound.  Adding the DLL
-    # directory directly gets around this.
-    os.add_dll_directory(sys._MEIPASS)

--- a/exe/hooks/rthook.py
+++ b/exe/hooks/rthook.py
@@ -12,3 +12,12 @@ if platform.system() == 'Darwin':
     # See https://bugreports.qt.io/browse/QTBUG-87014
     # and https://github.com/natcap/invest/issues/384
     os.environ['QT_MAC_WANTS_LAYER'] = '1'
+
+if platform.system() == 'Windows':
+    # Encountered with the GDAL 3.3.0 release.  Specific exception below.
+    #
+    # On Windows, with Python >= 3.8, DLLs are no longer imported from the
+    # PATH.  If gdalXXX.dll is in the PATH, then set the
+    # USE_PATH_FOR_GDAL_PYTHON=YES environment variable to feed the PATH into
+    # os.add_dll_directory().
+    os.environ['USE_PATH_FOR_GDAL_PYTHON'] = 'YES'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only
-pygeoprocessing>=2.1.1  # pip-only
+pygeoprocessing>=2.1.1,<2.2.0  # pip-only
 taskgraph[niced_processes]>=0.10.3  # pip-only
 psutil>=5.6.6
 chardet>=3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.1.2
+GDAL>=3.1.2,<3.3.0
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -406,7 +406,11 @@ def _accumulate_totals(raster_path):
     nodata = pygeoprocessing.get_raster_info(raster_path)['nodata'][0]
     raster_sum = 0.0
     for _, block in pygeoprocessing.iterblocks((raster_path, 1)):
-        raster_sum += numpy.sum(block[block != nodata])
+        # The float64 dtype in the sum is needed to reduce numerical error in
+        # the sum.  Users calculated the sum by hand, noticed a difference and
+        # wrote to us about it on the forum, so hence this fix.
+        raster_sum += numpy.sum(
+            block[~numpy.isclose(block, nodata)], dtype=numpy.float64)
     return raster_sum
 
 
@@ -492,7 +496,7 @@ def _calculate_valuation_constant(
     """
     n_years = lulc_fut_year - lulc_cur_year
     ratio = (
-        1 / ((1 + discount_rate / 100) * 
+        1 / ((1 + discount_rate / 100) *
              (1 + rate_change / 100)))
     valuation_constant = (price_per_metric_ton_of_c / n_years)
     # note: the valuation formula in the user's guide uses sum notation.

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -407,8 +407,8 @@ def _accumulate_totals(raster_path):
     raster_sum = 0.0
     for _, block in pygeoprocessing.iterblocks((raster_path, 1)):
         # The float64 dtype in the sum is needed to reduce numerical error in
-        # the sum.  Users calculated the sum by hand, noticed a difference and
-        # wrote to us about it on the forum, so hence this fix.
+        # the sum.  Users calculated the sum with ArcGIS zonal statistics,
+        # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
             block[~numpy.isclose(block, nodata)], dtype=numpy.float64)
     return raster_sum

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -8,6 +8,9 @@ import os
 from osgeo import gdal
 from osgeo import osr
 import numpy
+import numpy.random
+import numpy.testing
+import pygeoprocessing
 
 
 def make_simple_raster(base_raster_path, fill_val, nodata_val):
@@ -163,11 +166,11 @@ class CarbonTests(unittest.TestCase):
         carbon.execute(args)
 
         # Add assertions for npv for future and REDD scenarios.
-        # carbon change from cur to fut: 
+        # carbon change from cur to fut:
         # -58 Mg/ha * .0001 ha/pixel * 43 $/Mg = -0.2494 $/pixel
         assert_raster_equal_value(
             os.path.join(args['workspace_dir'], 'npv_fut.tif'), -0.2494)
-        # carbon change from cur to redd: 
+        # carbon change from cur to redd:
         # -78 Mg/ha * .0001 ha/pixel * 43 $/Mg = -0.3354 $/pixel
         assert_raster_equal_value(
             os.path.join(args['workspace_dir'], 'npv_redd.tif'), -0.3354)
@@ -335,3 +338,25 @@ class CarbonValidationTests(unittest.TestCase):
              'lulc_cur_year',
              'lulc_fut_year'])
         self.assertEqual(invalid_keys, expected_missing_keys)
+
+    def test_carbon_totals_precision(self):
+        """Carbon: check float64 precision in pixel value summation."""
+        from natcap.invest import carbon
+
+        big_float32_array = numpy.random.default_rng(seed=1).random(
+            (10000, 10000), dtype=numpy.float32)
+
+        nodata = numpy.finfo(numpy.float32).min
+        big_float32_array[1:15] = nodata
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
+        wkt = srs.ExportToWkt()
+        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
+        pygeoprocessing.numpy_array_to_raster(
+            big_float32_array, float(nodata), (2, -2), (2, -2), wkt,
+            raster_path)
+
+        numpy.testing.assert_allclose(
+            carbon._accumulate_totals(raster_path),
+            49935086.309929)

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -344,8 +344,9 @@ class CarbonValidationTests(unittest.TestCase):
         from natcap.invest import carbon
 
         big_float32_array = numpy.random.default_rng(seed=1).random(
-            (10000, 10000), dtype=numpy.float32)
+            (1000, 1000), dtype=numpy.float32)
 
+        # Throw in some nodata values for good measure.
         nodata = numpy.finfo(numpy.float32).min
         big_float32_array[1:15] = nodata
 
@@ -357,6 +358,9 @@ class CarbonValidationTests(unittest.TestCase):
             big_float32_array, float(nodata), (2, -2), (2, -2), wkt,
             raster_path)
 
+        # Verify better-than-float32 precision on raster summation.
+        # Using a numpy float32 in numpy.sum will pass up to rtol=1e-9.
         numpy.testing.assert_allclose(
             carbon._accumulate_totals(raster_path),
-            49935086.309929)
+            492919.73994,
+            rtol=1e-12)  # Note better precision


### PR DESCRIPTION
This PR updates `numpy.sum` in the carbon model to use a higher-precision aggregate number.  Python's `float` object is float64, so I thought it'd make sense to just stick with that.  A test has been added to assert the extra precision is retained.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
