### PR TITLE
Change signtool timestamp option t to tr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ signcode:
 signcode_windows:
 	$(GSUTIL) cp 'gs://stanford_cert/$(P12_FILE)' '$(BUILD_DIR)/$(P12_FILE)'
 	powershell.exe "& '$(SIGNTOOL)' sign /fd SHA256 /f '$(BUILD_DIR)\$(P12_FILE)' /p '$(CERT_KEY_PASS)' '$(BIN_TO_SIGN)'"
-	powershell.exe "& '$(SIGNTOOL)' timestamp -t http://timestamp.sectigo.com /td SHA256 '$(BIN_TO_SIGN)'"
+	powershell.exe "& '$(SIGNTOOL)' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$(BIN_TO_SIGN)'"
 	-$(RM) $(BUILD_DIR)/$(P12_FILE)
 	@echo "Installer was signed with signtool"
 


### PR DESCRIPTION
Missed this the first time around. `/t` needed to change to `/tr`, indicating it's a RFC 3161 time stamp server, not just any old time stamp server. I'm guessing this is required to make sure the hash option in `/td` is supported.

The code signing step does not run in PR workflows, which is how I missed this last time, but you can see that it's working in the checks on my branch.