### PR TITLE
Update HQ rarity index calculation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,9 +34,17 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Habitat Quality
+  * Changed how Habitat Rarity outputs are calculated to be less confusing.
+    Values now represent a 0 to 1 index where before there could be
+    negative values. Now values of 0 indicate current/future LULC not
+    represented in baseline LULC; values 0 to 0.5 indicate more
+    abundance in current/future LULC and therefore less rarity; values
+    of 0.5 indicate same abundance between baseline and current/future
+    LULC; values 0.5 to 1 indicate less abundance in current/future LULC
+    and therefore higher rarity.
 
 3.9.2 (2021-10-29)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,14 +37,14 @@
 Unreleased Changes
 ------------------
 * Habitat Quality
-  * Changed how Habitat Rarity outputs are calculated to be less confusing.
-    Values now represent a 0 to 1 index where before there could be
-    negative values. Now values of 0 indicate current/future LULC not
-    represented in baseline LULC; values 0 to 0.5 indicate more
-    abundance in current/future LULC and therefore less rarity; values
-    of 0.5 indicate same abundance between baseline and current/future
-    LULC; values 0.5 to 1 indicate less abundance in current/future LULC
-    and therefore higher rarity.
+    * Changed how Habitat Rarity outputs are calculated to be less confusing.
+      Values now represent a 0 to 1 index where before there could be
+      negative values. Now values of 0 indicate current/future LULC not
+      represented in baseline LULC; values 0 to 0.5 indicate more
+      abundance in current/future LULC and therefore less rarity; values
+      of 0.5 indicate same abundance between baseline and current/future
+      LULC; values 0.5 to 1 indicate less abundance in current/future LULC
+      and therefore higher rarity.
 
 3.9.2 (2021-10-29)
 ------------------

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -819,7 +819,7 @@ def _compute_rarity_operation(
         if code in lulc_code_count_b:
             numerator = lulc_code_count_x[code] * lulc_area
             denominator = lulc_code_count_b[code] * base_area
-            ratio = 1.0 - (numerator / denominator)
+            ratio = 1.0 - (numerator / (denominator + numerator))
             code_index[code] = ratio
         else:
             code_index[code] = 0.0

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -755,6 +755,12 @@ def _compute_rarity_operation(
         base_lulc_path_band, lulc_path_band, new_cover_path, rarity_path):
     """Calculate habitat rarity.
 
+    Output rarity values will be an index from 0 - 1 where:
+       pixel > 0.5 - more rare
+       pixel < 0.5 - less rare
+       pixel = 0.5 - no rarity change
+       pixel = 0.0 - LULC not found in the baseline for comparison
+
     Args:
         base_lulc_path_band (tuple): a 2 tuple for the path to input base
             LULC raster of the form (path, band index).

--- a/tests/test_habitat_quality.py
+++ b/tests/test_habitat_quality.py
@@ -176,15 +176,10 @@ class HabitatQualityTests(unittest.TestCase):
         # this lets us delete the workspace after its done no matter the
         # the rest result
         self.workspace_dir = tempfile.mkdtemp()
-        #dir_path = os.path.join('C:', os.sep, 'Users', 'ddenu', 'Documents',
-        #        'hq-rarity-test-changes')
-        #os.mkdir(dir_path)
-        #self.workspace_dir = dir_path
 
     def tearDown(self):
         """Override tearDown function to remove temporary directory."""
         shutil.rmtree(self.workspace_dir)
-        #pass
 
     def test_habitat_quality_regression(self):
         """Habitat Quality: base regression test with simplified data."""
@@ -238,8 +233,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 33.931896,
                 'quality_c_regression.tif': 7499.983,
                 'quality_f_regression.tif': 4999.9893,
-                'rarity_c_regression.tif': 3333.33335,
-                'rarity_f_regression.tif': 3333.33335}.items():
+                'rarity_c_regression.tif': 3333.3335,
+                'rarity_f_regression.tif': 3333.3335}.items():
             raster_path = os.path.join(args['workspace_dir'], output_filename)
             # Check that the raster's computed values are what we expect.
             # In this case, the LULC and threat rasters should have been

--- a/tests/test_habitat_quality.py
+++ b/tests/test_habitat_quality.py
@@ -176,10 +176,15 @@ class HabitatQualityTests(unittest.TestCase):
         # this lets us delete the workspace after its done no matter the
         # the rest result
         self.workspace_dir = tempfile.mkdtemp()
+        #dir_path = os.path.join('C:', os.sep, 'Users', 'ddenu', 'Documents',
+        #        'hq-rarity-test-changes')
+        #os.mkdir(dir_path)
+        #self.workspace_dir = dir_path
 
     def tearDown(self):
         """Override tearDown function to remove temporary directory."""
         shutil.rmtree(self.workspace_dir)
+        #pass
 
     def test_habitat_quality_regression(self):
         """Habitat Quality: base regression test with simplified data."""
@@ -233,8 +238,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 33.931896,
                 'quality_c_regression.tif': 7499.983,
                 'quality_f_regression.tif': 4999.9893,
-                'rarity_c_regression.tif': 2500.0000000,
-                'rarity_f_regression.tif': 2500.0000000}.items():
+                'rarity_c_regression.tif': 3333.33335,
+                'rarity_f_regression.tif': 3333.33335}.items():
             raster_path = os.path.join(args['workspace_dir'], output_filename)
             # Check that the raster's computed values are what we expect.
             # In this case, the LULC and threat rasters should have been
@@ -297,8 +302,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 46.279358,
                 'quality_c_regression.tif': 7499.9414,
                 'quality_f_regression.tif': 4999.955,
-                'rarity_c_regression.tif': 2500.0000000,
-                'rarity_f_regression.tif': 2500.0000000}.items():
+                'rarity_c_regression.tif': 3333.3335,
+                'rarity_f_regression.tif': 3333.3335}.items():
             raster_path = os.path.join(args['workspace_dir'], output_filename)
             # Check that the raster's computed values are what we expect.
             # In this case, the LULC and threat rasters should have been
@@ -358,8 +363,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 46.279358,
                 'quality_c_regression.tif': 7499.9414,
                 'quality_f_regression.tif': 4999.955,
-                'rarity_c_regression.tif': 2500.0000000,
-                'rarity_f_regression.tif': 2500.0000000}.items():
+                'rarity_c_regression.tif': 3333.3335,
+                'rarity_f_regression.tif': 3333.3335}.items():
             raster_path = os.path.join(args['workspace_dir'], output_filename)
             # Check that the raster's computed values are what we expect.
             # In this case, the LULC and threat rasters should have been
@@ -420,8 +425,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 46.279358,
                 'quality_c_regression.tif': 7499.9414,
                 'quality_f_regression.tif': 4999.955,
-                'rarity_c_regression.tif': 2500.0000000,
-                'rarity_f_regression.tif': 2500.0000000}.items():
+                'rarity_c_regression.tif': 3333.3335,
+                'rarity_f_regression.tif': 3333.3335}.items():
             raster_path = os.path.join(args['workspace_dir'], output_filename)
             # Check that the raster's computed values are what we expect.
             # In this case, the LULC and threat rasters should have been
@@ -563,8 +568,8 @@ class HabitatQualityTests(unittest.TestCase):
                 'deg_sum_f_regression.tif': 46.279358,
                 'quality_c_regression.tif': 7499.9414,
                 'quality_f_regression.tif': 4999.955,
-                'rarity_c_regression.tif': 2500.0000000,
-                'rarity_f_regression.tif': 2500.0000000
+                'rarity_c_regression.tif': 3333.3335,
+                'rarity_f_regression.tif': 3333.3335
         }.items():
             assert_array_sum(os.path.join(
                 args['workspace_dir'], output_filename), assert_value)
@@ -1078,7 +1083,7 @@ class HabitatQualityTests(unittest.TestCase):
             7499.524)
         assert_array_sum(
             os.path.join(args['workspace_dir'], 'rarity_c.tif'),
-            2500.000000)
+            3333.3335)
 
     def test_habitat_quality_missing_lucodes_in_table(self):
         """Habitat Quality: on missing lucodes in the sensitivity table."""


### PR DESCRIPTION
# Description
This PR changes the output of habitat rarity by constraining the values to a 0-1 index. One thing to note is that 0.5 indicates no abundance change / no rarity change. Values less than 0.5 indicate more abundance and "less" rare. Values greater than 0.5 indicate less abundance and higher rarity. See issue #720 for a complete description.

Fixes #720

Users Guide update is in a PR https://github.com/natcap/invest.users-guide/pull/51 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
