### PR TITLE
Fixing some key errors ahead of 3.9.2 release

### DIFF
--- a/src/natcap/invest/ui/hra.py
+++ b/src/natcap/invest/ui/hra.py
@@ -7,10 +7,10 @@ class HabitatRiskAssessment(model.InVESTModel):
     def __init__(self):
         model.InVESTModel.__init__(
             self,
-            label=MODEL_METADATA['hra'].model_title,
+            label=MODEL_METADATA['habitat_risk_assessment'].model_title,
             target=hra.execute,
             validator=hra.validate,
-            localdoc=MODEL_METADATA['hra'].userguide)
+            localdoc=MODEL_METADATA['habitat_risk_assessment'].userguide)
 
         self.info_table_path = inputs.File(
             args_key='info_table_path',

--- a/src/natcap/invest/ui/scenario_gen.py
+++ b/src/natcap/invest/ui/scenario_gen.py
@@ -12,10 +12,10 @@ class ScenarioGenProximity(model.InVESTModel):
     def __init__(self):
         model.InVESTModel.__init__(
             self,
-            label=MODEL_METADATA['scenario_gen_proximity'].model_title,
+            label=MODEL_METADATA['scenario_generator_proximity'].model_title,
             target=scenario_gen_proximity.execute,
             validator=scenario_gen_proximity.validate,
-            localdoc=MODEL_METADATA['scenario_gen_proximity'].userguide)
+            localdoc=MODEL_METADATA['scenario_generator_proximity'].userguide)
 
         self.base_lulc_path = inputs.File(
             args_key='base_lulc_path',


### PR DESCRIPTION
When running `invest-autotest.py` I came across some key errors from `src/natcap/invest/__init__.py` when referencing the `MODEL_METADATA`. I decided to clear these issues out of the way before starting the 3.9.2 release process.

Fixing for hra and scenario generator

No need to update History since these changes never rolled out.

# Description
#705 

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
