### PR TITLE
CV test: ignore order of rows when comparing output to regression data

### DIFF
--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -713,22 +713,67 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         args['slr_field'] = 'Trend'
         coastal_vulnerability.execute(args)
 
-        # shore points aren't necessarily created/numbered in the same order,
-        # so we can't compare the fid or shore_id fields at all
-        # and need to sort the rows before comparing
-        actual_values_df = pandas.read_csv(
-            os.path.join(args['workspace_dir'], 'coastal_exposure.csv')
-        ).drop(['fid', 'shore_id'], axis=1)
-        actual_values_df = actual_values_df.sort_values(
-            by=list(actual_values_df.columns)).reset_index(drop=True)
-        expected_values_df = pandas.read_csv(
-            os.path.join(REGRESSION_DATA, 'expected_coastal_exposure.csv')
-        ).drop(['fid', 'shore_id'], axis=1)
-        expected_values_df = expected_values_df.sort_values(
-            by=list(expected_values_df.columns)).reset_index(drop=True)
+        results_vector = gdal.OpenEx(
+            os.path.join(args['workspace_dir'], 'coastal_exposure.gpkg'),
+            gdal.OF_VECTOR)
+        results_layer = results_vector.GetLayer()
 
-        pandas.testing.assert_frame_equal(
-            actual_values_df, expected_values_df, check_dtype=False)
+        # shore points aren't necessarily created/numbered in the same order,
+        # so we can't compare by the fid or shore_id fields
+        # instead check that each point has the expected attributes
+        fields = [
+            'R_hab', 'R_wind', 'R_wave', 'R_surge', 'R_relief', 'R_geomorph',
+            'R_slr', 'population', 'exposure', 'habitat_role',
+            'exposure_no_habitats']
+        # mapping of x, y point coords to their fields in the order above
+        expected_point_results = {
+            (265195.9118871244, 5465342.359978485): [
+                4.05, 5, 5, 1, 5, 1, 5, 0, 3.063308387, 0.0936167899, 3.1569251777],
+            (275802.584962168, 5469283.47691652): [
+                5, 3, 1, 1, 5, 1, 4, 0, 2.2587827631, 0, 2.2587827631],
+            (376479.9819538344, 5383636.197270025): [
+                4.05, 5, 5, 4, 4, 4, 3, numpy.nan, 4.0989337064, 0.125266204816, 4.2241999112],
+            (355807.04065901926, 5394736.771414153): [
+                5, 5, 4, 4, 3, 4, 2, 0, 3.70591872429, 0, 3.70591872429],
+            (344736.25795214524, 5411347.428706937): [
+                5, 2, 4, 3, 3, 4, 1, 0, 2.8261463109, 0, 2.8261463109],
+            (361290.81087879254, 5427975.474574804): [
+                5, 1, 3, 5, 1, 4, 2, 0, 2.493898362454, 0, 2.493898362454],
+            (368269.9048903524, 5449541.99543876): [
+                5, 1, 1, 5, 2, 4, 2, 0.008, 2.3535468936, 0, 2.3535468936],
+            (361341.1463245464, 5433678.995435326): [
+                5, 2, 1, 5, 1, 4, 1, 0, 2.1316631165, 0, 2.1316631165],
+            (339388.60793905176, 5428895.077843302): [
+                5, 3, 4, 4, 2, 4, 1, 0, 2.94471340036, 0, 2.94471340036],
+            (318255.8192637532, 5423278.964182078): [
+                5, 4, 3, 2, 3, 2.5, 1, 0, 2.6426195539, 0, 2.6426195539],
+            (300130.0010361069, 5437435.4230010025): [
+                1.7999999, 4, 5, 2, 5, 1, 3, 0, 2.712353253, 0.426215219066, 3.138568472],
+            (306112.5574508078, 5450095.8865171345): [
+                5, 1, 3, 3, 2, 1, 3, 0, 2.225039271, 0, 2.225039271],
+            (290844.10673833836, 5460752.369983306): [
+                5, 4, 2, 2, 2, 1, 4, 0, 2.5169979012, 0, 2.5169979012],
+            (286971.1600469994, 5475571.525391179): [
+                5, 1, 1, 3, 1, 1, 4, 0, 1.7948229213, 0, 1.7948229213],
+            (268404.5296770451, 5479539.256472221): [
+                5, 2, 2, 1, 1, 1, 5, 0, 1.9306977288, 0, 1.9306977288],
+            (252692.2222200262, 5482540.950248547): [
+                5, 3, 2, 1, 4, 1, 5, 0, 2.49389836245, 0, 2.49389836245]
+        }
+
+        for feature in results_layer:
+            geom = feature.GetGeometryRef()
+            x = geom.GetX()
+            y = geom.GetY()
+            actual_row = []
+            for field in fields:
+                value = feature.GetField(field)
+                if value is None:
+                    actual_row.append(numpy.nan)
+                else:
+                    actual_row.append(value)
+            expected_row = expected_point_results[(x, y)]
+            numpy.testing.assert_allclose(actual_row, expected_row)
 
     def test_final_risk_calc(self):
         """CV: regression test for the final risk score calculation."""

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -713,26 +713,22 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         args['slr_field'] = 'Trend'
         coastal_vulnerability.execute(args)
 
