### PR TITLE
Feature/cv 581 raster habitats

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -49,6 +49,7 @@ Unreleased Changes (3.10)
 * Coastal Vulnerability:
     * Fixed bug where shore points were created on interior landmass holes
       (i.e. lakes).
+    * Added feature to accept raster (in addition to vector) habitat layers.
 
 3.9.2 (2021-10-29)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 24fe97466e67adbf45a98ccf7ba92b114f496169
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := a52a82ae21eb06c3f61b64e47c72e9bfe9d12b5d
+GIT_TEST_DATA_REPO_REV      := 698a89cecbdf0540dc5aae06c2a432197cde0d33
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := c07883c44e00d4c977849e551891eb27e1ba3b1e
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 8361823d5927f712a1aec2ee61620f92ff4f49b3
+GIT_TEST_DATA_REPO_REV      := a52a82ae21eb06c3f61b64e47c72e9bfe9d12b5d
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 24fe97466e67adbf45a98ccf7ba92b114f496169
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 698a89cecbdf0540dc5aae06c2a432197cde0d33
+GIT_TEST_DATA_REPO_REV      := 2a5a64b16493ccfaa60107c5212ed91edbcee7d9
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 698a89cecbdf0540dc5aae06c2a432197cde0d33
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 7d0128ed9341acbcc73daef254be171a6cfba844
+GIT_UG_REPO_REV             := d046b3b3ab3cfed99a383db972b74639a8591e4b
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 24fe97466e67adbf45a98ccf7ba92b114f496169
+GIT_SAMPLE_DATA_REPO_REV    := 9adec6ee9000e192589b3538ff381e574c1812d6
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := c07883c44e00d4c977849e551891eb27e1ba3b1e
+GIT_SAMPLE_DATA_REPO_REV    := 24fe97466e67adbf45a98ccf7ba92b114f496169
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 9adec6ee9000e192589b3538ff381e574c1812d6
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 2a5a64b16493ccfaa60107c5212ed91edbcee7d9
+GIT_TEST_DATA_REPO_REV      := 15754c80bc32bf15f30eaec265512014c9c8fab3
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1742,7 +1742,7 @@ def calculate_relief_exposure(
 
     def mean_op(array, mask):
         nonlocal missing_values
-        if numpy.count_nonzero(mask) > 0:
+        if numpy.any(mask):
             return numpy.mean(array[mask])
         missing_values += 1
         return numpy.nan
@@ -1871,7 +1871,7 @@ def aggregate_population_density(
 
     def density_op(array, mask):
         nonlocal missing_values
-        if numpy.count_nonzero(mask) > 0:
+        if numpy.any(mask):
             pixel_area_km = abs(pixel_size[0] * pixel_size[1]) / 1e6
             return numpy.mean(array[mask]) / pixel_area_km
         missing_values += 1

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2744,7 +2744,7 @@ def _aggregate_raster_values_in_radius(
         target_pickle_path (string): path to pickle file storing dict
             keyed by point id.
         aggregation_op (function): takes a signal array and a mask array
-            of same shape. Returns scalar.
+            of same shape. Returns scalar or numpy.nan.
 
     Returns:
         None

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1750,6 +1750,7 @@ def calculate_relief_exposure(
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, positive_dem_path, dem_averaging_radius,
         target_relief_pickle_path, mean_op)
+
     if missing_values:
         LOGGER.warning(
             f'{missing_values} shore points are missing values after '
@@ -2012,6 +2013,7 @@ def search_for_raster_habitat(
         clipped_projected_hab_path)
 
     def habitat_op(array, mask):
+        """Checking for non-zero or non-nodata values in array."""
         if numpy.any(array[mask]):
             return habitat_rank
         return 5  # the rank indicating no habitat protection
@@ -2731,8 +2733,8 @@ def _aggregate_raster_values_in_radius(
             for valid pixels.
         target_pickle_path (string): path to pickle file storing dict
             keyed by point id.
-        aggregation_op (function): takes a signal array, a mask array,
-            and arbitrary *args.
+        aggregation_op (function): takes a signal array and a mask array
+            of same shape. Returns scalar.
 
     Returns:
         None

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1653,7 +1653,8 @@ def calculate_surge_exposure(
                     "Could not transform feature from %s to spatial reference"
                     "system %s", shelf_contour_path, target_srs_wkt)
                 continue
-            shapely_geom = shapely.wkb.loads(bytes(clipped_geometry.ExportToWkb()))
+            shapely_geom = shapely.wkb.loads(
+                bytes(clipped_geometry.ExportToWkb()))
             if shapely_geom.type == 'MultiLineString':
                 shapely_geom_explode = [
                     shapely.geometry.LineString(x) for x in shapely_geom]
@@ -1731,20 +1732,25 @@ def calculate_relief_exposure(
         [(clipped_projected_dem_path, 1), (nodata, 'raw')],
         zero_negative_values, positive_dem_path, target_dtype, nodata)
 
+    missing_values = 0
+
     def mean_op(array, mask):
+        nonlocal missing_values
         if numpy.count_nonzero(mask) > 0:
             return numpy.mean(array[mask])
-        LOGGER.warning(
-            "missing value after aggregating %s because no valid pixels"
-            "were found within the search radius (%d meters) around a "
-            "shore point."
-            % (os.path.basename(positive_dem_path), dem_averaging_radius))
+        missing_values += 1
         return numpy.nan
 
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, positive_dem_path, dem_averaging_radius,
         target_relief_pickle_path, mean_op)
-    LOGGER.info("Finished calculating relief exposure")
+    if missing_values:
+        LOGGER.warning(
+            f'{missing_values} shore points are missing values after '
+            f'aggregating {positive_dem_path}. No valid pixels '
+            f'were found within the search radius '
+            f'({dem_averaging_radius} meters) around these points.')
+    LOGGER.info('Finished calculating relief exposure')
 
 
 def zero_negative_values(depth_array, nodata):
@@ -1855,21 +1861,27 @@ def aggregate_population_density(
     pixel_size = pygeoprocessing.get_raster_info(
         clipped_projected_pop_path)['pixel_size']
 
+    missing_values = 0
+
     def density_op(array, mask):
+        nonlocal missing_values
         if numpy.count_nonzero(mask) > 0:
             pixel_area_km = abs(pixel_size[0] * pixel_size[1]) / 1e6
             return numpy.mean(array[mask]) / pixel_area_km
-        LOGGER.warning(
-            "missing value after aggregating %s because no valid pixels"
-            "were found within the search radius (%d meters) around a "
-            "shore point."
-            % (os.path.basename(clipped_projected_pop_path), search_radius))
+        missing_values += 1
         return numpy.nan
 
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, clipped_projected_pop_path,
         search_radius, target_pickle_path, density_op)
-    LOGGER.info("Finished aggregating population data")
+
+    if missing_values:
+        LOGGER.warning(
+            f'{missing_values} shore points are missing values after '
+            f'aggregating {clipped_projected_pop_path}. No valid pixels '
+            f'were found within the search radius ({search_radius} meters) '
+            f'around these points.')
+    LOGGER.info('Finished aggregating population data')
 
 
 def _schedule_habitat_tasks(
@@ -2020,9 +2032,7 @@ def search_for_vector_habitat(
         habitat_id (string): unique string to represent each habitat.
         habitat_vector_path (string): path to a polygon vector.
         target_habitat_pickle_path (string): path to pickle file storing
-            a dict keyed by shore point ID, nested in a dict keyed by
-            habitat_id:
-            {'habitat_id': {<id0>: 5, <id1>.: 5, <id2>: 5}}
+            a dict keyed by shore point ID: { <id0>: 5, <id1>: 5, <id2>: 5 }
 
     Returns:
         None

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -180,9 +180,10 @@ ARGS_SPEC = {
                     "type": "freestyle_string",
                     "about": "Unique name for the habitat. No spaces allowed."},
                 "path": {
-                    "type": "vector",
+                    "type": {"vector", "raster"},
                     "fields": {},
                     "geometries": {"POLYGON", "MULTIPOLYGON"},
+                    "bands": {1: {"type": "number", "units": u.none}},
                     "about": "Map of area(s) where the habitat is present."},
                 "rank": {
                     "type": "option_string",

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2085,7 +2085,7 @@ def search_for_vector_habitat(
 
     search_habitat_logger = _make_logger_callback(
         ("searching for %s " % habitat_id) + "%.2f%% complete.", LOGGER)
-    result = {habitat_id: {}}
+    result = {}
     for point_feature in base_shore_point_layer:
         point_habitat_rank = 5  # represents no habitat protection
         shore_id = point_feature.GetField(SHORE_ID_FIELD)
@@ -2095,7 +2095,7 @@ def search_for_vector_habitat(
             base_shore_point_layer.GetFeatureCount())
 
         if habitat_rtree._n_geoms == 0:
-            result[habitat_id][shore_id] = point_habitat_rank
+            result[shore_id] = point_habitat_rank
             continue
 
         point_feature_geometry = point_feature.GetGeometryRef()
@@ -2111,7 +2111,7 @@ def search_for_vector_habitat(
                 point_habitat_rank = habitat_rank
                 continue
 
-        result[habitat_id][shore_id] = point_habitat_rank
+        result[shore_id] = point_habitat_rank
 
     with open(target_habitat_pickle_path, 'wb') as pickle_file:
         pickle.dump(result, pickle_file)
@@ -2139,16 +2139,17 @@ def calculate_habitat_rank(
     for hab_pickle in habitat_pickle_list:
         with open(hab_pickle, 'rb') as file:
             data = pickle.load(file)
-        habitat_id = list(data)[0]  # get habitat name to use in header
-        dataframe[habitat_id] = data[habitat_id].values()
+        habitat_id = os.path.splitext(
+            os.path.basename(hab_pickle))[0]  # get habitat id to use in header
+        habitat_id_list.append(habitat_id)
+        dataframe[habitat_id] = data.values()
         # Count of points protected by habitat. 5 was assigned for no
         # protection.
-        n_pts_protected = dataframe[habitat_id][dataframe[habitat_id] != 5].size
+        n_pts_protected = numpy.count_nonzero(dataframe[habitat_id] != 5)
         LOGGER.info(
             '%s: found protecting %d shore points' %
             (habitat_id, n_pts_protected))
-        habitat_id_list.append(habitat_id)
-    dataframe[SHORE_ID_FIELD] = data[habitat_id].keys()
+    dataframe[SHORE_ID_FIELD] = data.keys()
 
     def _calc_Rhab(row):
         """Equation 4 from User's Guide."""

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1731,9 +1731,19 @@ def calculate_relief_exposure(
         [(clipped_projected_dem_path, 1), (nodata, 'raw')],
         zero_negative_values, positive_dem_path, target_dtype, nodata)
 
+    def mean_op(array, mask):
+        if numpy.count_nonzero(mask) > 0:
+            return numpy.mean(array[mask])
+        LOGGER.warning(
+            "missing value after aggregating %s because no valid pixels"
+            "were found within the search radius (%d meters) around a "
+            "shore point."
+            % (os.path.basename(positive_dem_path), dem_averaging_radius))
+        return numpy.nan
+
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, positive_dem_path, dem_averaging_radius,
-        target_relief_pickle_path, 'mean')
+        target_relief_pickle_path, mean_op)
     LOGGER.info("Finished calculating relief exposure")
 
 
@@ -1842,9 +1852,23 @@ def aggregate_population_density(
         model_resolution, workspace_dir, file_suffix,
         clipped_projected_pop_path)
 
+    pixel_size = pygeoprocessing.get_raster_info(
+        clipped_projected_pop_path)['pixel_size']
+
+    def density_op(array, mask):
+        if numpy.count_nonzero(mask) > 0:
+            pixel_area_km = abs(pixel_size[0] * pixel_size[1]) / 1e6
+            return numpy.mean(array[mask]) / pixel_area_km
+        LOGGER.warning(
+            "missing value after aggregating %s because no valid pixels"
+            "were found within the search radius (%d meters) around a "
+            "shore point."
+            % (os.path.basename(clipped_projected_pop_path), search_radius))
+        return numpy.nan
+
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, clipped_projected_pop_path,
-        search_radius, target_pickle_path, 'density')
+        search_radius, target_pickle_path, density_op)
     LOGGER.info("Finished aggregating population data")
 
 
@@ -1944,9 +1968,12 @@ def search_for_raster_habitat(
         model_resolution, working_dir, file_suffix,
         clipped_projected_hab_path)
 
+    def habitat_op(array, mask, *args):
+        return numpy.nan
+
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, clipped_projected_hab_path,
-        search_radius, target_habitat_pickle_path, 'density')
+        search_radius, target_habitat_pickle_path, habitat_op)
 
 
 def search_for_vector_habitat(
@@ -2632,7 +2659,7 @@ def clip_and_project_vector(
 
 def _aggregate_raster_values_in_radius(
         base_point_vector_path, base_raster_path, sample_distance,
-        target_pickle_path, aggregation_mode):
+        target_pickle_path, aggregation_op):
     """Aggregate raster values in radius around a point.
 
     Do the radial search by constructing a rectangular kernel mask
@@ -2649,6 +2676,8 @@ def _aggregate_raster_values_in_radius(
            [False,  True,  True,  True,  True,  True, False],
            [False, False, False,  True, False, False, False]])
 
+    Do the aggregation with an arbitrary function ``aggregation_op``.
+
     Args:
         base_point_vector_path (string): point vector with projected
             coordinates in units matching sample_disatnce.
@@ -2656,20 +2685,15 @@ def _aggregate_raster_values_in_radius(
             projection matching base_point_vector_path.
         sample_distance (float): radius around each point to search
             for valid pixels.
-        aggregation_mode (string): 'mean' or 'density'. Calculate the mean
-            of valid pixels in search window, or if 'density', divide the mean
-            by the area of valid pixels. 'density' assumes units of meters
-            for sample_distance and raster geotransform.
         target_pickle_path (string): path to pickle file storing dict
             keyed by point id.
+        aggregation_op (function): takes a signal array, a mask array,
+            and arbitrary *args.
 
     Returns:
         None
 
     """
-    if aggregation_mode not in ['mean', 'density']:
-        raise ValueError('aggregation mode must be either "mean" or "density"')
-
     raster = gdal.OpenEx(base_raster_path, gdal.OF_RASTER | gdal.GA_Update)
     band = raster.GetRasterBand(1)
     n_rows = band.YSize
@@ -2750,47 +2774,21 @@ def _aggregate_raster_values_in_radius(
                 'extends beyond bounds of raster %s',
                 point_x, point_y, base_raster_path)
         if win_xsize <= 0 or win_ysize <= 0:
-            pixel_value = 0
+            # TODO: I don't know how to get here,
+            point_value = numpy.nan
+            # point_value = 0
         else:
-            try:
-                array = band.ReadAsArray(
-                    xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
-                    win_ysize=win_ysize)
-                if nodata is not None:
-                    mask = ~numpy.isclose(array, nodata) & temp_kernel_mask
-                else:
-                    mask = kernel_mask
-                if numpy.count_nonzero(mask) > 0:
-                    pixel_value = numpy.mean(array[mask])
-                else:
-                    pixel_value = numpy.nan
-            except Exception:
-                LOGGER.error(
-                    'band size %d %d', band.XSize,
-                    band.YSize)
-                raise
+            array = band.ReadAsArray(
+                xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
+                win_ysize=win_ysize)
+            if nodata is not None:
+                mask = ~numpy.isclose(array, nodata) & temp_kernel_mask
+            else:
+                mask = kernel_mask
+            point_value = aggregation_op(
+                array, mask)
 
-        # calculate pixel area in sq km
-        if aggregation_mode == 'density' and ~numpy.isnan(pixel_value):
-            pixel_area_km = abs(
-                geotransform[1] * geotransform[5]) / 1e6  # converts m^2 to km^2
-            pixel_value /= pixel_area_km
-
-        result[shore_id] = pixel_value
-
-    n_missing_data = numpy.count_nonzero(numpy.isnan(list(result.values())))
-    if n_missing_data:
-        LOGGER.warning(
-            "\n**************************************************\n"
-            "%d points have a missing value after aggregating %s because no "
-            "valid pixels were found within the search radius (%d meters) "
-            "around these points. You may wish to increase the search radius "
-            "input parameter, or you may wish to view %s and the landmass "
-            "polygon input in a GIS to confirm that both layers are accurate "
-            "and well-aligned. "
-            "\n**************************************************"
-            % (n_missing_data, os.path.basename(base_raster_path),
-                sample_distance, os.path.basename(base_raster_path)))
+        result[shore_id] = point_value
 
     with open(target_pickle_path, 'wb') as pickle_file:
         pickle.dump(result, pickle_file)

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -591,13 +591,14 @@ def execute(args):
     if ('geomorphology_vector_path' in args and
             args['geomorphology_vector_path'] != ''):
         projected_geomorphology_vector_path = os.path.join(
-            geomorph_dir, 'geomorphology_projected%s.shp' % file_suffix)
+            geomorph_dir, 'geomorphology_projected%s.gpkg' % file_suffix)
         target_srs_wkt = pygeoprocessing.get_vector_info(
             args['aoi_vector_path'])['projection_wkt']
         project_geomorph_task = task_graph.add_task(
             func=pygeoprocessing.reproject_vector,
             args=(args['geomorphology_vector_path'], target_srs_wkt,
                   projected_geomorphology_vector_path),
+            kwargs={'driver_name': 'GPKG'},
             target_path_list=[projected_geomorphology_vector_path],
             task_name='project geomorphology input')
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2762,7 +2762,7 @@ def _aggregate_raster_values_in_radius(
     top_half = numpy.flip(bottom_half[1:, :], axis=0)
     kernel_index_distances = numpy.concatenate((top_half, bottom_half), axis=0)
 
-    kernel_mask = numpy.where(
+    radial_kernel_mask = numpy.where(
         kernel_index_distances > pixel_dist, False, True)
 
     result = {}
@@ -2771,9 +2771,8 @@ def _aggregate_raster_values_in_radius(
     layer = vector.GetLayer()
     for point_feature in layer:
         warn_msg = 0
-        win_xsize = kernel_mask.shape[0]
-        win_ysize = kernel_mask.shape[1]
-        temp_kernel_mask = kernel_mask[:]
+        win_xsize = radial_kernel_mask.shape[0]
+        win_ysize = radial_kernel_mask.shape[1]
 
         shore_id = point_feature.GetField(SHORE_ID_FIELD)
         point_geometry = point_feature.GetGeometryRef()
@@ -2789,52 +2788,50 @@ def _aggregate_raster_values_in_radius(
             (point_y - geotransform[3]) /
             geotransform[5]) - pixel_dist
 
+        kernel_mask = numpy.copy(radial_kernel_mask)
         # if kernel origin is outside bounds of the raster
         if pixel_x < 0:
             warn_msg = 1
             win_xsize += pixel_x
             pixel_x = 0
             # trim mask columns by indexing backward from the right
-            temp_kernel_mask = temp_kernel_mask[:, (-1 * win_xsize):]
+            kernel_mask = kernel_mask[:, (-1 * win_xsize):]
         if pixel_y < 0:
             warn_msg = 1
             win_ysize += pixel_y
             pixel_y = 0
             # trim mask rows by indexing backward from the bottom
-            temp_kernel_mask = temp_kernel_mask[(-1 * win_ysize):, :]
+            kernel_mask = kernel_mask[(-1 * win_ysize):, :]
 
         # if kernel extent is outside bounds of the raster
         if pixel_x + win_xsize > n_cols:
             warn_msg = 1
             win_xsize -= pixel_x + win_xsize - n_cols
             # trim mask columns by indexing forward from left
-            temp_kernel_mask = temp_kernel_mask[:, :win_xsize]
+            kernel_mask = kernel_mask[:, :win_xsize]
         if pixel_y + win_ysize > n_rows:
             warn_msg = 1
             win_ysize -= pixel_y + win_ysize - n_rows
             # trim mask rows by indexing forward from top
-            temp_kernel_mask = temp_kernel_mask[:win_ysize, :]
+            kernel_mask = kernel_mask[:win_ysize, :]
         if warn_msg:
             LOGGER.warning(
                 'search radius around point (%.6f, %.6f) '
                 'extends beyond bounds of raster %s',
                 point_x, point_y, base_raster_path)
         if win_xsize <= 0 or win_ysize <= 0:
-            # TODO: I don't know how to get here,
-            point_value = numpy.nan
-            # point_value = 0
-        else:
-            array = band.ReadAsArray(
-                xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
-                win_ysize=win_ysize)
-            if nodata is not None:
-                mask = ~numpy.isclose(array, nodata) & temp_kernel_mask
-            else:
-                mask = kernel_mask
-            point_value = aggregation_op(
-                array, mask)
+            # Not sure how we get here, but clamping to 0 allows
+            # the aggregation_op to decide what to return given
+            # an empty array.
+            win_xsize = 0
+            win_ysize = 0
+        array = band.ReadAsArray(
+            xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
+            win_ysize=win_ysize)
+        if nodata is not None:
+            kernel_mask &= ~numpy.isclose(array, nodata)
 
-        result[shore_id] = point_value
+        result[shore_id] = aggregation_op(array, kernel_mask)
 
     with open(target_pickle_path, 'wb') as pickle_file:
         pickle.dump(result, pickle_file)

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1948,7 +1948,30 @@ def search_for_raster_habitat(
         base_shore_point_vector_path, search_radius, habitat_rank,
         habitat_id, habitat_raster_path, target_habitat_pickle_path,
         model_resolution, file_suffix):
+    """Search for habitat raster within a radius of each shore point.
 
+    If habitat is present within the search radius, assign the habitat_rank
+    to the shore point ID. If habitat is not present, assign rank of 5.
+
+    Args:
+        base_shore_point_vector_path (string): path to a shore point vector.
+        search_radius (integer): distance around each point to search for
+            habitat. units match units from base_shore_point_vector SRS.
+        habitat_rank (integer): from 1 to 5 representing the relative
+            protection offered by this habitat (5 = no protection).
+        habitat_id (string): unique string to represent each habitat.
+        habitat_raster_path (string): path to a raster where 0 and nodata
+            represent absence of habitat, all other values represent presence.
+        target_habitat_pickle_path (string): path to pickle file storing
+            a dict keyed by shore point ID: { <id0>: 5, <id1>: 5, <id2>: 5}
+        model_resolution (float): to be the target pixel size in case habitat
+            rasters are unprojected.
+        file_suffix (string): to be appended to output filenames
+
+    Returns:
+        None
+
+    """
     # SRS here is inherited from the user's AOI
     base_shore_point_info = pygeoprocessing.get_vector_info(
         base_shore_point_vector_path)
@@ -2125,7 +2148,7 @@ def calculate_habitat_rank(
 
     Args:
         habitat_pickle_list (list): list of file paths to pickled dictionaries
-            in the form of: {'habitat_id': {<id0>: 5, <id1>.: 5, <id2>: 5}}
+            in the form of: { <id0>: 5, <id1>: 5, <id2>: 5 }
         target_habitat_protection_path (string): path to a csv file with a row
             for each shore point, and a header like:
             'fid','kelp','eelgrass','coral','R_hab'

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2159,6 +2159,35 @@ def search_for_vector_habitat(
     LOGGER.info(f'Finished searching for {habitat_id}')
 
 
+def _calc_Rhab(row):
+    """Equation 4 from User's Guide.
+
+    Args:
+        row (sequence): a sequence of integers 1 to 5, or numpy.nan
+
+    Returns:
+        float
+
+    """
+    if numpy.isnan(row).any():
+        return numpy.nan
+    sum_sq_rank = 0.0
+    min_rank = 5  # 5 is least protection
+    for r in row:
+        if r < min_rank:
+            min_rank = r
+        sum_sq_rank += (5 - r)**2
+
+    if sum_sq_rank > 0:
+        r_hab_val = max(
+            1.0, 4.8 - 0.5 * (
+                (1.5 * (5 - min_rank))**2 + sum_sq_rank -
+                (5 - min_rank)**2)**0.5)
+    else:
+        r_hab_val = 5.0
+    return r_hab_val
+
+
 def calculate_habitat_rank(
         habitat_pickle_list, target_habitat_protection_path):
     """Combine dicts of habitat ranks into a dataframe and calcuate Rhab.
@@ -2190,24 +2219,6 @@ def calculate_habitat_rank(
             '%s: found protecting %d shore points' %
             (habitat_id, n_pts_protected))
     dataframe[SHORE_ID_FIELD] = data.keys()
-
-    def _calc_Rhab(row):
-        """Equation 4 from User's Guide."""
-        sum_sq_rank = 0.0
-        min_rank = 5  # 5 is least protection
-        for r in row:
-            if r < min_rank:
-                min_rank = r
-            sum_sq_rank += (5 - r)**2
-
-        if sum_sq_rank > 0:
-            r_hab_val = max(
-                1.0, 4.8 - 0.5 * (
-                    (1.5 * (5 - min_rank))**2 + sum_sq_rank -
-                    (5 - min_rank)**2)**0.5)
-        else:
-            r_hab_val = 5.0
-        return r_hab_val
 
     # Apply _calc_Rhab to each row, excluding the ID value.
     dataframe['R_hab'] = (

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -463,7 +463,7 @@ def execute(args):
 
     shore_point_vector_path = os.path.join(
         shore_dir, 'shore_points%s.gpkg' % file_suffix)
-    handle_landmass_geom_and_shore_points_task = task_graph.add_task(
+    landmass_geom_and_shore_points_task = task_graph.add_task(
         func=prepare_landmass_line_index_and_interpolate_shore_points,
         args=(args['aoi_vector_path'], clipped_landmass_path,
               model_resolution, shore_point_vector_path,
@@ -495,7 +495,7 @@ def execute(args):
         args=(shore_point_vector_path, args['wwiii_vector_path'],
               target_wwiii_point_vector_path),
         target_path_list=[target_wwiii_point_vector_path],
-        dependent_task_list=[handle_landmass_geom_and_shore_points_task],
+        dependent_task_list=[landmass_geom_and_shore_points_task],
         priority=10,  # the longest running task is dependent on this one.
         task_name='interpolate wwiii to shore points')
     exposure_variables_task_list.append(interpolate_wwiii_task)
@@ -550,7 +550,7 @@ def execute(args):
         args=(shore_point_vector_path, args['shelf_contour_vector_path'],
               target_surge_exposure_path),
         target_path_list=[target_surge_exposure_path],
-        dependent_task_list=[handle_landmass_geom_and_shore_points_task],
+        dependent_task_list=[landmass_geom_and_shore_points_task],
         task_name='calculate surge exposure'))
 
     relief_point_pickle_path = os.path.join(
@@ -563,15 +563,15 @@ def execute(args):
               float(args['dem_averaging_radius']), model_resolution,
               relief_dir, file_suffix, relief_point_pickle_path),
         target_path_list=[relief_point_pickle_path],
-        dependent_task_list=[handle_landmass_geom_and_shore_points_task],
+        dependent_task_list=[landmass_geom_and_shore_points_task],
         task_name='calculate relief exposure'))
 
     # Joining this task instead of passing it to this scheduler function.
     # Tasks added by the scheduler are dependent on shore_points_task
-    handle_landmass_geom_and_shore_points_task.join()
+    landmass_geom_and_shore_points_task.join()
     hab_tasks_list, hab_targets_list = _schedule_habitat_tasks(
         shore_point_vector_path, args['habitat_table_path'],
-        habitat_dir, file_suffix, task_graph)
+        model_resolution, habitat_dir, file_suffix, task_graph)
 
     target_habitat_protection_path = os.path.join(
         habitat_dir, 'habitat_protection%s.csv' % file_suffix)
@@ -611,7 +611,7 @@ def execute(args):
             target_path_list=[
                 target_geomorphology_pickle_path],
             dependent_task_list=[
-                handle_landmass_geom_and_shore_points_task, project_geomorph_task],
+                landmass_geom_and_shore_points_task, project_geomorph_task],
             task_name='calculate geomorphology exposure'))
 
     if 'slr_vector_path' in args and args['slr_vector_path'] != '':
@@ -624,7 +624,7 @@ def execute(args):
             args=(shore_point_vector_path, args['slr_vector_path'],
                   args['slr_field'], target_slr_pickle_path),
             target_path_list=[target_slr_pickle_path],
-            dependent_task_list=[handle_landmass_geom_and_shore_points_task],
+            dependent_task_list=[landmass_geom_and_shore_points_task],
             task_name='interpolate sea-level rise values'))
 
     if ('population_raster_path' in args and
@@ -639,7 +639,7 @@ def execute(args):
                   float(args['population_radius']), model_resolution,
                   population_dir, file_suffix, target_population_pickle_path),
             target_path_list=[target_population_pickle_path],
-            dependent_task_list=[handle_landmass_geom_and_shore_points_task],
+            dependent_task_list=[landmass_geom_and_shore_points_task],
             task_name='aggregate population raster'))
 
     task_graph.close()
