### PR TITLE
Urban Nature Access: boilerplate and population resampling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires = ['setuptools', 'wheel', 'setuptools_scm', 'numpy', 'cython']
 # Each section of imports will be sorted alphabetically
 force_alphabetical_sort_within_sections = true
 
-# "from osgeo import gdal" and "from osgeo impor osr" are on separate lines
+# "from osgeo import gdal" and "from osgeo import osr" are on separate lines
 force_single_line = true
 
 # This defines the sections used, and clarifies that we don't want to have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,23 @@
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
 requires = ['setuptools', 'wheel', 'setuptools_scm', 'numpy', 'cython']
+
+[tool.isort]
+# isort can be installed from conda-forge
+# flake8-isort can also be used for flake8 linting integration
+#
+# To test isort configuration, run:
+#     isort . --show-config
+# A warning will present if config can't be loaded.
+#
+# Each section of imports will be sorted alphabetically
+force_alphabetical_sort_within_sections = true
+
+# "from osgeo import gdal" and "from osgeo impor osr" are on separate lines
+force_single_line = true
+
+# This defines the sections used, and clarifies that we don't want to have
+# lines between the FIRSTPARTY (absolute natcap.invest imports) and the
+# LOCALFOLDER (relative imports, e.g. "from . import validation) section.
+sections = 'FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER'
+no_lines_before = 'LOCALFOLDER'

--- a/src/natcap/invest/__init__.py
+++ b/src/natcap/invest/__init__.py
@@ -197,6 +197,12 @@ MODEL_METADATA = {
         gui='urban_cooling_model.UrbanCoolingModel',
         userguide='urban_cooling_model.html',
         aliases=('ucm',)),
