### PR TITLE
Graceful exit from CLI even after invest exception

### DIFF
--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -587,7 +587,13 @@ def main(user_args=None):
 
             # We're deliberately not validating here because the user
             # can just call ``invest validate <datastack>`` to validate.
-            getattr(model_module, 'execute')(parsed_datastack.args)
+            try:
+                getattr(model_module, 'execute')(parsed_datastack.args)
+            # Graceful exit from this program, otherwise the pyinstaller-made
+            # executeable will exit with 'Failed to execute script cli' on an
+            # uncaught exception. And that only adds unhelpful noise to stderr.
+            except Exception as error:
+                parser.exit(DEFAULT_EXIT_CODE, str(error))
 
     # If we're running in a GUI (either through ``invest run`` or
     # ``invest quickrun``), we'll need to load the Model's GUI class,

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -593,7 +593,8 @@ def main(user_args=None):
             # executeable will exit with 'Failed to execute script cli' on an
             # uncaught exception. And that only adds unhelpful noise to stderr.
             except Exception as error:
-                parser.exit(DEFAULT_EXIT_CODE, str(error))
+                LOGGER.exception(error)
+                parser.exit(DEFAULT_EXIT_CODE)
 
     # If we're running in a GUI (either through ``invest run`` or
     # ``invest quickrun``), we'll need to load the Model's GUI class,


### PR DESCRIPTION
This fixes #580 . Aside from preventing the trailing 'Failed to execute script cli` message, it also changes the traceback slightly as it now doesn't go all the way back to include 
```
  File "natcap\invest\cli.py", line 663, in <module>
  File "natcap\invest\cli.py", line 590, in main
  File "natcap\invest\carbon.py", line 317, in execute
```
That makes sense, but I can't really explain why there's a different number of Traceback blocks after this change. Maybe there's a different/better way to fix #580?

See the full before & after tracebacks:

**Before:**
```
07/09/2021 11:05:32  pygeoprocessing.geoprocessing ERROR    exception encountered in raster_calculator
Traceback (most recent call last):
  File "pygeoprocessing\geoprocessing.py", line 440, in raster_calculator
  File "pygeoprocessing\geoprocessing.py", line 1849, in _map_dataset_to_value_op
pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: ('The following 11 raster values [52 53 54 55 56 57 58 59 60 61 62] from "C:\\Users\\dmf\\projects\\invest\\data\\bad-data\\Carbon\\lulc_current_willamette.tif" do not have corresponding entries in the ``value_map``: {1: 1.35, 2: 0.45, 3: 0.18, 4: 0.0, 5: 0.9, 6: 0.0, 7: 0.0, 8: 0.0, 9: 0.0, 10: 0.0, 11: 0.0, 16: 0.0, 102: 0.0}.', array([52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62], dtype=int16))
07/09/2021 11:05:32  pygeoprocessing.geoprocessing INFO     Waiting for raster stats worker result.
07/09/2021 11:05:32  pygeoprocessing.geoprocessing_core WARNING  No valid pixels were received, sending None.
07/09/2021 11:05:32  taskgraph.Task     ERROR    Something went wrong when adding task carbon_map_c_above_cur (0), terminating taskgraph.
Traceback (most recent call last):
  File "natcap\invest\utils.py", line 863, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 1856, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 440, in raster_calculator
  File "pygeoprocessing\geoprocessing.py", line 1849, in _map_dataset_to_value_op
pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: ('The following 11 raster values [52 53 54 55 56 57 58 59 60 61 62] from "C:\\Users\\dmf\\projects\\invest\\data\\bad-data\\Carbon\\lulc_current_willamette.tif" do not have corresponding entries in the ``value_map``: {1: 1.35, 2: 0.45, 3: 0.18, 4: 0.0, 5: 0.9, 6: 0.0, 7: 0.0, 8: 0.0, 9: 0.0, 10: 0.0, 11: 0.0, 16: 0.0, 102: 0.0}.', array([52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62], dtype=int16))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "taskgraph\Task.py", line 697, in add_task
  File "taskgraph\Task.py", line 1174, in _call
  File "natcap\invest\carbon.py", line 442, in _generate_carbon_map
  File "natcap\invest\utils.py", line 871, in reclassify_raster
ValueError: Values in the LULC raster were found that are not represented under the 'lucode' column of the Carbon Pools table. The missing values found in the LULC raster but not the table are: [52 53 54 55 56 57 58 59 60 61 62].
07/09/2021 11:05:32  natcap.invest.utils INFO     Elapsed time: 0.17s
Traceback (most recent call last):
  File "natcap\invest\utils.py", line 863, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 1856, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 440, in raster_calculator
  File "pygeoprocessing\geoprocessing.py", line 1849, in _map_dataset_to_value_op
pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: ('The following 11 raster values [52 53 54 55 56 57 58 59 60 61 62] from "C:\\Users\\dmf\\projects\\invest\\data\\bad-data\\Carbon\\lulc_current_willamette.tif" do not have corresponding entries in the ``value_map``: {1: 1.35, 2: 0.45, 3: 0.18, 4: 0.0, 5: 0.9, 6: 0.0, 7: 0.0, 8: 0.0, 9: 0.0, 10: 0.0, 11: 0.0, 16: 0.0, 102: 0.0}.', array([52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62], dtype=int16))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "natcap\invest\cli.py", line 663, in <module>
  File "natcap\invest\cli.py", line 590, in main
  File "natcap\invest\carbon.py", line 317, in execute
  File "taskgraph\Task.py", line 697, in add_task
  File "taskgraph\Task.py", line 1174, in _call
  File "natcap\invest\carbon.py", line 442, in _generate_carbon_map
  File "natcap\invest\utils.py", line 871, in reclassify_raster
ValueError: Values in the LULC raster were found that are not represented under the 'lucode' column of the Carbon Pools table. The missing values found in the LULC raster but not the table are: [52 53 54 55 56 57 58 59 60 61 62].
[11836] Failed to execute script cli
```

