### PR TITLE
Bugfix/651 hra traceback not written to logfile

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -77,6 +77,13 @@ Unreleased Changes (3.9.1)
       debugging some hard-to-reproduce GDAL logging errors that occasionally
       cause InVEST models to crash.  If GDAL calls ``_log_gdal_errors`` with an
       incorrect set of arguments, this is now logged.
+    * Improved the reliability and consistency of log messages across the
+      various ways that InVEST models can be run.  Running InVEST in
+      ``--headless`` mode, for example, will now have the same logging behavior,
+      including with exceptions, as the UI would produce.
+    * The default log level for the CLI has been lowered from
+      ``logging.CRITICAL`` to ``logging.ERROR``.  This ensures that exceptions
+      should always be written to the correct logging streams.
 * Carbon
     * Fixed a bug where, if rate change and discount rate were set to 0, the
       valuation results were in $/year rather than $, too small by a factor of

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -387,9 +387,9 @@ def main(user_args=None):
               'the console and (if running in headless mode) how much is '
               'written to the logfile.'))
     verbosity_group.add_argument(
-        '--debug', dest='log_level', default=logging.CRITICAL,
+        '--debug', dest='log_level', default=logging.ERROR,
         action='store_const', const=logging.DEBUG,
-        help='Enable debug logging. Alias for -vvvvv')
+        help='Enable debug logging. Alias for -vvvv')
 
     subparsers = parser.add_subparsers(dest='subcommand')
 
@@ -475,7 +475,7 @@ def main(user_args=None):
     # arguments.  Verbosity: the more v's the lower the logging threshold.
     # If --debug is used, the logging threshold is 10.
     # If the user goes lower than logging.DEBUG, default to logging.DEBUG.
-    log_level = min(args.log_level, logging.CRITICAL - (args.verbosity*10))
+    log_level = min(args.log_level, logging.ERROR - (args.verbosity*10))
     handler.setLevel(max(log_level, logging.DEBUG))  # don't go below DEBUG
     root_logger.addHandler(handler)
     LOGGER.info('Setting handler log level to %s', log_level)

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -587,6 +587,10 @@ def main(user_args=None):
 
             # We're deliberately not validating here because the user
             # can just call ``invest validate <datastack>`` to validate.
+            #
+            # Exceptions will already be logged to the logfile but will ALSO be
+            # written to stdout if this exception is uncaught.  This is by
+            # design.
             getattr(model_module, 'execute')(parsed_datastack.args)
 
     # If we're running in a GUI (either through ``invest run`` or

--- a/src/natcap/invest/ui/inputs.py
+++ b/src/natcap/invest/ui/inputs.py
@@ -2497,9 +2497,13 @@ class Form(QtWidgets.QWidget):
         if not hasattr(target, '__call__'):
             raise ValueError('Target %s must be callable' % target)
 
+        # Don't need to log an exception or completion in the Executor thread
+        # in the case of a model run; those messages are handled by
+        # utils.prepare_workspace.
         self._thread = execution.Executor(target,
                                           args,
-                                          kwargs)
+                                          kwargs,
+                                          log_events=False)
         self._thread.finished.connect(self._run_finished)
 
         self.run_dialog.show()

--- a/src/natcap/invest/ui/model.py
+++ b/src/natcap/invest/ui/model.py
@@ -692,8 +692,8 @@ class WindowTitle(QtCore.QObject):
         # that handle __setattr__ differently. In 3.7, the super()
         # implementation causes a `TypeError: can't apply this __setattr__
         # to object object` when running `invest run carbon`. In Python 3.8.4+
-        # with the object implementation the error `TypeError: can't apply 
-        # this __setattr__ to Carbon object` 
+        # with the object implementation the error `TypeError: can't apply
+        # this __setattr__ to Carbon object`
         if (sys.version_info.minor >= 8) and (sys.version_info.micro >= 4):
             super().__setattr__(name, value)
         else:
@@ -1477,8 +1477,8 @@ class InVESTModel(QtWidgets.QMainWindow):
         # that handle __setattr__ differently. In 3.7, the super()
         # implementation causes a `TypeError: can't apply this __setattr__
         # to object object` when running `invest run carbon`. In Python 3.8.4+
-        # with the object implementation the error `TypeError: can't apply 
-        # this __setattr__ to Carbon object` 
+        # with the object implementation the error `TypeError: can't apply
+        # this __setattr__ to Carbon object`
         if (sys.version_info.minor >= 8) and (sys.version_info.micro >= 4):
             super().__setattr__(name, value)
         else:
@@ -1645,15 +1645,9 @@ class InVESTModel(QtWidgets.QMainWindow):
                                'Starting model with parameters: \n%s',
                                datastack.format_args_dict(
                                    args, self.target.__module__))
