### PR TITLE
Include newly required flags on signtool commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,8 +390,8 @@ signcode:
 
 signcode_windows:
 	$(GSUTIL) cp 'gs://stanford_cert/$(P12_FILE)' '$(BUILD_DIR)/$(P12_FILE)'
-	powershell.exe "& '$(SIGNTOOL)' sign /f '$(BUILD_DIR)\$(P12_FILE)' /p '$(CERT_KEY_PASS)' '$(BIN_TO_SIGN)'"
-	powershell.exe "& '$(SIGNTOOL)' timestamp -t http://timestamp.sectigo.com '$(BIN_TO_SIGN)'"
+	powershell.exe "& '$(SIGNTOOL)' sign /fd SHA256 /f '$(BUILD_DIR)\$(P12_FILE)' /p '$(CERT_KEY_PASS)' '$(BIN_TO_SIGN)'"
+	powershell.exe "& '$(SIGNTOOL)' timestamp -t http://timestamp.sectigo.com /td SHA256 '$(BIN_TO_SIGN)'"
 	-$(RM) $(BUILD_DIR)/$(P12_FILE)
 	@echo "Installer was signed with signtool"
 


### PR DESCRIPTION
# Description
Windows builds on `main` are now failing due to a change to SignTool (see the Note here: https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe). Example: https://github.com/natcap/invest/runs/3624109257#step:10:28

This PR adds the newly required flags to the signtool commands.

# Checklist
~- [ ] Updated HISTORY.rst (if these changes are user-facing)~
~- [ ] Updated the user's guide (if needed)~
