### PR TITLE
reverting the changes in #582, to address #580.

### DIFF
--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -587,14 +587,7 @@ def main(user_args=None):
 
             # We're deliberately not validating here because the user
             # can just call ``invest validate <datastack>`` to validate.
-            try:
-                getattr(model_module, 'execute')(parsed_datastack.args)
-            # Graceful exit from this program, otherwise the pyinstaller-made
-            # executeable will exit with 'Failed to execute script cli' on an
-            # uncaught exception. And that only adds unhelpful noise to stderr.
-            except Exception as error:
-                LOGGER.exception(error)
-                parser.exit(DEFAULT_EXIT_CODE)
+            getattr(model_module, 'execute')(parsed_datastack.args)
 
     # If we're running in a GUI (either through ``invest run`` or
     # ``invest quickrun``), we'll need to load the Model's GUI class,


### PR DESCRIPTION
This PR reverts the changes we made in #582. It was not a good idea to catch all invest exceptions just for the purpose of hiding the final bit of stderr emitted by the Pyinstaller-built executeable. 
Fixes #580 

# Checklist
- [ ] Updated HISTORY.rst - we never updated history during #582, so no need to update it here.

- [ ] Updated the user's guide (if needed)
