### PR TITLE
Add JSON files to the single sampledata archive

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,12 +40,12 @@ Unreleased Changes
     * Improving our binary build by including a data file needed for the
       ``charset-normalizer`` python package.  This eliminates a warning that
       was printed to stdout on Windows.
-    * The Annual Water Yield model name is now standardized throughout InVEST. 
-      This model has been known in different contexts as Hydropower, Hydropower 
-      Water Yield, or Annual Water Yield. This name was chosen to emphasize 
-      that the model can be used for purposes other than hydropower (though the 
-      valuation component is hydropower-specific) and to highlight its 
-      difference from the Seasonal Water Yield model. The corresponding python 
+    * The Annual Water Yield model name is now standardized throughout InVEST.
+      This model has been known in different contexts as Hydropower, Hydropower
+      Water Yield, or Annual Water Yield. This name was chosen to emphasize
+      that the model can be used for purposes other than hydropower (though the
+      valuation component is hydropower-specific) and to highlight its
+      difference from the Seasonal Water Yield model. The corresponding python
       module, formerly ``natcap.invest.hydropower.hydropower_water_yield``, is
       now ``natcap.invest.annual_water_yield``.
     * Minor changes to some other models' display names.
@@ -55,6 +55,8 @@ Unreleased Changes
       when looking for GDAL DLLs.  This fixes an issue where InVEST would not
       launch on computers where the ``%PATH%`` either contained other
       environment variables or was malformed.
+    * JSON sample data parameter sets are now included in the complete sample
+      data archives.
 * Seasonal Water Yield
     * Fixed a bug in validation where providing the monthly alpha table would
       cause a "Spatial file <monthly alpha table> has no projection" error.

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ SAMPLEDATA_SINGLE_ARCHIVE := dist/InVEST_$(VERSION)_sample_data.zip
 sampledata_single: $(SAMPLEDATA_SINGLE_ARCHIVE)
 
 $(SAMPLEDATA_SINGLE_ARCHIVE): $(GIT_SAMPLE_DATA_REPO_PATH) dist
-	$(BASHLIKE_SHELL_COMMAND) "cd $(GIT_SAMPLE_DATA_REPO_PATH) && $(ZIP) -r ../../$(SAMPLEDATA_SINGLE_ARCHIVE) ./* -x .svn -x .git -x *.json"
+	$(BASHLIKE_SHELL_COMMAND) "cd $(GIT_SAMPLE_DATA_REPO_PATH) && $(ZIP) -r ../../$(SAMPLEDATA_SINGLE_ARCHIVE) ./* -x .svn -x .git"
 
 
 # Installers for each platform.


### PR DESCRIPTION
I've verified that the JSON datastack files are now included in _both_ the unified sample data archive and the individual sample data archives.

Fixes #669

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) (not needed)