-
-                    try:
-                        return self.target(args=args)
-                    except Exception:
-                        LOGGER.exception('Exception while executing %s',
-                                         self.target)
-                        raise
-                    finally:
-                        LOGGER.info('Execution finished')
+                    # Exceptions will be captured and logged in
+                    # utils.prepare_workspace.
+                    return self.target(args=args)
 
         self.form.run(target=_logged_target,
                       window_title='Running %s' % self.label,
@@ -1853,7 +1847,7 @@ class InVESTModel(QtWidgets.QMainWindow):
         def _validate(new_value):
             # We want to validate the whole form; discard the individual value
             self.validate(block=False)
-        
+
         # Set up quickrun options if we're doing a quickrun
         if quickrun:
             @QtCore.Slot()

--- a/src/natcap/invest/ui/usage.py
+++ b/src/natcap/invest/ui/usage.py
@@ -115,12 +115,15 @@ def _calculate_args_bounding_box(args, args_spec):
         # Using gdal.OpenEx to check if an input is spatial caused the
         # model to hang sometimes (possible race condition), so only
         # get the bounding box of inputs that are known to be spatial.
+        # Also eliminate any string paths that are empty to prevent an
+        # exception.
         spatial_info = None
-        if args_spec['args'][key]['type'] == 'raster':
+        if args_spec['args'][key]['type'] == 'raster' and value.strip() != '':
             spatial_info = pygeoprocessing.get_raster_info(value)
-        elif args_spec['args'][key]['type'] == 'vector':
+        elif (args_spec['args'][key]['type'] == 'vector'
+                and value.strip() != ''):
             spatial_info = pygeoprocessing.get_vector_info(value)
-                    
+
         if spatial_info:
             local_bb = spatial_info['bounding_box']
             projection_wkt = spatial_info['projection_wkt']
@@ -181,7 +184,7 @@ def _log_exit_status(session_id, status):
         log_finish_url = json.loads(urlopen(
             _ENDPOINTS_INDEX_URL).read().strip())['FINISH']
 
-        # The data must be a python string of bytes. This will be ``bytes`` 
+        # The data must be a python string of bytes. This will be ``bytes``
         # in python3.
         urlopen(Request(log_finish_url, urlencode(payload).encode('utf-8')))
     except Exception as exception:
@@ -236,7 +239,7 @@ def _log_model(model_name, model_args, session_id=None):
         log_start_url = json.loads(urlopen(
             _ENDPOINTS_INDEX_URL).read().strip())['START']
 
-        # The data must be a python string of bytes. This will be ``bytes`` 
+        # The data must be a python string of bytes. This will be ``bytes``
         # in python3.
         urlopen(Request(log_start_url, urlencode(payload).encode('utf-8')))
     except Exception as exception:

--- a/src/natcap/invest/ui/usage.py
+++ b/src/natcap/invest/ui/usage.py
@@ -116,7 +116,9 @@ def _calculate_args_bounding_box(args, args_spec):
         # model to hang sometimes (possible race condition), so only
         # get the bounding box of inputs that are known to be spatial.
         # Also eliminate any string paths that are empty to prevent an
-        # exception.
+        # exception. By the time we've made it to this function, all paths
+        # should already have been validated so the path is either valid or
+        # blank.
         spatial_info = None
         if args_spec['args'][key]['type'] == 'raster' and value.strip() != '':
             spatial_info = pygeoprocessing.get_raster_info(value)

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -158,10 +158,14 @@ def prepare_workspace(
             start_time = time.time()
             try:
                 yield
+            except Exception:
+                LOGGER.exception(f'Exception while executing {modelname}')
+                raise
             finally:
                 LOGGER.info('Elapsed time: %s',
                             _format_time(round(time.time() - start_time, 2)))
                 logging.captureWarnings(False)
+                LOGGER.info('Execution finished')
 
 
 class ThreadFilter(logging.Filter):

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -143,10 +143,11 @@ def prepare_workspace(
     if not os.path.exists(workspace):
         os.makedirs(workspace)
 
+    modelname = '-'.join(name.replace(':', '').split(' '))
     logfile = os.path.join(
         workspace,
         'InVEST-{modelname}-log-{timestamp}.txt'.format(
-            modelname='-'.join(name.replace(':', '').split(' ')),
+            modelname=modelname,
             timestamp=datetime.now().strftime("%Y-%m-%d--%H_%M_%S")))
 
     with capture_gdal_logging(), log_to_file(logfile,

--- a/ui_tests/test_model_logging.py
+++ b/ui_tests/test_model_logging.py
@@ -58,14 +58,18 @@ class ModelLoggingTests(unittest.TestCase):
         model_args = {
             'raster': raster_path,
             'vector': vector_path,
-            'not_a_gis_input': 'foobar'
+            'not_a_gis_input': 'foobar',
+            'blank_raster_path': '',
+            'blank_vector_path': '',
         }
 
         args_spec = {
             'args': {
                 'raster': {'type': 'raster'},
                 'vector': {'type': 'vector'},
-                'not_a_gis_input': {'type': 'freestyle_string'}
+                'not_a_gis_input': {'type': 'freestyle_string'},
+                'blank_raster_path': {'type': 'raster'},
+                'blank_vector_path': {'type': 'vector'},
             }
         }
 


### PR DESCRIPTION
This PR improves the consistency of logging across the various ways we typically run InVEST models by:

* Ensuring that `utils.prepare_workspace` is the source of truth for logging a traceback on model failure
* Lowering the default logging threshold from `logging.CRITICAL` to `logging.ERROR`, which ensures that
   exceptions should be logged by default (`LOGGER.exception` calls have an `ERROR` level)

`--headless` runs will still print their traceback to stderr, but the above changes should still ensure that the appropriate logging streams (stdout, logfile, Qt messages window) will all show exceptions.

@davemfish I'd really appreciate if you could make sure that the changes included here look reasonable to you and don't break anything in the workbench!  I've tried not to make any drastic functional changes (aside from fiddling with what's logged where), but I'd appreciate you taking a look at this.  Thanks in advance!

Fixes #651

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) _not needed_
