### PR TITLE
Bugfix/cv 627 inland holes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,17 @@
   Unreleased Changes
   ------------------
 
+Unreleased Changes (3.10)
+-------------------------
+* General:
+    * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
+      and server on the localhost, to support the workbench.
+    * Major updates to each model's ``ARGS_SPEC`` (and some related validation)
+      to facilitate re-use & display in the Workbench and User's Guide.
+* Coastal Vulnerability:
+    * Fixed bug where shore points were created on interior landmass holes
+      (i.e. lakes).
+
 3.9.2 (2021-10-29)
 ------------------
 * General:
@@ -78,14 +89,6 @@
     * Fixed a bug where lucodes present in the LULC raster but missing from
       the biophysical table would either raise a cryptic IndexError or silently
       apply invalid curve numbers. Now a helpful ValueError is raised.
-
-Unreleased Changes (3.10)
--------------------------
-* General:
-    * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
-      and server on the localhost, to support the workbench.
-    * Major updates to each model's ``ARGS_SPEC`` (and some related validation)
-      to facilitate re-use & display in the Workbench and User's Guide.
 
 3.9.1 (2021-09-22)
 ------------------

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -751,12 +751,10 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
         landmass_shapely = [landmass_shapely]
 
     LOGGER.info("indexing geometry of landmass and creating shore points")
-
     for landmass_polygon in landmass_shapely:
-
         lines_in_aoi_list = []
-
-        for landmass_line in geometry_to_lines(landmass_polygon):
+        for landmass_line in geometry_to_lines(
+                landmass_polygon, include_interiors=False):
             if (landmass_line.bounds[0] == landmass_line.bounds[2] and
                     landmass_line.bounds[1] == landmass_line.bounds[3]):
                 continue
@@ -2748,10 +2746,10 @@ def _aggregate_raster_values_in_radius(
         pickle.dump(result, pickle_file)
 
 
-def geometry_to_lines(geometry):
+def geometry_to_lines(geometry, include_interiors=True):
     """Convert a geometry object to a list of lines."""
     if geometry.type == 'Polygon':
-        return polygon_to_lines(geometry)
+        return polygon_to_lines(geometry, include_interiors=include_interiors)
     elif geometry.type == 'MultiPolygon':
         line_list = []
         for geom in geometry.geoms:
@@ -2761,7 +2759,7 @@ def geometry_to_lines(geometry):
         return []
 
 
-def polygon_to_lines(geometry):
+def polygon_to_lines(geometry, include_interiors=True):
     """Return a list of shapely lines given higher order shapely geometry."""
     line_list = []
     starting_point = geometry.exterior.coords[0]
@@ -2773,17 +2771,18 @@ def polygon_to_lines(geometry):
         previous_point = point
     line_list.append(shapely.geometry.LineString([
         previous_point, starting_point]))
-    for interior in geometry.interiors:
-        starting_point = interior.coords[0]
-        previous_point = interior.coords[0]
-        for point in interior.coords[1::]:
-            if point == starting_point:
-                continue
-            line_list.append(
-                shapely.geometry.LineString([previous_point, point]))
-            previous_point = point
-        line_list.append(shapely.geometry.LineString([
-            previous_point, starting_point]))
+    if include_interiors:
+        for interior in geometry.interiors:
+            starting_point = interior.coords[0]
+            previous_point = interior.coords[0]
+            for point in interior.coords[1::]:
+                if point == starting_point:
+                    continue
+                line_list.append(
+                    shapely.geometry.LineString([previous_point, point]))
+                previous_point = point
+            line_list.append(shapely.geometry.LineString([
+                previous_point, starting_point]))
     return line_list
 
 

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1167,6 +1167,57 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         n_points = layer.GetFeatureCount()
         self.assertTrue(n_points == 6)
 
+    def test_landmass_interior_holes(self):
+        """CV: test no shore points created on interior holes."""
+        workspace_dir = self.workspace_dir
+
+        aoi_path = os.path.join(workspace_dir, 'aoi.geojson')
+        landmass_path = os.path.join(workspace_dir, 'landmass.geojson')
+        polygon_pickle = os.path.join(
+            workspace_dir, 'polygon.pickle')
+        lines_pickle = os.path.join(
+            workspace_dir, 'lines.pickle')
+        lines_rtree = os.path.join(
+            workspace_dir, 'rtree.dat')
+        target_vector_path = os.path.join(
+            workspace_dir, 'shore_points.gpkg')
+        model_resolution = 100
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)  # UTM Zone 10N
+        wkt = srs.ExportToWkt()
+
+        aoi_poly = Polygon([
+            (-200, -200), (200, -200), (200, 200), (-200, 200), (-200, -200)])
+        pygeoprocessing.shapely_geometry_to_vector(
+            [aoi_poly], aoi_path, wkt, 'GeoJSON')
+
+        def count_shore_points(landmass_geometries):
+            pygeoprocessing.shapely_geometry_to_vector(
+                [landmass_geometries], landmass_path, wkt, 'GeoJSON')
+
+            coastal_vulnerability.prepare_landmass_line_index_and_interpolate_shore_points(
+                aoi_path, landmass_path, model_resolution, target_vector_path,
+                polygon_pickle, lines_pickle, lines_rtree)
+
+            vector = gdal.OpenEx(
+                target_vector_path, gdal.OF_VECTOR | gdal.GA_ReadOnly)
+            layer = vector.GetLayer()
+            return layer.GetFeatureCount()
+
+        # Count points created by a landmass with no holes, this will
+        # be the expected count for the landmass with holes.
+        exterior = [
+            (-190, -190), (190, -190), (190, 190), (-190, 190), (-190, -190)]
+        landmass_poly_no_holes = Polygon(exterior)
+        n_points_expected = count_shore_points(landmass_poly_no_holes)
+
+        interior = [
+            (-100, -100), (100, -100), (100, 100), (-100, 100), (-100, -100)]
+        landmass_poly_holes = Polygon(exterior, [interior])
+        n_points_actual = count_shore_points(landmass_poly_holes)
+        
+        self.assertEqual(n_points_expected, n_points_actual)
+
     def test_aoi_invalid_geometry(self):
         """CV: test shore point creation with invalid geom in AOI."""
         aoi_path = os.path.join(self.workspace_dir, 'aoi.gpkg')


### PR DESCRIPTION
Fixes #627 

This PR removes interior rings of the landmass polygon as it's geometries are pre-processed for use in subsequent tasks. So now we don't get shore points in interior holes (i.e. lakes).

The same landmass geometries are also used in the wind exposure routine to measure fetch distances. In that case, the interior edges were always irrelevant so there's no change in the outcome of that routine.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) I think the UG already reads as if shore points will only be created along the exterior of the landmass.
