### PR TITLE
Bugfix/594 mac binaries failing on rtree import

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -232,12 +232,17 @@ jobs:
                   name: InVEST-dmg
                   path: dist/InVEST*.dmg
 
+            - name: Tar the workspace to preserve permissions
+              if: ${{ failure() }}
+              shell: bash -l {0}
+              run: tar -cvf InVEST-failed-mac-workspace.tar ${{ github.workspace }}
+
             - name: Upload workspace on failure
               if: ${{ failure() }}
               uses: actions/upload-artifact@v2
               with:
                   name: InVEST-failed-mac-workspace
-                  path: ${{ github.workspace }}
+                  path: InVEST-failed-mac-workspace.tar
 
     build-sampledata:
         name: Build sampledata archives

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -125,16 +125,23 @@ jobs:
 
             - name: Upload installer artifact
               if: always()
-              uses: actions/upload-artifact@v2-preview
+              uses: actions/upload-artifact@v2
               with:
                   name: InVEST-windows-installer
                   path: dist/*.exe
 
             - name: Upload user's guide artifact
-              uses: actions/upload-artifact@v2-preview
+              uses: actions/upload-artifact@v2
               with:
                   name: InVEST-user-guide
                   path: dist/InVEST_*_userguide.zip
+
+            - name: Upload workspace on failure
+              if: ${{ failure() }}
+              uses: actions/upload-artifact@v2
+              with:
+                  name: InVEST-failed-windows-workspace
+                  path: ${{ env.GITHUB_WORKSPACE }}
 
     build-mac-binaries:
         name: "Build mac binaries"
@@ -214,16 +221,23 @@ jobs:
               run: make deploy
 
             - name: Upload binaries artifact
-              uses: actions/upload-artifact@v2-preview
+              uses: actions/upload-artifact@v2
               with:
                   name: InVEST-mac-binaries
                   path: dist/InVEST-*-mac.zip
 
             - name: Upload DMG artifact
-              uses: actions/upload-artifact@v2-preview
+              uses: actions/upload-artifact@v2
               with:
                   name: InVEST-dmg
                   path: dist/InVEST*.dmg
+
+            - name: Upload workspace on failure
+              if: ${{ failure() }}
+              uses: actions/upload-artifact@v2
+              with:
+                  name: InVEST-failed-mac-workspace
+                  path: ${{ env.GITHUB_WORKSPACE }}
 
     build-sampledata:
         name: Build sampledata archives
@@ -259,7 +273,7 @@ jobs:
               run: make deploy
 
             - name: Upload sample data artifact
-              uses: actions/upload-artifact@v2-preview
+              uses: actions/upload-artifact@v2
               with:
                   name: InVEST-sample-data
                   path: dist/*.zip

--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -141,7 +141,7 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: InVEST-failed-windows-workspace
-                  path: ${{ env.GITHUB_WORKSPACE }}
+                  path: ${{ github.workspace }}
 
     build-mac-binaries:
         name: "Build mac binaries"
@@ -237,7 +237,7 @@ jobs:
               uses: actions/upload-artifact@v2
               with:
                   name: InVEST-failed-mac-workspace
-                  path: ${{ env.GITHUB_WORKSPACE }}
+                  path: ${{ github.workspace }}
 
     build-sampledata:
         name: Build sampledata archives

--- a/exe/hooks/rthook.py
+++ b/exe/hooks/rthook.py
@@ -12,3 +12,8 @@ if platform.system() == 'Darwin':
     # See https://bugreports.qt.io/browse/QTBUG-87014
     # and https://github.com/natcap/invest/issues/384
     os.environ['QT_MAC_WANTS_LAYER'] = '1'
+
+    # Rtree will look in this directory first for libspatialindex_c.dylib.
+    # In response to issues with github mac binary builds:
+    # https://github.com/natcap/invest/issues/594
+    os.environ['SPATIALINDEX_C_LIBRARY'] = sys._MEIPASS

--- a/installer/darwin/build_app_bundle.sh
+++ b/installer/darwin/build_app_bundle.sh
@@ -54,6 +54,10 @@ echo "# binary to run on OSX Big Sur." >> $new_command_file
 echo "#" >> $new_command_file
 echo "# Taken from https://stackoverflow.com/a/246128/299084" >> $new_command_file
 echo 'DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"' >> $new_command_file
-echo 'QT_MAC_WANTS_LAYER=1 "$DIR/invest_dist/invest" launch' >> $new_command_file
+# QT_MAC_WANTS_LAYER is to address a hanging issue in Qt 5.15 with launching Qt
+# on OS 11 Big Sur.
+# QT_QPA_PLATFORM_PLUGIN_PATH addresses an issue where sometimes Qt can't find
+# the plugins where they are expected to be.
+echo 'QT_MAC_WANTS_LAYER=1 QT_QPA_PLATFORM_PLUGIN_PATH=$DIR/invest_dist/PySide2/Qt/plugins "$DIR/invest_dist/invest" launch' >> $new_command_file
 chmod a+x $new_command_file
 

--- a/installer/darwin/build_app_bundle.sh
+++ b/installer/darwin/build_app_bundle.sh
@@ -54,7 +54,7 @@ echo "# binary to run on OSX Big Sur." >> $new_command_file
 echo "#" >> $new_command_file
 echo "# Taken from https://stackoverflow.com/a/246128/299084" >> $new_command_file
 echo 'DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"' >> $new_command_file
-# QT_MAC_WANTS_LAYER is to address a hanging issue in Qt 5.15 with launching Qt
+# QT_MAC_WANTS_LAYER is to address a hanging issue in Qt 5.13 with launching Qt
 # on OS 11 Big Sur.
 # QT_QPA_PLATFORM_PLUGIN_PATH addresses an issue where sometimes Qt can't find
 # the plugins where they are expected to be.


### PR DESCRIPTION
This PR addresses the RTree binary issue described in #594 and a couple of other things along the way:

* A Qt issue experienced on mac (couldn't find the plugin directory) has been addressed with a new environment variable in the app bundle launcher script
* In the binary build workflow, The entire build workspace is wrapped up on build failure for examination.  This has been done as a part of the debugging of this on mac and preemptively for future debugging on Windows.
* Upload-artifact version has been bumped from `v2-preview` to `v2`.

Because this isn't exactly a user-facing set of changes (these failures have not been reported in an officially-released version of InVEST), no note has been recorded in HISTORY nor in the user's guide.

Fixes #594

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