+        # shore points aren't necessarily created/numbered in the same order,
+        # so we can't compare the fid or shore_id fields at all
+        # and need to sort the rows before comparing
         actual_values_df = pandas.read_csv(
-            os.path.join(args['workspace_dir'], 'coastal_exposure.csv'))
+            os.path.join(args['workspace_dir'], 'coastal_exposure.csv')
+        ).drop(['fid', 'shore_id'], axis=1)
+        actual_values_df = actual_values_df.sort_values(
+            by=list(actual_values_df.columns)).reset_index(drop=True)
         expected_values_df = pandas.read_csv(
-            os.path.join(REGRESSION_DATA, 'expected_coastal_exposure.csv'))
+            os.path.join(REGRESSION_DATA, 'expected_coastal_exposure.csv')
+        ).drop(['fid', 'shore_id'], axis=1)
+        expected_values_df = expected_values_df.sort_values(
+            by=list(expected_values_df.columns)).reset_index(drop=True)
+
         pandas.testing.assert_frame_equal(
             actual_values_df, expected_values_df, check_dtype=False)
-
-        # Also expect matching shore_id field in all tabular outputs:
-        intermediate_csv = pandas.read_csv(
-            os.path.join(
-                args['workspace_dir'],
-                'intermediate/intermediate_exposure.csv'))
-        habitat_csv = pandas.read_csv(
-            os.path.join(
-                args['workspace_dir'],
-                'intermediate/habitats/habitat_protection.csv'))
-        pandas.testing.assert_series_equal(
-            actual_values_df['shore_id'], intermediate_csv['shore_id'])
-        pandas.testing.assert_series_equal(
-            actual_values_df['shore_id'], habitat_csv['shore_id'])
 
     def test_final_risk_calc(self):
         """CV: regression test for the final risk score calculation."""
@@ -1112,7 +1108,8 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         landmass_path = os.path.join(
             self.workspace_dir, 'landmass.geojson')
         pygeoprocessing.shapely_geometry_to_vector(
-            [Polygon([(-100, -100), (100, -100), (100, 100), (-100, 100), (-100, -100)])],
+            [Polygon([(-100, -100), (100, -100), (100, 100),
+                      (-100, 100), (-100, -100)])],
             landmass_path, wkt, 'GeoJSON')
 
         model_resolution = 100
@@ -1390,6 +1387,7 @@ def assert_pickled_arrays_almost_equal(
 
 class CoastalVulnerabilityValidationTests(unittest.TestCase):
     """Tests for the CV Model ARGS_SPEC and validation."""
+
     def setUp(self):
         """Create a temporary workspace."""
         self.workspace_dir = tempfile.mkdtemp()
@@ -1513,7 +1511,7 @@ class CoastalVulnerabilityValidationTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             for keys, message in warning_messages:
                 if (keys == ['slr_vector_path'] and
-                    message == 'Must be a point or multipoint geometry.'):
+                        message == 'Must be a point or multipoint geometry.'):
                     raise ValueError(warning_messages)
 
 

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -725,42 +725,45 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             'R_hab', 'R_wind', 'R_wave', 'R_surge', 'R_relief', 'R_geomorph',
             'R_slr', 'population', 'exposure', 'habitat_role',
             'exposure_no_habitats']
