### PR TITLE
Bugfix/428 pandas unicode decode errors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,8 @@
 Unreleased Changes (3.9.1)
 --------------------------
 * General:
+    * Added error-handling for when ``pandas`` fails to decode a non-utf8
+      encoded CSV.
     * Moved the sample data JSON files out of the root sample_data folder and
       into their respective model folders.
     * Updated documentation on installing InVEST from source.

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -587,7 +587,7 @@ def read_csv_to_dataframe(
                                     sep=sep, **kwargs)
     except UnicodeDecodeError as error:
         LOGGER.error(
-            f'{path} must be encoded as utf-8 or avoid non-ASCII characters')
+            f'{path} must be encoded as utf-8 or ASCII')
         raise error
 
     # this won't work on integer types, which happens if you set header=None

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -582,8 +582,13 @@ def read_csv_to_dataframe(
     # allow encoding kwarg to override this if it's provided
     if not encoding and has_utf8_bom(path):
         encoding = 'utf-8-sig'
-    dataframe = pandas.read_csv(path, engine=engine, encoding=encoding,
-                                sep=sep, **kwargs)
+    try:
+        dataframe = pandas.read_csv(path, engine=engine, encoding=encoding,
+                                    sep=sep, **kwargs)
+    except UnicodeDecodeError as error:
+        LOGGER.error(
+            f'{path} must be encoded as utf-8 or avoid non-ASCII characters')
+        raise error
 
     # this won't work on integer types, which happens if you set header=None
     # however, there's little reason to use this function if there's no header

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -870,29 +870,6 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df.columns[0], 'header1')
         self.assertEqual(df['HEADER2'][1], 5)
 
-    def test_non_utf8_encoding(self):
-        """utils: test that non-UTF8 encoding doesn't raise an error"""
-        from natcap.invest import utils
-
-        csv_file = os.path.join(self.workspace_dir, 'csv.csv')
-
-        # encode with ISO Cyrillic, include a non-ASCII character
-        with open(csv_file, 'w', encoding='iso8859_5') as file_obj:
-            file_obj.write(textwrap.dedent(
-                """
-                header,
-                fЮЮ,
-                bar
-                """
-            ).strip())
-
-        df = utils.read_csv_to_dataframe(csv_file)
-        # the default engine='python' should replace the unknown characters
-        # different encodings of replacement character depending on the system
-        self.assertTrue(df['header'][0] in ['f\xce\xce', 
-            'f\N{REPLACEMENT CHARACTER}\N{REPLACEMENT CHARACTER}'])
-        self.assertEqual(df['header'][1], 'bar')
-
     def test_override_default_encoding(self):
         """utils: test that you can override the default encoding kwarg"""
         from natcap.invest import utils

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -707,28 +707,6 @@ class CSVValidation(unittest.TestCase):
             target_file, required_fields=['field_a'])
         self.assertTrue('missing from this table' in error_msg)
 
-    def test_csv_not_utf_8(self):
-        """Validation: test that non-UTF8 CSVs can validate."""
-        from natcap.invest import validation
-
-        df = pandas.DataFrame([
-            {'fЮЮ': 1, 'bar': 2, 'baz': 3},  # special characters here.
-            {'foo': 2, 'bar': 3, 'baz': 4},
-            {'foo': 3, 'bar': 4, 'baz': 5}])
-
-        target_file = os.path.join(self.workspace_dir, 'test.csv')
-
-        # Save the CSV with the Windows Cyrillic codepage.
-        # https://en.wikipedia.org/wiki/ISO/IEC_8859-5
-        df.to_csv(target_file, encoding='iso8859_5')
-
-        # Note that non-UTF8 encodings should pass this check, but aren't
-        # actually being read correctly. Characters outside the ASCII set may
-        # be replaced with a replacement character.
-        # UTF16, UTF32, etc. will still raise an error.
-        error_msg = validation.check_csv(target_file)
-        self.assertEqual(error_msg, None)
-
     def test_excel_missing_fieldnames(self):
         """Validation: test that we can check missing fieldnames in excel."""
         from natcap.invest import validation


### PR DESCRIPTION
This PR fixes #428. From my comment there:

>This issue came back with version 1.3.0 where pandas once again does not catch the UnicodeDecodeError and does not replace the characters. I really don't know why this keeps flipping back and forth - it doesn't seem like a deliberate decision as it's never mentioned in the changelogs.

>Assuming this behavior could switch back again with any given pandas release, I'm thinking the resilient solution for us is:
> 1. catch & re-raise a UnicodeDecodeError in utils.read_csv_to_dataframe with a message that tells users to use utf-8 encoding. That's how we solved this originally.
> 2. eliminate the two tests (test_utils & test_validation) that we have been switching back and forth between asserting the replacement characters are present & asserting the UnicodeDecodeError is raised. I think that test really only tests pandas behavior. And since we seem to be okay with either behavior, I don't think we need the test. Thoughts @phargogh ?

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
