### PR TITLE
UCM tests different on re-run

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,9 @@ Unreleased Changes
 ------------------
 * General
     * Update to FontAwesome 5 icons in the QT interface.
+    * Updating the ``taskgraph`` requirement to ``0.11.0`` to resolve an issue
+      where modifying a file within a roughly 2-second window would fool
+      ``taskgraph`` into believing that the file had not been modified.
 * Habitat Quality
     * Changed how Habitat Rarity outputs are calculated to be less confusing.
       Values now represent a 0 to 1 index where before there could be

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only
 pygeoprocessing>=2.3.2  # pip-only
-taskgraph[niced_processes]>=0.10.3  # pip-only
+#taskgraph[niced_processes]>=0.10.3  # pip-only
+git+https://github.com/phargogh/taskgraph.git@bugfix/76-flaky-zerodivisionerror-on-linux-tests#egg=taskgraph
 psutil>=5.6.6
 chardet>=3.0.4
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,7 @@ Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only
 pygeoprocessing>=2.3.2  # pip-only
-#taskgraph[niced_processes]>=0.10.3  # pip-only
-git+https://github.com/phargogh/taskgraph.git@bugfix/76-flaky-zerodivisionerror-on-linux-tests#egg=taskgraph
+taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6
 chardet>=3.0.4
 openpyxl


### PR DESCRIPTION
This PR fixes #615 by bumping the taskgraph requirement.  The ultimate issue here is the `mtime` bug that was resolved in https://github.com/natcap/taskgraph/pull/75

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed) (not needed)