-        # mapping of x, y point coords to their fields in the order above
-        expected_point_results = {
-            (265195.9118871244, 5465342.359978485): [
-                4.05, 5, 5, 1, 5, 1, 5, 0, 3.063308387, 0.0936167899, 3.1569251777],
-            (275802.584962168, 5469283.47691652): [
-                5, 3, 1, 1, 5, 1, 4, 0, 2.2587827631, 0, 2.2587827631],
-            (376479.9819538344, 5383636.197270025): [
-                4.05, 5, 5, 4, 4, 4, 3, numpy.nan, 4.0989337064, 0.125266204816, 4.2241999112],
-            (355807.04065901926, 5394736.771414153): [
-                5, 5, 4, 4, 3, 4, 2, 0, 3.70591872429, 0, 3.70591872429],
-            (344736.25795214524, 5411347.428706937): [
-                5, 2, 4, 3, 3, 4, 1, 0, 2.8261463109, 0, 2.8261463109],
-            (361290.81087879254, 5427975.474574804): [
-                5, 1, 3, 5, 1, 4, 2, 0, 2.493898362454, 0, 2.493898362454],
-            (368269.9048903524, 5449541.99543876): [
-                5, 1, 1, 5, 2, 4, 2, 0.008, 2.3535468936, 0, 2.3535468936],
-            (361341.1463245464, 5433678.995435326): [
-                5, 2, 1, 5, 1, 4, 1, 0, 2.1316631165, 0, 2.1316631165],
-            (339388.60793905176, 5428895.077843302): [
-                5, 3, 4, 4, 2, 4, 1, 0, 2.94471340036, 0, 2.94471340036],
-            (318255.8192637532, 5423278.964182078): [
-                5, 4, 3, 2, 3, 2.5, 1, 0, 2.6426195539, 0, 2.6426195539],
-            (300130.0010361069, 5437435.4230010025): [
-                1.7999999, 4, 5, 2, 5, 1, 3, 0, 2.712353253, 0.426215219066, 3.138568472],
-            (306112.5574508078, 5450095.8865171345): [
-                5, 1, 3, 3, 2, 1, 3, 0, 2.225039271, 0, 2.225039271],
-            (290844.10673833836, 5460752.369983306): [
-                5, 4, 2, 2, 2, 1, 4, 0, 2.5169979012, 0, 2.5169979012],
-            (286971.1600469994, 5475571.525391179): [
-                5, 1, 1, 3, 1, 1, 4, 0, 1.7948229213, 0, 1.7948229213],
-            (268404.5296770451, 5479539.256472221): [
-                5, 2, 2, 1, 1, 1, 5, 0, 1.9306977288, 0, 1.9306977288],
-            (252692.2222200262, 5482540.950248547): [
-                5, 3, 2, 1, 4, 1, 5, 0, 2.49389836245, 0, 2.49389836245]
-        }
 
