### PR TITLE
Bugfix/709 logfile message logginglevel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -56,6 +56,8 @@ Unreleased Changes
       when looking for GDAL DLLs.  This fixes an issue where InVEST would not
       launch on computers where the ``%PATH%`` either contained other
       environment variables or was malformed.
+    * invest processes announce their logfile path at a very high logging level
+      that cannot be filtered out by the user.
 * Seasonal Water Yield
     * Fixed a bug in validation where providing the monthly alpha table would
       cause a "Spatial file <monthly alpha table> has no projection" error.

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -155,7 +155,10 @@ def prepare_workspace(
                                              logging_level=logging_level):
         with sandbox_tempdir(dir=workspace):
             logging.captureWarnings(True)
-            LOGGER.info('Writing log messages to %s', logfile)
+            # If invest is launched as a subprocess (e.g. the Workbench)
+            # the parent process can rely on this announcement to know the
+            # logfile path, and to know the invest process has started.
+            LOGGER.log(100, 'Writing log messages to %s', logfile)
             start_time = time.time()
             try:
                 yield


### PR DESCRIPTION
Change the log level on a key message that is emitted at the start of every invest job. Please see #709 for the details.

Fixes #709 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
