### PR TITLE
don't download gnu zip after choco install zip.

### DIFF
--- a/ci/windows-ci-binary-install.ps1
+++ b/ci/windows-ci-binary-install.ps1
@@ -14,15 +14,6 @@
 choco install make vcredist140 pandoc zip 7zip unzip
 $env:PATH += ";C:\ProgramData\chocolatey\bin"
 
-# Install Zip.  This has been failing recently, so better to just install directly.
-# See https://sourceforge.net/p/forge/documentation/Mirrors/ for mirror options
-# See http://gnuwin32.sourceforge.net/setup.html for full list of installer CLI flags.
-# The installer doesn't add the target directory to the PATH, so we need to do that too.
-Write-Host "Installing GNU Zip"
-Invoke-WebRequest https://pilotfiber.dl.sourceforge.net/project/gnuwin32/zip/3.0/zip-3.0-setup.exe -OutFile zip-setup.exe
-& ./zip-setup.exe /VERYSILENT /SP /SUPPRESSMSGBOXES
-[Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files (x86)\GnuWin32\bin", "Machine")
-
 # Choco-provided command to reload environment variables
 refreshenv
 


### PR DESCRIPTION
There appears to be a redundant install of `zip` in our windows installer workflow. Sorry I didn't create an issue for this, was just trying out a fix and it appears to work. 

Our builds had been failing because that second download and install of `zip` was failing due to unresponsive sourceforge mirror, or something like that.

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