@@ -1873,7 +1873,7 @@ def aggregate_population_density(
 
 
 def _schedule_habitat_tasks(
-        base_shore_point_vector_path, habitat_table_path,
+        base_shore_point_vector_path, habitat_table_path, model_resolution,
         working_dir, file_suffix, task_graph):
     """Add a habitat processing task to the graph, for each habitat.
 
@@ -1886,6 +1886,7 @@ def _schedule_habitat_tasks(
                 offered by this habitat
             'protection distance (m)': integer used as a search radius around
                 each shore point.
+        model_resolution ()
         working_dir (string): path to a directory for intermediate files
         file_suffix (string): to be appended to output filenames
         task_graph (Taskgraph): the graph that was initialized in ``execute``
@@ -1968,7 +1969,7 @@ def search_for_raster_habitat(
         model_resolution, working_dir, file_suffix,
         clipped_projected_hab_path)
 
-    def habitat_op(array, mask, *args):
+    def habitat_op(array, mask):
         return numpy.nan
 
     _aggregate_raster_values_in_radius(

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1909,11 +1909,44 @@ def _schedule_habitat_tasks(
                       habitat_row.rank,
                       habitat_row.id,
                       base_habitat_path,
-                      target_habitat_pickle_path),
+                      target_habitat_pickle_path,
+                      model_resolution,
+                      file_suffix),
                 target_path_list=[target_habitat_pickle_path],
                 task_name='searching for %s' % habitat_row.id))
 
     return habitat_task_list, habitat_pickles_list
+
+
+def search_for_raster_habitat(
+        base_shore_point_vector_path, search_radius, habitat_rank,
+        habitat_id, habitat_raster_path, target_habitat_pickle_path,
+        model_resolution, file_suffix):
+
+    # SRS here is inherited from the user's AOI
+    base_shore_point_info = pygeoprocessing.get_vector_info(
+        base_shore_point_vector_path)
+    target_srs_wkt = base_shore_point_info['projection_wkt']
+
+    # extend the clipping box to accomodate the search radius,
+    # plus a little extra to avoid nodata within radius after warping.
+    shore_point_bounding_box = base_shore_point_info['bounding_box']
+    shore_point_bounding_box[0] -= search_radius
+    shore_point_bounding_box[1] -= search_radius
+    shore_point_bounding_box[2] += search_radius
+    shore_point_bounding_box[3] += search_radius
+
+    working_dir = os.path.dirname(target_habitat_pickle_path)
+    clipped_projected_hab_path = os.path.join(
+        working_dir, f'clipped_projected_{habitat_id}_{file_suffix}.tif')
+    clip_and_project_raster(
+        habitat_raster_path, shore_point_bounding_box, target_srs_wkt,
+        model_resolution, working_dir, file_suffix,
+        clipped_projected_hab_path)
+
+    _aggregate_raster_values_in_radius(
+        base_shore_point_vector_path, clipped_projected_hab_path,
+        search_radius, target_habitat_pickle_path, 'density')
 
 
 def search_for_vector_habitat(

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1851,7 +1851,6 @@ def aggregate_population_density(
     target_srs_wkt = base_shore_point_info['projection_wkt']
 
     # extend the clipping box to accomodate the search radius,
-    # plus a little extra to avoid nodata within radius after warping.
     shore_point_bounding_box = base_shore_point_info['bounding_box']
     shore_point_bounding_box[0] -= search_radius
     shore_point_bounding_box[1] -= search_radius
@@ -1873,6 +1872,7 @@ def aggregate_population_density(
     def density_op(array, mask):
         nonlocal missing_values
         if numpy.any(mask):
+            # validate guarantees pixel size units are meters
             pixel_area_km = abs(pixel_size[0] * pixel_size[1]) / 1e6
             return numpy.mean(array[mask]) / pixel_area_km
         missing_values += 1
@@ -1997,7 +1997,6 @@ def search_for_raster_habitat(
     target_srs_wkt = base_shore_point_info['projection_wkt']
 
     # extend the clipping box to accomodate the search radius,
-    # plus a little extra to avoid nodata within radius after warping.
     shore_point_bounding_box = base_shore_point_info['bounding_box']
     shore_point_bounding_box[0] -= search_radius
     shore_point_bounding_box[1] -= search_radius
@@ -3083,7 +3082,7 @@ def _validate_habitat_table_paths(habitat_table_path):
 
     if bad_paths:
         raise ValueError(
-            f'Could not open these vectors referenced in {habitat_table_path}:'
+            f'Could not open these datasets referenced in {habitat_table_path}:'
             + ' | '.join(bad_paths))
 
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1857,7 +1857,7 @@ def _schedule_habitat_tasks(
         base_shore_point_vector_path (string): path to a shore point vector.
         habitat_table_path (string): path to a CSV file with these fields:
             'id': unique string to represent each habitat
-            'path': absolute or relative path to a polygon vector
+            'path': absolute or relative path to a polygon vector or raster
             'rank': integer from 1 to 5 representing the relative protection
                 offered by this habitat
             'protection distance (m)': integer used as a search radius around
@@ -1885,21 +1885,38 @@ def _schedule_habitat_tasks(
             working_dir, '%s%s.pickle' %
             (habitat_row.id, file_suffix))
         habitat_pickles_list.append(target_habitat_pickle_path)
-        habitat_task_list.append(task_graph.add_task(
-            func=search_for_habitat,
-            args=(base_shore_point_vector_path,
-                  habitat_row.distance,
-                  habitat_row.rank,
-                  habitat_row.id,
-                  base_habitat_path,
-                  target_habitat_pickle_path),
-            target_path_list=[target_habitat_pickle_path],
-            task_name='searching for %s' % habitat_row.id))
+        vector = gdal.OpenEx(base_habitat_path, gdal.OF_VECTOR)
+        if vector:
+            vector = None
+            habitat_task_list.append(task_graph.add_task(
+                func=search_for_vector_habitat,
+                args=(base_shore_point_vector_path,
+                      habitat_row.distance,
+                      habitat_row.rank,
+                      habitat_row.id,
+                      base_habitat_path,
+                      target_habitat_pickle_path),
+                target_path_list=[target_habitat_pickle_path],
+                task_name='searching for %s' % habitat_row.id))
+            continue
+        raster = gdal.OpenEx(base_habitat_path, gdal.OF_RASTER)
+        if raster:
+            raster = None
+            habitat_task_list.append(task_graph.add_task(
+                func=search_for_raster_habitat,
+                args=(base_shore_point_vector_path,
+                      habitat_row.distance,
+                      habitat_row.rank,
+                      habitat_row.id,
+                      base_habitat_path,
+                      target_habitat_pickle_path),
+                target_path_list=[target_habitat_pickle_path],
+                task_name='searching for %s' % habitat_row.id))
 
     return habitat_task_list, habitat_pickles_list
 
 
-def search_for_habitat(
+def search_for_vector_habitat(
         base_shore_point_vector_path, search_radius, habitat_rank,
         habitat_id, habitat_vector_path, target_habitat_pickle_path):
     """Search for habitat polygon within a radius of each shore point.
@@ -2985,7 +3002,11 @@ def _validate_habitat_table_paths(habitat_table_path):
         try:
             pygeoprocessing.get_vector_info(base_habitat_path)
         except ValueError:
-            bad_paths.append(base_habitat_path)
+            try:
+                pygeoprocessing.get_raster_info(base_habitat_path)
+            except ValueError:
+                bad_paths.append(base_habitat_path)
+
     if bad_paths:
         raise ValueError(
             f'Could not open these vectors referenced in {habitat_table_path}:'

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2815,15 +2815,18 @@ def _aggregate_raster_values_in_radius(
             kernel_mask = kernel_mask[:win_ysize, :]
         if warn_msg:
             LOGGER.warning(
-                'search radius around point (%.6f, %.6f) '
-                'extends beyond bounds of raster %s',
-                point_x, point_y, base_raster_path)
+                f'search radius around point ({point_x}, {point_y}) '
+                f'extends beyond bounds of {base_raster_path}')
         if win_xsize <= 0 or win_ysize <= 0:
-            # Not sure how we get here, but clamping to 0 allows
-            # the aggregation_op to decide what to return given
-            # an empty array.
-            win_xsize = 0
-            win_ysize = 0
+            # We get here if the point is so far off the raster
+            # that the kernel extent does not overlap raster extent.
+            LOGGER.warning(
+                f'search radius around point ({point_x}, {point_y}) '
+                f'is completely outside the exent of {base_raster_path}.'
+                f'nan value assigned to point.')
+            result[shore_id] = numpy.nan
+            continue
+
         array = band.ReadAsArray(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1930,9 +1930,8 @@ def _schedule_habitat_tasks(
             working_dir, '%s%s.pickle' %
             (habitat_row.id, file_suffix))
         habitat_pickles_list.append(target_habitat_pickle_path)
-        vector = gdal.OpenEx(base_habitat_path, gdal.OF_VECTOR)
-        if vector:
-            vector = None
+        gis_type = pygeoprocessing.get_gis_type(base_habitat_path)
+        if gis_type == 2:
             habitat_task_list.append(task_graph.add_task(
                 func=search_for_vector_habitat,
                 args=(base_shore_point_vector_path,
@@ -1944,9 +1943,7 @@ def _schedule_habitat_tasks(
                 target_path_list=[target_habitat_pickle_path],
                 task_name='searching for %s' % habitat_row.id))
             continue
-        raster = gdal.OpenEx(base_habitat_path, gdal.OF_RASTER)
-        if raster:
-            raster = None
+        if gis_type == 1:
             habitat_task_list.append(task_graph.add_task(
                 func=search_for_raster_habitat,
                 args=(base_shore_point_vector_path,
@@ -3076,12 +3073,12 @@ def _validate_habitat_table_paths(habitat_table_path):
         base_habitat_path = _sanitize_path(
             habitat_table_path, habitat_row.path)
         try:
-            pygeoprocessing.get_vector_info(base_habitat_path)
-        except ValueError:
-            try:
-                pygeoprocessing.get_raster_info(base_habitat_path)
-            except ValueError:
+            gis_type = pygeoprocessing.get_gis_type(base_habitat_path)
+            if not gis_type:
+                # Treating an unknown GIS type the same as a bad filepath
                 bad_paths.append(base_habitat_path)
+        except ValueError:
+            bad_paths.append(base_habitat_path)
 
     if bad_paths:
         raise ValueError(

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -184,7 +184,11 @@ ARGS_SPEC = {
                     "fields": {},
                     "geometries": {"POLYGON", "MULTIPOLYGON"},
                     "bands": {1: {"type": "number", "units": u.none}},
-                    "about": "Map of area(s) where the habitat is present."},
+                    "about": (
+                        "Map of area(s) where the habitat is present. "
+                        "If raster, presence of the habitat can be "
+                        "represented by any value and absence of the habitat "
+                        "can be represented by 0 and nodata values.")},
                 "rank": {
                     "type": "option_string",
                     "options": {

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1886,7 +1886,8 @@ def _schedule_habitat_tasks(
                 offered by this habitat
             'protection distance (m)': integer used as a search radius around
                 each shore point.
-        model_resolution ()
+        model_resolution (float): to be the target pixel size in case habitat
+            rasters are unprojected.
         working_dir (string): path to a directory for intermediate files
         file_suffix (string): to be appended to output filenames
         task_graph (Taskgraph): the graph that was initialized in ``execute``
@@ -1970,7 +1971,9 @@ def search_for_raster_habitat(
         clipped_projected_hab_path)
 
     def habitat_op(array, mask):
-        return numpy.nan
+        if numpy.any(array[mask]):
+            return habitat_rank
+        return 5  # the rank indicating no habitat protection
 
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, clipped_projected_hab_path,

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1991,6 +1991,9 @@ def search_for_raster_habitat(
         None
 
     """
+    LOGGER.info(
+        f'Searching for {habitat_id} within {search_radius} meters '
+        f'of shore points')
     # SRS here is inherited from the user's AOI
     base_shore_point_info = pygeoprocessing.get_vector_info(
         base_shore_point_vector_path)
@@ -2020,6 +2023,7 @@ def search_for_raster_habitat(
     _aggregate_raster_values_in_radius(
         base_shore_point_vector_path, clipped_projected_hab_path,
         search_radius, target_habitat_pickle_path, habitat_op)
+    LOGGER.info(f'Finished searching for {habitat_id}')
 
 
 def search_for_vector_habitat(
@@ -2046,8 +2050,8 @@ def search_for_vector_habitat(
 
     """
     LOGGER.info(
-        "Searching for %s within %d meters of shore points" %
-        (habitat_id, search_radius))
+        f'Searching for {habitat_id} within {search_radius} meters '
+        f'of shore points')
     base_shore_point_info = pygeoprocessing.get_vector_info(
         base_shore_point_vector_path)
 
@@ -2155,8 +2159,7 @@ def search_for_vector_habitat(
 
     with open(target_habitat_pickle_path, 'wb') as pickle_file:
         pickle.dump(result, pickle_file)
-    LOGGER.info(
-        "Finished searching for %s in proximity to shore points", habitat_id)
+    LOGGER.info(f'Finished searching for {habitat_id}')
 
 
 def calculate_habitat_rank(

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -313,7 +313,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             result = pickle.load(file)
         # When no habitat is found near a point, it gets a protection rank of 5
         self.assertTrue(
-            set(list(result[habitat_id].values())) == set([5]))
+            set(list(result.values())) == set([5]))
 
     def test_geomorphology_rank(self):
         """CV: regression test for geomorphology values."""

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -629,12 +629,11 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         expected_message = 'fieldname %s not found in' % nonexistent_field
         self.assertTrue(expected_message in actual_message)
 
-    def test_long_aggregate_radius(self):
-        """CV: handle unreasonably long search radius in raster aggregation."""
+    def test_aggregate_raster_edge_cases(self):
+        """CV: test literal edge-cases in raster aggregation."""
         workspace_dir = self.workspace_dir
         raster_path = os.path.join(workspace_dir, 'simple_raster.tif')
         target_pickle_path = os.path.join(workspace_dir, 'target.pickle')
-        sample_distance = 1.5
 
         # Make a simple raster
         srs = osr.SpatialReference()
@@ -659,28 +658,31 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         new_band = None
         new_raster = None
 
+        search_radius = geotransform[1] * 3
         geometries = [
-            Point(0.1, -0.1),  # pixel (0,0): kernel origin out of bounds
-            Point(1.25, -1.25),  # pixel (2,2): kernel origin & extent O.O.B
-            Point(2.1, -2.1),  # pixel (4,4): kernel extent out of bounds
+            Point(0.1, -0.1),    # pixel (0,0): kernel upper-left out of bounds
+            Point(1.25, -1.25),  # pixel (2,2): kernel upper-left & lower-right O.O.B
+            Point(2.1, -2.1),    # pixel (4,4): kernel lower-right out of bounds
+            Point(-10, 10)       # entire kernel out of bounds
         ]
         fields = {'shore_id': ogr.OFTInteger}
-        attributes = [{'shore_id': 0}, {'shore_id': 1}, {'shore_id': 2}]
+        attributes = [{'shore_id': 0}, {'shore_id': 1},
+                      {'shore_id': 2}, {'shore_id': 3}]
         # Make a vector proximate to the raster
-        simple_points_path = os.path.join(workspace_dir, 'simple_points.shp')
+        simple_points_path = os.path.join(workspace_dir, 'simple_points.geojson')
         pygeoprocessing.shapely_geometry_to_vector(
             geometries, simple_points_path, projection_wkt, 'GeoJSON',
             fields=fields, attribute_list=attributes,
             ogr_geom_type=ogr.wkbPoint)
 
         coastal_vulnerability._aggregate_raster_values_in_radius(
-            simple_points_path, raster_path, sample_distance,
+            simple_points_path, raster_path, search_radius,
             target_pickle_path, _mean_op)
 
         with open(target_pickle_path, 'rb') as file:
             actual_values = pickle.load(file)
 
-        expected_values = numpy.array([6.5454, 12.0, 17.4545])
+        expected_values = numpy.array([6.5454, 12.0, 17.4545, numpy.nan])
 
         numpy.testing.assert_allclose(
             list(actual_values.values()), expected_values, rtol=0, atol=1e-4)

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -490,7 +490,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             REGRESSION_DATA, 'expected_relief.json')
         assert_pickled_arrays_almost_equal(
             target_relief_pickle_path, expected_raw_values_path)
-        
+
     def test_population_values(self):
         """CV: regression test for aggregated population density."""
         workspace_dir = self.workspace_dir

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -26,7 +26,9 @@ INPUT_DATA = os.path.join(
 
 
 def _mean_op(array, mask):
-    return numpy.mean(array[mask])
+    if numpy.any(mask):
+        return numpy.mean(array[mask])
+    return numpy.nan
 
 
 class CoastalVulnerabilityTests(unittest.TestCase):

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -272,12 +272,13 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         target_habitat_protection_path = os.path.join(
             workspace_dir, 'habitat_protection.csv')
         file_suffix = ''
+        model_resolution = 5000
 
         task_graph = taskgraph.TaskGraph(
             os.path.join(workspace_dir, 'taskgraph_dir'), -1)
 
         task_list, pickle_list = coastal_vulnerability._schedule_habitat_tasks(
-            base_shore_point_vector_path, habitat_table_path,
+            base_shore_point_vector_path, habitat_table_path, model_resolution,
             workspace_dir, file_suffix, task_graph)
 
         coastal_vulnerability.calculate_habitat_rank(

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -487,14 +487,8 @@ class CoastalVulnerabilityTests(unittest.TestCase):
 
         expected_raw_values_path = os.path.join(
             REGRESSION_DATA, 'expected_relief.json')
-
-        with open(target_relief_pickle_path, 'rb') as file:
-            actual_values_dict = pickle.load(file)
-        with open(expected_raw_values_path, 'r') as file:
-            expected_values_dict = json.load(file)
-        numpy.testing.assert_array_almost_equal(
-            list(actual_values_dict.values()),
-            list(expected_values_dict.values()))
+        assert_pickled_arrays_almost_equal(
+            target_relief_pickle_path, expected_raw_values_path)
         
     def test_population_values(self):
         """CV: regression test for aggregated population density."""

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1437,7 +1437,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             coastal_vulnerability._validate_habitat_table_paths(
                 habitat_table_path)
         actual_message = str(cm.exception)
-        expected_message = 'Could not open these vectors referenced in'
+        expected_message = 'Could not open these datasets referenced in'
         self.assertTrue(expected_message in actual_message)
 
     def test_polygon_to_lines(self):

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -25,6 +25,10 @@ INPUT_DATA = os.path.join(
     'coastal_vulnerability', 'input')
 
 
+def _mean_op(array, mask):
+    return numpy.mean(array[mask])
+
+
 class CoastalVulnerabilityTests(unittest.TestCase):
     """Tests for the Coastal Vulnerability Model."""
 
@@ -300,7 +304,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         target_habitat_pickle_path = os.path.join(
             workspace_dir, 'target.pickle')
 
-        coastal_vulnerability.search_for_habitat(
+        coastal_vulnerability.search_for_vector_habitat(
             base_shore_point_vector_path, search_radius, habitat_rank,
             habitat_id, habitat_vector_path, target_habitat_pickle_path)
 
@@ -688,7 +692,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
 
         coastal_vulnerability._aggregate_raster_values_in_radius(
             simple_points_path, raster_path, sample_distance,
-            target_pickle_path, 'mean')
+            target_pickle_path, _mean_op)
 
         with open(target_pickle_path, 'rb') as file:
             actual_values = pickle.load(file)
@@ -936,7 +940,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
 
         coastal_vulnerability._aggregate_raster_values_in_radius(
             simple_points_path, raster_path, sample_distance,
-            target_pickle_path, 'density')
+            target_pickle_path, _mean_op)
 
         with open(target_pickle_path, 'rb') as file:
             actual_values = pickle.load(file)
@@ -1438,23 +1442,6 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         target_layer = target_vector.GetLayer()
         n_actual_features = target_layer.GetFeatureCount()
         self.assertTrue(n_actual_features == n_features - 1)
-
-    def test_invalid_raster_aggregation_mode(self):
-        """CV: test ValueError raised on invalid raster aggration mode."""
-        base_point_vector_path = 'base.gpkg'
-        base_raster_path = 'base.tif'
-        sample_distance = 3
-        target_pickle_path = os.path.join(self.workspace_dir, 'some.pickle')
-        aggregation_mode = 'foo'
-
-        with self.assertRaises(ValueError) as cm:
-            coastal_vulnerability._aggregate_raster_values_in_radius(
-                base_point_vector_path, base_raster_path, sample_distance,
-                target_pickle_path, aggregation_mode)
-        actual_message = str(cm.exception)
-        expected_message = ('aggregation mode must be either "mean" or '
-                            '"density"')
-        self.assertTrue(actual_message == expected_message)
 
     def test_invalid_habitat_table_paths(self):
         """CV: test ValueError raised on invalid filepaths inside table."""

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -488,28 +488,14 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         expected_raw_values_path = os.path.join(
             REGRESSION_DATA, 'expected_relief.json')
 
-        # I found minor gdal version differences produced slightly different
-        # pixel values from gdal.Warp. So asserting exact values
-        # from calculate_relief_exposure might fail depending on gdal version.
-        # Rather than pin this test to a specific gdal version, I'm asserting
-        # equal rank values after binning the raw values into 1-5 ranks.
         with open(target_relief_pickle_path, 'rb') as file:
             actual_values_dict = pickle.load(file)
-        actual_rank_dict = coastal_vulnerability._bin_values_to_percentiles(
-            actual_values_dict, invert_values=True)
         with open(expected_raw_values_path, 'r') as file:
             expected_values_dict = json.load(file)
-        expected_rank_dict = coastal_vulnerability._bin_values_to_percentiles(
-            expected_values_dict, invert_values=True)
-        expected_rank_dict = {
-            int(x[0]): int(x[1]) for x in expected_rank_dict.items()}
-        # the dict items need sorting by FID to match the pre-sorted pickled
-        # items
-        expected_ranks = [x[1] for x in sorted(expected_rank_dict.items())]
-
-        numpy.testing.assert_array_equal(
-            list(actual_rank_dict.values()), expected_ranks)
-
+        numpy.testing.assert_array_almost_equal(
+            list(actual_values_dict.values()),
+            list(expected_values_dict.values()))
+        
     def test_population_values(self):
         """CV: regression test for aggregated population density."""
         workspace_dir = self.workspace_dir

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -687,6 +687,56 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         numpy.testing.assert_allclose(
             list(actual_values.values()), expected_values, rtol=0, atol=1e-4)
 
+    def test_nodata_raster_aggregation(self):
+        """CV: test raster aggregation over entirely nodata returns nan."""
+        workspace_dir = self.workspace_dir
+        raster_path = os.path.join(workspace_dir, 'nodata_raster.tif')
+        target_pickle_path = os.path.join(workspace_dir, 'target.pickle')
+        sample_distance = 1.5
+
+        # Make a simple raster filled with all nodata
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)  # UTM Zone 10N
+        projection_wkt = srs.ExportToWkt()
+        geotransform = [0, 0.5, 0.0, 0, 0.0, -0.5]
+        n = 5
+        nodata_val = -1
+        gtiff_driver = gdal.GetDriverByName('GTiff')
+        new_raster = gtiff_driver.Create(
+            raster_path, n, n, 1, gdal.GDT_Int32, options=[
+                'TILED=YES', 'BIGTIFF=YES', 'COMPRESS=LZW',
+                'BLOCKXSIZE=16', 'BLOCKYSIZE=16'])
+        new_raster.SetProjection(projection_wkt)
+        new_raster.SetGeoTransform(geotransform)
+        new_band = new_raster.GetRasterBand(1)
+        array = numpy.array([nodata_val] * n**2).reshape((n, n))
+        new_band.WriteArray(array)
+        if nodata_val is not None:
+            new_band.SetNoDataValue(nodata_val)
+        new_raster.FlushCache()
+        new_band = None
+        new_raster = None
+
+        # Make a vector proximate to the raster
+        simple_points_path = os.path.join(workspace_dir, 'simple_points.shp')
+        fields = {'shore_id': ogr.OFTInteger}
+        attributes = [{'shore_id': 0}]
+        pygeoprocessing.shapely_geometry_to_vector(
+            [Point(0., 0.)], simple_points_path, projection_wkt, 'GeoJSON',
+            fields=fields, attribute_list=attributes,
+            ogr_geom_type=ogr.wkbPoint)
+
+        coastal_vulnerability._aggregate_raster_values_in_radius(
+            simple_points_path, raster_path, sample_distance,
+            target_pickle_path, _mean_op)
+
+        with open(target_pickle_path, 'rb') as file:
+            actual_values = pickle.load(file)
+
+        expected_values = numpy.array([numpy.nan])
+        numpy.testing.assert_allclose(
+            list(actual_values.values()), expected_values, rtol=0, atol=1e-4)
+
     def test_complete_run(self):
         """CV: regression test for a complete run w/ all optional arguments."""
         args = CoastalVulnerabilityTests.generate_base_args(self.workspace_dir)
@@ -883,57 +933,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         # and the masked indices should be nans
         self.assertTrue(
             all(numpy.isnan(numpy.array(list(ranks_dict.values()))[mask])))
-
-    def test_nodata_raster_aggregation(self):
-        """CV: test raster aggregation over entirely nodata returns nan."""
-        workspace_dir = self.workspace_dir
-        raster_path = os.path.join(workspace_dir, 'nodata_raster.tif')
-        target_pickle_path = os.path.join(workspace_dir, 'target.pickle')
-        sample_distance = 1.5
-
-        # Make a simple raster filled with all nodata
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(26910)  # UTM Zone 10N
-        projection_wkt = srs.ExportToWkt()
-        geotransform = [0, 0.5, 0.0, 0, 0.0, -0.5]
-        n = 5
-        nodata_val = -1
-        gtiff_driver = gdal.GetDriverByName('GTiff')
-        new_raster = gtiff_driver.Create(
-            raster_path, n, n, 1, gdal.GDT_Int32, options=[
-                'TILED=YES', 'BIGTIFF=YES', 'COMPRESS=LZW',
-                'BLOCKXSIZE=16', 'BLOCKYSIZE=16'])
-        new_raster.SetProjection(projection_wkt)
-        new_raster.SetGeoTransform(geotransform)
-        new_band = new_raster.GetRasterBand(1)
-        array = numpy.array([nodata_val] * n**2).reshape((n, n))
-        new_band.WriteArray(array)
-        if nodata_val is not None:
-            new_band.SetNoDataValue(nodata_val)
-        new_raster.FlushCache()
-        new_band = None
-        new_raster = None
-
-        # Make a vector proximate to the raster
-        simple_points_path = os.path.join(workspace_dir, 'simple_points.shp')
-        fields = {'shore_id': ogr.OFTInteger}
-        attributes = [{'shore_id': 0}]
-        pygeoprocessing.shapely_geometry_to_vector(
-            [Point(0., 0.)], simple_points_path, projection_wkt, 'GeoJSON',
-            fields=fields, attribute_list=attributes,
-            ogr_geom_type=ogr.wkbPoint)
-
-        coastal_vulnerability._aggregate_raster_values_in_radius(
-            simple_points_path, raster_path, sample_distance,
-            target_pickle_path, _mean_op)
-
-        with open(target_pickle_path, 'rb') as file:
-            actual_values = pickle.load(file)
-
-        expected_values = numpy.array([numpy.nan])
-        numpy.testing.assert_allclose(
-            list(actual_values.values()), expected_values, rtol=0, atol=1e-4)
-
+    
     def test_positive_dem_with_nodata_floats(self):
         """CV: test coercing negative DEM values to zero.
 
@@ -1204,7 +1204,7 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             (-100, -100), (100, -100), (100, 100), (-100, 100), (-100, -100)]
         landmass_poly_holes = Polygon(exterior, [interior])
         n_points_actual = count_shore_points(landmass_poly_holes)
-        
+
         self.assertEqual(n_points_expected, n_points_actual)
 
     def test_aoi_invalid_geometry(self):

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -933,7 +933,12 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         # and the masked indices should be nans
         self.assertTrue(
             all(numpy.isnan(numpy.array(list(ranks_dict.values()))[mask])))
-    
+
+    def test_calc_habitat_rank_with_missing_values(self):
+        """CV: test calc Rhab when a habitat has a missing value."""
+        rank = coastal_vulnerability._calc_Rhab([3, 3, 3, numpy.nan])
+        self.assertTrue(numpy.isnan(rank))
+
     def test_positive_dem_with_nodata_floats(self):
         """CV: test coercing negative DEM values to zero.
 


### PR DESCRIPTION
This PR adds support for accepting raster format habitat layers in the CV model. Habitat maps are only used to represent presence/absence of habitat, so for rasters, I chose to treat 0 and nodata as absence, and anything else as presence.

The new `search_for_raster_habitat` function makes use of the pre-existing utility `_aggregate_raster_values_in_radius`. That function just needed to be made slightly more abstract by taking an `aggregation_op` (inspired by raster calculator) so that it can be shared by the `relief`, `population`, and `habitat` calculations.

I updated test habitat data to replace a shapefile with a raster. This is hard to notice in the test code because that reference is hidden inside a CSV. But `test_habitat_rank` and `test_complete_run` now run with a raster habitat layer. And I updated the sample data in the same manner.

Fixes #581 and fixes #628 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) -- only a minor update was needed because the details in the Data Needs section now come straight from the `ARGS_SPEC`!
