### PR TITLE
CLI: fixing helptext for verbosity arg. #682.

### DIFF
--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -389,7 +389,7 @@ def main(user_args=None):
     verbosity_group.add_argument(
         '--debug', dest='log_level', default=logging.ERROR,
         action='store_const', const=logging.DEBUG,
-        help='Enable debug logging. Alias for -vvvv')
+        help='Enable debug logging. Alias for -vvv')
 
     subparsers = parser.add_subparsers(dest='subcommand')
 


### PR DESCRIPTION
This PR updates the help text to reflect the change in #655 . Since we changed the default logging level from CRITICAL to ERROR, we now have a verbosity arg that breaks down like this:

`-vvv` = DEBUG
`-vv`   = INFO
`-v`      = WARNING

Fixes #682 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing) I feel like this is so minor it's not worth drawing attention to in history.

- [x] Updated the user's guide (if needed)