**After:**
```
2021-07-09 10:56:41,284 (pygeoprocessing.geoprocessing) geoprocessing.raster_calculator(495) ERROR exception encountered in raster_calculator
Traceback (most recent call last):
  File "pygeoprocessing\geoprocessing.py", line 440, in raster_calculator
  File "pygeoprocessing\geoprocessing.py", line 1849, in _map_dataset_to_value_op
pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: ('The following 11 raster values [52 53 54 55 56 57 58 59 60 61 62] from "C:\\Users\\dmf\\projects\\invest\\data\\bad-data\\Carbon\\lulc_current_willamette.tif" do not have corresponding entries in the ``value_map``: {1: 1.35, 2: 0.45, 3: 0.18, 4: 0.0, 5: 0.9, 6: 0.0, 7: 0.0, 8: 0.0, 9: 0.0, 10: 0.0, 11: 0.0, 16: 0.0, 102: 0.0}.', array([52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62], dtype=int16))
2021-07-09 10:56:41,288 (pygeoprocessing.geoprocessing) geoprocessing.raster_calculator(510) INFO Waiting for raster stats worker result.
2021-07-09 10:56:41,288 (pygeoprocessing.geoprocessing_core) threading.run(870) WARNING No valid pixels were received, sending None.
2021-07-09 10:56:41,289 (taskgraph.Task) Task.add_task(731) ERROR Something went wrong when adding task carbon_map_c_above_cur (0), terminating taskgraph.
Traceback (most recent call last):
  File "natcap\invest\utils.py", line 863, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 1856, in reclassify_raster
  File "pygeoprocessing\geoprocessing.py", line 440, in raster_calculator
  File "pygeoprocessing\geoprocessing.py", line 1849, in _map_dataset_to_value_op
pygeoprocessing.geoprocessing.ReclassificationMissingValuesError: ('The following 11 raster values [52 53 54 55 56 57 58 59 60 61 62] from "C:\\Users\\dmf\\projects\\invest\\data\\bad-data\\Carbon\\lulc_current_willamette.tif" do not have corresponding entries in the ``value_map``: {1: 1.35, 2: 0.45, 3: 0.18, 4: 0.0, 5: 0.9, 6: 0.0, 7: 0.0, 8: 0.0, 9: 0.0, 10: 0.0, 11: 0.0, 16: 0.0, 102: 0.0}.', array([52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62], dtype=int16))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "taskgraph\Task.py", line 697, in add_task
  File "taskgraph\Task.py", line 1174, in _call
  File "natcap\invest\carbon.py", line 442, in _generate_carbon_map
  File "natcap\invest\utils.py", line 871, in reclassify_raster
ValueError: Values in the LULC raster were found that are not represented under the 'lucode' column of the Carbon Pools table. The missing values found in the LULC raster but not the table are: [52 53 54 55 56 57 58 59 60 61 62].
2021-07-09 10:56:41,291 (natcap.invest.utils) utils.prepare_workspace(130) INFO Elapsed time: 0.16s
```

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