+        # sorted list of expected x, y point coords and their corresponding expected
+        # values for the fields in the order above
+        sorted_expected_data = [
+            [(252692.2222200262, 5482540.950248547),
+                [5, 3, 2, 1, 4, 1, 5, 0, 2.49389836245, 0, 2.49389836245]],
+            [(265195.9118871244, 5465342.359978485),
+                [4.05, 5, 5, 1, 5, 1, 5, 0, 3.063308387, 0.0936167899, 3.1569251777]],
+            [(268404.5296770451, 5479539.256472221),
+                [5, 2, 2, 1, 1, 1, 5, 0, 1.9306977288, 0, 1.9306977288]],
+            [(275802.584962168, 5469283.47691652),
+                [5, 3, 1, 1, 5, 1, 4, 0, 2.2587827631, 0, 2.2587827631]],
+            [(286971.1600469994, 5475571.525391179),
+                [5, 1, 1, 3, 1, 1, 4, 0, 1.7948229213, 0, 1.7948229213]],
+            [(290844.10673833836, 5460752.369983306),
+                [5, 4, 2, 2, 2, 1, 4, 0, 2.5169979012, 0, 2.5169979012]],
+            [(300130.0010361069, 5437435.4230010025),
+                [1.7999999, 4, 5, 2, 5, 1, 3, 0, 2.712353253, 0.426215219066, 3.138568472]],
+            [(306112.5574508078, 5450095.8865171345),
+                [5, 1, 3, 3, 2, 1, 3, 0, 2.225039271, 0, 2.225039271]],
+            [(318255.8192637532, 5423278.964182078),
+                [5, 4, 3, 2, 3, 2.5, 1, 0, 2.6426195539, 0, 2.6426195539]],
+            [(339388.60793905176, 5428895.077843302),
+                [5, 3, 4, 4, 2, 4, 1, 0, 2.94471340036, 0, 2.94471340036]],
+            [(344736.25795214524, 5411347.428706937),
+                [5, 2, 4, 3, 3, 4, 1, 0, 2.8261463109, 0, 2.8261463109]],
+            [(355807.04065901926, 5394736.771414153),
+                [5, 5, 4, 4, 3, 4, 2, 0, 3.70591872429, 0, 3.70591872429]],
+            [(361290.81087879254, 5427975.474574804),
+                [5, 1, 3, 5, 1, 4, 2, 0, 2.493898362454, 0, 2.493898362454]],
+            [(361341.1463245464, 5433678.995435326),
+                [5, 2, 1, 5, 1, 4, 1, 0, 2.1316631165, 0, 2.1316631165]],
+            [(368269.9048903524, 5449541.99543876),
+                [5, 1, 1, 5, 2, 4, 2, 0.008, 2.3535468936, 0, 2.3535468936]],
+            [(376479.9819538344, 5383636.197270025),
+                [4.05, 5, 5, 4, 4, 4, 3, numpy.nan, 4.0989337064, 0.125266204816, 4.2241999112]]
+        ]
+
+        actual_data = []
         for feature in results_layer:
             geom = feature.GetGeometryRef()
             x = geom.GetX()
@@ -772,8 +775,31 @@ class CoastalVulnerabilityTests(unittest.TestCase):
                     actual_row.append(numpy.nan)
                 else:
                     actual_row.append(value)
-            expected_row = expected_point_results[(x, y)]
-            numpy.testing.assert_allclose(actual_row, expected_row)
+            actual_data.append([(x, y), actual_row])
+
+        # the coords and corresponding field values should be close to expected
+        sorted_actual_data = sorted(actual_data)
+        for actual, expected in zip(sorted_actual_data, sorted_expected_data):
+            actual_coords, actual_data = actual[0], actual[1:]
+            expected_coords, expected_data = expected[0], expected[1:]
+            numpy.testing.assert_allclose(actual_coords, expected_coords)
+            numpy.testing.assert_allclose(actual_data, expected_data)
+
+        # Also expect matching shore_id field in all tabular outputs:
+        actual_values_df = pandas.read_csv(
+            os.path.join(args['workspace_dir'], 'coastal_exposure.csv'))
+        intermediate_df = pandas.read_csv(
+            os.path.join(
+                args['workspace_dir'],
+                'intermediate/intermediate_exposure.csv'))
+        habitat_df = pandas.read_csv(
+            os.path.join(
+                args['workspace_dir'],
+                'intermediate/habitats/habitat_protection.csv'))
+        pandas.testing.assert_series_equal(
+            actual_values_df['shore_id'], intermediate_df['shore_id'])
+        pandas.testing.assert_series_equal(
+            actual_values_df['shore_id'], habitat_df['shore_id'])
 
     def test_final_risk_calc(self):
         """CV: regression test for the final risk score calculation."""


### PR DESCRIPTION
# Description
Fixes #597

# Checklist
~~- [ ] Updated HISTORY.rst (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