+    'urban_nature_access': _MODELMETA(
+        model_title='Urban Nature Access',
+        pyname='natcap.invest.urban_nature_access',
+        gui='',  # TODO
+        userguide='',  # TODO,
+        aliases=('una',)),
 }
 
 

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -39,8 +39,7 @@ ARGS_SPEC = {
             'about': (
                 "A map of LULC codes. "
                 "All values in this raster must have corresponding entries "
-                "in the LULC attribute table.  This raster must be linearly "
-                "projected in meters."),
+                "in the LULC attribute table."),
         },
         'lulc_attribute_table': {
             'name': 'LULC attribute table',

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -74,7 +74,7 @@ ARGS_SPEC = {
             'projection_units': u.meter,
             'about': (
                 "A raster representing the number of people who live in each "
-                "pixel. This raster must be linearly projected in meters."
+                "pixel."
             ),
         },
         'admin_unit_vector_path': {

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -39,7 +39,8 @@ ARGS_SPEC = {
             'about': (
                 "A map of LULC codes. "
                 "All values in this raster must have corresponding entries "
-                "in the LULC attribute table."),
+                "in the LULC attribute table.  This raster must be linearly "
+                "projected in meters."),
         },
         'lulc_attribute_table': {
             'name': 'LULC attribute table',
@@ -71,9 +72,10 @@ ARGS_SPEC = {
                 1: {'type': 'number', 'units': u.none}
             },
             'projected': True,
+            'projection_units': u.meter,
             'about': (
                 "A raster representing the number of people who live in each "
-                "pixel. This raster must be linearly projected."
+                "pixel. This raster must be linearly projected in meters."
             ),
         },
         'admin_unit_vector_path': {
@@ -207,6 +209,7 @@ def _resample_population_raster(
     Args:
         source_population_raster_path (string): The source population raster.
             Pixel values represent the number of people occupying the pixel.
+            Must be linearly projected in meters.
         target_population_raster_path (string): The path to where the target,
             warped population raster will live on disk.
         target_pixel_size (tuple): A tuple of the pixel size for the target
@@ -215,7 +218,8 @@ def _resample_population_raster(
             Passed directly to ``pygeoprocessing.warp_raster``.
         target_projection_wkt (string): The Well-Known Text of the target
             spatial reference fro the target raster.  Passed directly to
-            ``pygeoprocessing.warp_raster``.
+            ``pygeoprocessing.warp_raster``.  Assumed to be a linear projection
+            in meters.
         working_dir (string): The path to a directory on disk.  A new directory
             is created within this directory for the storage of temporary files
             and then deleted upon successful completion of the function.

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -23,7 +23,9 @@ ARGS_SPEC = {
     'pyname': MODEL_METADATA['urban_nature_access'].pyname,
     'userguide_html': MODEL_METADATA['urban_nature_access'].userguide,
     'args_with_spatial_overlap': {
-        'spatial_keys': [],
+        'spatial_keys': [
+            'lulc_raster_path', 'population_raster_path',
+            'admin_unit_vector_path'],
         'different_projections_ok': True,
     },
     'args': {
@@ -312,4 +314,5 @@ def _resample_population_raster(
 
 
 def validate(args, limit_to=None):
-    return validation.validate(args, ARGS_SPEC['args'])
+    return validation.validate(
+        args, ARGS_SPEC['args'], ARGS_SPEC['args_with_spatial_overlap'])

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -3,6 +3,9 @@ import logging
 
 import pygeoprocessing
 import taskgraph
+from osgeo import gdal
+from osgeo import osr
+import numpy
 
 from . import validation
 from . import spec_utils
@@ -11,6 +14,8 @@ from .spec_utils import u
 from .. import MODEL_METADATA
 
 LOGGER = logging.getLogger(__name__)
+UINT32_NODATA = numpy.finfo(numpy.uint32).max
+FLOAT32_NODATA = numpy.finfo(numpy.float32).max
 ARGS_SPEC = {
     'model_name': MODEL_METADATA['urban_nature_access'].model_title,
     'pyname': MODEL_METADATA['urban_nature_access'].pyname,
@@ -42,7 +47,10 @@ ARGS_SPEC = {
         'population_raster_path': {
             'type': 'raster',
             'name': 'population raster',
-            'bands': {1: {'type': 'float'}},
+            'bands': {
+                1: {'type': 'number', 'units': u.none}
+            },
+            'projected': True,
             'about': "",  # TODO,
         },
         'admin_unit_vector_path': {
@@ -71,6 +79,7 @@ ARGS_SPEC = {
 
 _OUTPUT_BASE_FILES = {}
 _INTERMEDIATE_BASE_FILES = {}
+
 
 def execute(args):
     """Urban Nature Access.
@@ -134,7 +143,114 @@ def execute(args):
         n_workers = -1  # Synchronous execution
     graph = taskgraph.TaskGraph(work_token_dir, n_workers)
 
+    graph.close()
+    graph.join()
     LOGGER.info('Finished Urban Nature Access Model')
+
+
+def _resample_population_raster(
+        source_population_raster_path, target_population_raster_path,
+        target_pixel_size, target_bb, target_projection_wkt, working_dir):
+    # Assumes population raster is linearly projected
+    # Reasoning: the total population of a pixel is great, but we need to be
+    # able to convert that pixel size without losing or gaining people due to
+    # resampling.
+    #
+    # Approach:
+    # * Assume population raster is linearly projected.
+    # * raster_calculator: convert population raster to density of people/pixel
+    # * align_and_resize_raster_stack: resample (bilinear should be fine) to
+    #   LULC raster's alignment/resolution
+    # * raster_calculator: Reconvert the population raster from density to
+    #   population
+
+    # Option 1: I could do each task right in the execute function
+    # Option 2: I could do the 2 raster_calculator calls and 1 warp_raster call
+    #     right here in this function
+
+    population_raster_info = pygeoprocessing.get_raster_info(
+        source_population_raster_path)
+    pixel_area = numpy.multiply(population_raster_info['pixel_size'])
+    population_nodata = population_raster_info['nodata'][0]
+
+    population_srs = osr.SpatialReference()
+    population_srs.ImportFromWKT(population_raster_info['projection_wkt'])
+
+    # Convert population pixel area to square km
+    population_pixel_area = (
+        pixel_area * population_srs.GetLinearUnits()) / 1e6
+
+    def _convert_population_to_density(population):
+        """Convert population counts to population per square km.
+
+        Args:
+            population (numpy.array): A numpy array where pixel values
+                represent the number of people who reside in a pixel.
+
+        Returns:
+            """
+        out_array = numpy.full(
+            population.shape, FLOAT32_NODATA, dtype=numpy.float32)
+
+        valid_mask = slice()
+        if population_nodata is not None:
+            valid_mask = ~numpy.isclose(population, population_nodata)
+
+        out_array[valid_mask] = population[valid_mask] / population_pixel_area
+        return out_array
+
+    # Step 1: convert the population raster to population density per sq. km
+    density_raster_path = os.path.join(working_dir, 'pop_density.tif')
+    pygeoprocessing.raster_calculator(
+        [(source_population_raster_path, 1)],
+        _convert_population_to_density,
+        density_raster_path, gdal.GDT_Float32, FLOAT32_NODATA)
+
+    # Step 2: align to the LULC
+    warped_density_path = os.path.join(working_dir, 'warped_density.tif')
+    pygeoprocessing.warp_raster(
+        density_raster_path,
+        target_pixel_size=target_pixel_size,
+        target_raster_path=warped_density_path,
+        resample_method='bilinear',
+        target_bb=target_bb,
+        target_projection_wkt=target_projection_wkt)
+
+    # Step 3: convert the warped population raster back from density to the
+    # population per pixel
+    target_srs = osr.SpatialReference()
+    target_srs.ImportFromWKT(target_projection_wkt)
+    # Calculate target pixel area in km to match above
+    target_pixel_area = (
+        numpy.multiply(target_pixel_size) * target_srs.GetLinearUnits()) / 1e6
+
+    def _convert_density_to_population(density):
+        """Convert a population density raster back to population counts.
+
+        Args:
+            density (numpy.array): An array of the population density per
+                square kilometer.
+
+        Returns:
+            A ``numpy.array`` of the population counts given the target pixel
+            size of the output raster."""
+        # We're using a float32 array here because doing these unit
+        # conversions is likely to end up with partial people spread out
+        # between multiple pixels.  So it's preserving an unrealistic degree of
+        # precision, but that's probably OK because pixels are imprecise
+        # measures anyways.
+        out_array = numpy.full(
+            density.shape, FLOAT32_NODATA, dtype=numpy.float32)
+
+        # We already know that the nodata value is FLOAT32_NODATA
+        valid_mask = ~numpy.isclose(density, FLOAT32_NODATA)
+        out_array[valid_mask] = density[valid_mask] * target_pixel_area
+        return out_array
+
+    pygeoprocessing.raster_calculator(
+        [(warped_density_path, 1)],
+        _convert_density_to_population,
+        target_population_raster_path, gdal.GDT_Float32, FLOAT32_NODATA)
 
 
 def validate(args, limit_to=None):

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -153,6 +153,39 @@ def execute(args):
 def _resample_population_raster(
         source_population_raster_path, target_population_raster_path,
         target_pixel_size, target_bb, target_projection_wkt, working_dir):
+    """Resample a population raster without losing or gaining people.
+
+    Population rasters are an interesting special case where the data are
+    neither continuous nor categorical, and the total population count
+    typically matters.  Common resampling methods for continuous
+    (interpolation) and categorical (nearest-neighbor) datasets leave room for
+    the total population of a resampled raster to significantly change.  This
+    function resamples a population raster with the following steps:
+
+        1. Convert a population count raster to population density per pixel
+        2. Warp the population density raster to the target spatial reference
+           and pixel size using bilinear interpolation.
+        3. Convert the warped density raster back to population counts.
+
+    Args:
+        source_population_raster_path (string): The source population raster.
+            Pixel values represent the number of people occupying the pixel.
+        target_population_raster_path (string): The path to where the target,
+            warped population raster will live on disk.
+        target_pixel_size (tuple): A tuple of the pixel size for the target
+            raster.  Passed directly to ``pygeoprocessing.warp_raster``.
+        target_bb (tuple): A tuple of the bounding box for the target raster.
+            Passed directly to ``pygeoprocessing.warp_raster``.
+        target_projection_wkt (string): The Well-Known Text of the target
+            spatial reference fro the target raster.  Passed directly to
+            ``pygeoprocessing.warp_raster``.
+        working_dir (string): The path to a directory on disk.  A new directory
+            is created within this directory for the storage of temporary files
+            and then deleted upon successful completion of the function.
+
+    Returns:
+        ``None``
+    """
     # Assumes population raster is linearly projected
     # Reasoning: the total population of a pixel is great, but we need to be
     # able to convert that pixel size without losing or gaining people due to

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -1,0 +1,113 @@
+import logging
+
+import pygeoprocessing
+
+from . import validation
+from . import spec_utils
+from .spec_utils import u
+from .. import MODEL_METADATA
+
+LOGGER = logging.getLogger(__name__)
+ARGS_SPEC = {
+    'model_name': MODEL_METADATA['urban_nature_access'].model_title,
+    'pyname': MODEL_METADATA['urban_nature_access'].pyname,
+    'userguide_html': MODEL_METADATA['urban_nature_access'].userguide,
+    'args_with_spatial_overlap': {
+        'spatial_keys': [],
+        'different_projections_ok': True,
+    },
+    'args': {
+        'workspace_dir': spec_utils.WORKSPACE,
+        'results_suffix': spec_utils.SUFFIX,
+        'n_workers': spec_utils.N_WORKERS,
+        'lulc_raster_path': {
+            **spec_utils.LULC,
+            'projected': True,
+            'projection_units': u.meter,
+            'about': "",  # TODO
+        },
+        'lulc_attribute_table': {
+            'name': 'LULC attribute table',
+            'type': 'csv',
+            'columns': {
+                'lucode': {'type': 'integer'},
+                'greenspace': {'type': 'number', 'units': u.none,
+                               'about': ''}  # TODO,
+            },
+            'about': '',  # TODO
+        },
+        'population_raster_path': {
+            'type': 'raster',
+            'name': 'population raster',
+            'bands': {1: {'type': 'float'}},
+            'about': "",  # TODO,
+        },
+        'admin_unit_vector_path': {
+            'type': 'vector',
+            'name': 'administrative boundaries',
+            'geometries': spec_utils.POLYGONS,
+            'about': "",  # TODO
+        },
+        'greenspace_demand': {
+            'type': 'number',
+            'name': 'greenspace demand per capita',
+            'units': u.m**2,  # defined as m² per capita
+            'expression': "value > 0",
+            'about': "",  # TODO,
+        },
+        'search_radius': {
+            'type': 'number',
+            'name': 'search radius',
+            'units': u.m,
+            'expression': "value > 0",
+            'about': "",  # TODO,
+        }
+    }
+}
+
+
+def execute(args):
+    """Urban Nature Access.
+
+    Args:
+        args['workspace_dir'] (string): (required) Output directory for
+            intermediate, temporary and final files.
+        args['results_suffix'] (string): (optional) String to append to any
+            output file.
+        args['n_workers'] (int): (optional) The number of worker processes to
+            use for executing the tasks of this model.  If omitted, computation
+            will take place in the current process.
+        args['lulc_raster_path'] (string): (required) A string path to a
+            GDAL-compatible land-use/land-cover raster containing integer
+            landcover codes.
+        args['lulc_attribute_table'] (string): (required) A string path to a
+            CSV with the following columns:
+
+            * ``lucode``: the integer landcover code represented.
+            * ``greenspace``: ``0`` or ``1`` indicating whether this landcover
+              code is (``1``) or is not (``0``) a greenspace pixel.
+
+        args['population_raster_path'] (string): (required) A string path to a
+            GDAL-compatible raster where pixels represent the population of
+            that pixel.
+        args['admin_unit_vector_path'] (string): (required) A string path to a
+            GDAL-compatible vector containing polygon administrative
+            boundaries.
+        args['greenspace_demand'] (number): (required) A positive, nonzero
+            number indicating the required greenspace, in m² per capita.
+        args['search_radius'] (number): (required) A positive, nonzero number
+            indicating the maximum distance that people travel for recreation.
+
+    Returns:
+        ``None``
+    """
+    LOGGER.info('Starting Urban Nature Access Model')
+
+    # for initial PR, get the basic workflow going with a single test.
+    # * Test on basic datasets
+    # * align inputs  (what's the best way to reproject a population raster?)
+    # * validation
+
+
+def validate(args, limit_to=None):
+    return validation.validate(args, ARGS_SPEC['args'])

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -1,13 +1,13 @@
-import os
 import logging
+import os
 import shutil
 import tempfile
 
-import pygeoprocessing
-import taskgraph
+import numpy
 from osgeo import gdal
 from osgeo import osr
-import numpy
+import pygeoprocessing
+import taskgraph
 
 from . import validation
 from . import spec_utils

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -122,7 +122,7 @@ def execute(args):
             will take place in the current process.
         args['lulc_raster_path'] (string): (required) A string path to a
             GDAL-compatible land-use/land-cover raster containing integer
-            landcover codes.
+            landcover codes.  Must be linearly projected in meters.
         args['lulc_attribute_table'] (string): (required) A string path to a
             CSV with the following columns:
 
@@ -132,7 +132,7 @@ def execute(args):
 
         args['population_raster_path'] (string): (required) A string path to a
             GDAL-compatible raster where pixels represent the population of
-            that pixel.
+            that pixel.  Must be linearly projected in meters.
         args['admin_unit_vector_path'] (string): (required) A string path to a
             GDAL-compatible vector containing polygon administrative
             boundaries.

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -4,16 +4,16 @@ import shutil
 import tempfile
 
 import numpy
-from osgeo import gdal
-from osgeo import osr
 import pygeoprocessing
 import taskgraph
+from osgeo import gdal
+from osgeo import osr
 
-from . import validation
+from natcap.invest import MODEL_METADATA
 from . import spec_utils
 from . import utils
+from . import validation
 from .spec_utils import u
-from natcap.invest import MODEL_METADATA
 
 LOGGER = logging.getLogger(__name__)
 UINT32_NODATA = int(numpy.iinfo(numpy.uint32).max)

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -34,17 +34,33 @@ ARGS_SPEC = {
             **spec_utils.LULC,
             'projected': True,
             'projection_units': u.meter,
-            'about': "",  # TODO
+            'about': (
+                "A map of LULC codes. "
+                "All values in this raster must have corresponding entries "
+                "in the LULC attribute table."),
         },
         'lulc_attribute_table': {
             'name': 'LULC attribute table',
             'type': 'csv',
             'columns': {
-                'lucode': {'type': 'integer'},
-                'greenspace': {'type': 'number', 'units': u.none,
-                               'about': ''}  # TODO,
+                'lucode': {
+                    'type': 'integer',
+                    'about': (
+                        "LULC code.  Every value in the LULC map must have a "
+                        "corresponding entry in this column."),
+                },
+                'greenspace': {
+                    'type': 'number',
+                    'units': u.none,
+                    'about': (
+                        "1 if this landcover code represents greenspace, 0 "
+                        "if not."
+                    ),
+                }
             },
-            'about': '',  # TODO
+            'about': (
+                "A table identifying which LULC codes represent greenspace."
+            ),
         },
         'population_raster_path': {
             'type': 'raster',
@@ -53,27 +69,30 @@ ARGS_SPEC = {
                 1: {'type': 'number', 'units': u.none}
             },
             'projected': True,
-            'about': "",  # TODO,
+            'about': (
+                "A raster representing the number of people who live in each "
+                "pixel. This raster must be linearly projected."
+            ),
         },
         'admin_unit_vector_path': {
             'type': 'vector',
             'name': 'administrative boundaries',
             'geometries': spec_utils.POLYGONS,
-            'about': "",  # TODO
+            'about': "",  # TODO, will know more about this when I implement.
         },
         'greenspace_demand': {
             'type': 'number',
             'name': 'greenspace demand per capita',
             'units': u.m**2,  # defined as m² per capita
             'expression': "value > 0",
-            'about': "",  # TODO,
+            'about': "",  # TODO, will know more about this when I implement.
         },
         'search_radius': {
             'type': 'number',
             'name': 'search radius',
             'units': u.m,
             'expression': "value > 0",
-            'about': "",  # TODO,
+            'about': "",  # TODO, will know more about this when I implement.
         }
     }
 }
@@ -121,11 +140,6 @@ def execute(args):
         ``None``
     """
     LOGGER.info('Starting Urban Nature Access Model')
-
-    # for initial PR, get the basic workflow going with a single test.
-    # * Test on basic datasets
-    # * align inputs  (what's the best way to reproject a population raster?)
-    # * validation
 
     output_dir = os.path.join(args['workspace_dir'], 'output')
     intermediate_dir = os.path.join(args['workspace_dir'], 'intermediate')

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -176,9 +176,9 @@ def execute(args):
             'source_population_raster_path': args['population_raster_path'],
             'target_population_raster_path': file_registry[
                 'resampled_population'],
-            'target_pixel_size': lulc_raster_info['pixel_size'],
-            'target_bb': lulc_raster_info['bounding_box'],
-            'target_projection_wkt': lulc_raster_info['projection_wkt'],
+            'lulc_pixel_size': lulc_raster_info['pixel_size'],
+            'lulc_bb': lulc_raster_info['bounding_box'],
+            'lulc_projection_wkt': lulc_raster_info['projection_wkt'],
             'working_dir': intermediate_dir,
         },
         target_path_list=[file_registry['resampled_population']],
@@ -191,7 +191,7 @@ def execute(args):
 
 def _resample_population_raster(
         source_population_raster_path, target_population_raster_path,
-        target_pixel_size, target_bb, target_projection_wkt, working_dir):
+        lulc_pixel_size, lulc_bb, lulc_projection_wkt, working_dir):
     """Resample a population raster without losing or gaining people.
 
     Population rasters are an interesting special case where the data are
@@ -212,11 +212,11 @@ def _resample_population_raster(
             Must be linearly projected in meters.
         target_population_raster_path (string): The path to where the target,
             warped population raster will live on disk.
-        target_pixel_size (tuple): A tuple of the pixel size for the target
+        lulc_pixel_size (tuple): A tuple of the pixel size for the target
             raster.  Passed directly to ``pygeoprocessing.warp_raster``.
-        target_bb (tuple): A tuple of the bounding box for the target raster.
+        lulc_bb (tuple): A tuple of the bounding box for the target raster.
             Passed directly to ``pygeoprocessing.warp_raster``.
-        target_projection_wkt (string): The Well-Known Text of the target
+        lulc_projection_wkt (string): The Well-Known Text of the target
             spatial reference fro the target raster.  Passed directly to
             ``pygeoprocessing.warp_raster``.  Assumed to be a linear projection
             in meters.
@@ -272,19 +272,19 @@ def _resample_population_raster(
     warped_density_path = os.path.join(tmp_working_dir, 'warped_density.tif')
     pygeoprocessing.warp_raster(
         density_raster_path,
-        target_pixel_size=target_pixel_size,
+        target_pixel_size=lulc_pixel_size,
         target_raster_path=warped_density_path,
         resample_method='bilinear',
-        target_bb=target_bb,
-        target_projection_wkt=target_projection_wkt)
+        target_bb=lulc_bb,
+        target_projection_wkt=lulc_projection_wkt)
 
     # Step 3: convert the warped population raster back from density to the
     # population per pixel
     target_srs = osr.SpatialReference()
-    target_srs.ImportFromWkt(target_projection_wkt)
+    target_srs.ImportFromWkt(lulc_projection_wkt)
     # Calculate target pixel area in km to match above
     target_pixel_area = (
-        numpy.multiply(*target_pixel_size) * target_srs.GetLinearUnits()) / 1e6
+        numpy.multiply(*lulc_pixel_size) * target_srs.GetLinearUnits()) / 1e6
 
     def _convert_density_to_population(density):
         """Convert a population density raster back to population counts.

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -220,22 +220,6 @@ def _resample_population_raster(
     Returns:
         ``None``
     """
-    # Assumes population raster is linearly projected
-    # Reasoning: the total population of a pixel is great, but we need to be
-    # able to convert that pixel size without losing or gaining people due to
-    # resampling.
-    #
-    # Approach:
-    # * Assume population raster is linearly projected.
-    # * raster_calculator: convert population raster to density of people/pixel
-    # * align_and_resize_raster_stack: resample (bilinear should be fine) to
-    #   LULC raster's alignment/resolution
-    # * raster_calculator: Reconvert the population raster from density to
-    #   population
-
-    # Option 1: I could do each task right in the execute function
-    # Option 2: I could do the 2 raster_calculator calls and 1 warp_raster call
-    #     right here in this function
     if not os.path.isdir(working_dir):
         os.makedirs(working_dir)
     tmp_working_dir = tempfile.mkdtemp(dir=working_dir)

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -78,6 +78,7 @@ ARGS_SPEC = {
             'type': 'vector',
             'name': 'administrative boundaries',
             'geometries': spec_utils.POLYGONS,
+            'fields': {},  # TODO, complete required fields (if any)
             'about': "",  # TODO, will know more about this when I implement.
         },
         'greenspace_demand': {

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -49,18 +49,22 @@ class UNATests(unittest.TestCase):
             projection_wkt=population_wkt,
             target_path=source_population_raster_path)
 
-        target_population_raster_path = os.path.join(
-            self.workspace_dir, 'resampled_population.tif')
-        urban_nature_access._resample_population_raster(
-            source_population_raster_path=source_population_raster_path,
-            target_population_raster_path=target_population_raster_path,
-            target_pixel_size=(30, -30),  # 1/3 the population pixel size
-            target_bb=pygeoprocessing.get_raster_info(
-                source_population_raster_path)['bounding_box'],
-            target_projection_wkt=population_wkt,
-            working_dir=os.path.join(self.workspace_dir, 'working'))
+        for target_pixel_size in (
+                (30, -30),  # 1/3 the pixel size
+                (4, -4),  # way smaller
+                (100, -100)):  # bigger
+            target_population_raster_path = os.path.join(
+                self.workspace_dir, 'resampled_population.tif')
+            urban_nature_access._resample_population_raster(
+                source_population_raster_path=source_population_raster_path,
+                target_population_raster_path=target_population_raster_path,
+                target_pixel_size=target_pixel_size,
+                target_bb=pygeoprocessing.get_raster_info(
+                    source_population_raster_path)['bounding_box'],
+                target_projection_wkt=population_wkt,
+                working_dir=os.path.join(self.workspace_dir, 'working'))
 
-        resampled_population_array = pygeoprocessing.raster_to_numpy_array(
-            target_population_raster_path)
-        numpy.testing.assert_allclose(
-            population_array.sum(), resampled_population_array.sum())
+            resampled_population_array = pygeoprocessing.raster_to_numpy_array(
+                target_population_raster_path)
+            numpy.testing.assert_allclose(
+                population_array.sum(), resampled_population_array.sum())

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -68,10 +68,10 @@ class UNATests(unittest.TestCase):
                 urban_nature_access._resample_population_raster(
                     source_population_raster_path,
                     target_population_raster_path,
-                    target_pixel_size=target_pixel_size,
-                    target_bb=pygeoprocessing.get_raster_info(
+                    lulc_pixel_size=target_pixel_size,
+                    lulc_bb=pygeoprocessing.get_raster_info(
                         source_population_raster_path)['bounding_box'],
-                    target_projection_wkt=population_wkt,
+                    lulc_projection_wkt=population_wkt,
                     working_dir=os.path.join(self.workspace_dir, 'working'))
 
                 resampled_population_array = (

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -4,6 +4,7 @@ import unittest
 import tempfile
 import shutil
 import os
+import random
 
 import pygeoprocessing
 import numpy
@@ -32,39 +33,54 @@ class UNATests(unittest.TestCase):
         """UNA: Test population raster resampling."""
         from natcap.invest import urban_nature_access
 
+        random.seed(-1)  # for our random number generation
+
         source_population_raster_path = os.path.join(
             self.workspace_dir, 'population.tif')
         population_pixel_size = (90, -90)
         population_array_shape = (10, 10)
-        population_array = numpy.full(
+        array_of_100s = numpy.full(
             population_array_shape, 100, dtype=numpy.uint32)
-        population_srs = osr.SpatialReference()
-        population_srs.ImportFromEPSG(_DEFAULT_EPSG)
-        population_wkt = population_srs.ExportToWkt()
-        pygeoprocessing.numpy_array_to_raster(
-            base_array=population_array,
-            target_nodata=-1,
-            pixel_size=population_pixel_size,
-            origin=_DEFAULT_ORIGIN,
-            projection_wkt=population_wkt,
-            target_path=source_population_raster_path)
+        array_of_random_ints = numpy.array(
+            random.choices(range(0, 100), k=100),
+            dtype=numpy.uint32).reshape(population_array_shape)
 
-        for target_pixel_size in (
-                (30, -30),  # 1/3 the pixel size
-                (4, -4),  # way smaller
-                (100, -100)):  # bigger
-            target_population_raster_path = os.path.join(
-                self.workspace_dir, 'resampled_population.tif')
-            urban_nature_access._resample_population_raster(
-                source_population_raster_path=source_population_raster_path,
-                target_population_raster_path=target_population_raster_path,
-                target_pixel_size=target_pixel_size,
-                target_bb=pygeoprocessing.get_raster_info(
-                    source_population_raster_path)['bounding_box'],
-                target_projection_wkt=population_wkt,
-                working_dir=os.path.join(self.workspace_dir, 'working'))
+        for population_array in (
+                array_of_100s, array_of_random_ints):
+            population_srs = osr.SpatialReference()
+            population_srs.ImportFromEPSG(_DEFAULT_EPSG)
+            population_wkt = population_srs.ExportToWkt()
+            pygeoprocessing.numpy_array_to_raster(
+                base_array=population_array,
+                target_nodata=-1,
+                pixel_size=population_pixel_size,
+                origin=_DEFAULT_ORIGIN,
+                projection_wkt=population_wkt,
+                target_path=source_population_raster_path)
 
-            resampled_population_array = pygeoprocessing.raster_to_numpy_array(
-                target_population_raster_path)
-            numpy.testing.assert_allclose(
-                population_array.sum(), resampled_population_array.sum())
+            for target_pixel_size in (
+                    (30, -30),  # 1/3 the pixel size
+                    (4, -4),  # way smaller
+                    (100, -100)):  # bigger
+                target_population_raster_path = os.path.join(
+                    self.workspace_dir, 'resampled_population.tif')
+                urban_nature_access._resample_population_raster(
+                    source_population_raster_path,
+                    target_population_raster_path,
+                    target_pixel_size=target_pixel_size,
+                    target_bb=pygeoprocessing.get_raster_info(
+                        source_population_raster_path)['bounding_box'],
+                    target_projection_wkt=population_wkt,
+                    working_dir=os.path.join(self.workspace_dir, 'working'))
+
+                resampled_population_array = (
+                    pygeoprocessing.raster_to_numpy_array(
+                        target_population_raster_path))
+
+                # There should be no significant loss or gain of population due
+                # to warping, but the fact that this is aggregating across the
+                # whole raster (lots of pixels) means we need to lower the
+                # relative tolerance.
+                numpy.testing.assert_allclose(
+                    population_array.sum(), resampled_population_array.sum(),
+                    rtol=1e-3)

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -3,6 +3,16 @@
 import unittest
 import tempfile
 import shutil
+import os
+
+import pygeoprocessing
+import numpy
+from osgeo import gdal
+from osgeo import osr
+
+_DEFAULT_ORIGIN = (444720, 3751320)
+_DEFAULT_PIXEL_SIZE = (30, -30)
+_DEFAULT_EPSG = 3116
 
 
 class UNATests(unittest.TestCase):
@@ -17,3 +27,22 @@ class UNATests(unittest.TestCase):
     def tearDown(self):
         """Override tearDown function to remove temporary directory."""
         shutil.rmtree(self.workspace_dir)
+
+    def test_resample_population_raster(self):
+        """UNA: Test population raster resampling."""
+
+        source_population_raster_path = os.path.join(
+            self.workspace_dir, 'population.tif')
+        population_pixel_size = (90, -90)
+        population_array_shape = (10, 10)
+        population_array = numpy.full(
+            population_array_shape, 100, dtype=numpy.uint32)
+        population_srs = osr.SpatialReference()
+        population_srs.ImportFromEPSG(_DEFAULT_EPSG)
+        pygeoprocessing.numpy_array_to_raster(
+            base_array=population_array,
+            target_nodata=-1,
+            pixel_size=population_pixel_size,
+            origin=_DEFAULT_ORIGIN,
+            projection_wkt=population_srs.ExportToWkt(),
+            target_path=source_population_raster_path)

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -1,13 +1,13 @@
 # coding=UTF-8
 """Tests for the Urban Nature Access Model."""
-import unittest
-import tempfile
-import shutil
 import os
 import random
+import shutil
+import tempfile
+import unittest
 
-import pygeoprocessing
 import numpy
+import pygeoprocessing
 from osgeo import gdal
 from osgeo import osr
 

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -22,7 +22,7 @@ class UNATests(unittest.TestCase):
     def setUp(self):
         """Override setUp function to create temp workspace directory."""
         # this lets us delete the workspace after its done no matter the
-        # the rest result
+        # the test result
         self.workspace_dir = tempfile.mkdtemp(suffix='\U0001f60e')  # smiley
 
     def tearDown(self):

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -1,0 +1,19 @@
+# coding=UTF-8
+"""Tests for the Urban Nature Access Model."""
+import unittest
+import tempfile
+import shutil
+
+
+class UNATests(unittest.TestCase):
+    """Tests for the Urban Nature Access Model."""
+
+    def setUp(self):
+        """Override setUp function to create temp workspace directory."""
+        # this lets us delete the workspace after its done no matter the
+        # the rest result
+        self.workspace_dir = tempfile.mkdtemp(suffix='\U0001f60e')  # smiley
+
+    def tearDown(self):
+        """Override tearDown function to remove temporary directory."""
+        shutil.rmtree(self.workspace_dir)

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -30,6 +30,7 @@ class UNATests(unittest.TestCase):
 
     def test_resample_population_raster(self):
         """UNA: Test population raster resampling."""
+        from natcap.invest import urban_nature_access
 
         source_population_raster_path = os.path.join(
             self.workspace_dir, 'population.tif')
@@ -39,10 +40,27 @@ class UNATests(unittest.TestCase):
             population_array_shape, 100, dtype=numpy.uint32)
         population_srs = osr.SpatialReference()
         population_srs.ImportFromEPSG(_DEFAULT_EPSG)
+        population_wkt = population_srs.ExportToWkt()
         pygeoprocessing.numpy_array_to_raster(
             base_array=population_array,
             target_nodata=-1,
             pixel_size=population_pixel_size,
             origin=_DEFAULT_ORIGIN,
-            projection_wkt=population_srs.ExportToWkt(),
+            projection_wkt=population_wkt,
             target_path=source_population_raster_path)
+
+        target_population_raster_path = os.path.join(
+            self.workspace_dir, 'resampled_population.tif')
+        urban_nature_access._resample_population_raster(
+            source_population_raster_path=source_population_raster_path,
+            target_population_raster_path=target_population_raster_path,
+            target_pixel_size=(30, -30),  # 1/3 the population pixel size
+            target_bb=pygeoprocessing.get_raster_info(
+                source_population_raster_path)['bounding_box'],
+            target_projection_wkt=population_wkt,
+            working_dir=os.path.join(self.workspace_dir, 'working'))
+
+        resampled_population_array = pygeoprocessing.raster_to_numpy_array(
+            target_population_raster_path)
+        numpy.testing.assert_allclose(
+            population_array.sum(), resampled_population_array.sum())


### PR DESCRIPTION
This PR is the first of several relating to #722 .  This PR specifically starts out by:

* Adding an `ARGS_SPEC` (mostly there, not 100% complete yet)
* Implements and tests a function to resample a population raster without gaining or losing significant numbers of people (this is the only serious computation in the model right now)
* Adds the start to a test for the model.

I haven't yet made any notes in the README and there isn't a UG chapter yet, so both of those checklist items are pending a later PR.

I've already created a new target branch (`feature/urban-nature-access`, based on `release/3.10`) that this PR is set to merge into.  If we end up waiting to merge this into `release/3.11` after the 3.10 release, that'll work too.

