### PR TITLE
Create a mask indicating NDR, SDR drainage

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,6 +47,16 @@ Unreleased Changes
       of 0.5 indicate same abundance between baseline and current/future
       LULC; values 0.5 to 1 indicate less abundance in current/future LULC
       and therefore higher rarity.
+* SDR
+    * Added a new raster to the model's workspace,
+      ``intermediate_outputs/what_drains_to_stream[suffix].tif``.  This raster
+      has pixel values of 1 where DEM pixels flow to an identified stream, and
+      0 where they do not.
+* NDR
+    * Added a new raster to the model's workspace,
+      ``intermediate_outputs/what_drains_to_stream[suffix].tif``.  This raster
+      has pixel values of 1 where DEM pixels flow to an identified stream, and
+      0 where they do not.
 
 3.9.2 (2021-10-29)
 ------------------

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -692,7 +692,8 @@ def _calculate_what_drains_to_stream(
     This is useful because ``pygeoprocessing.distance_to_stream_mfd`` may leave
     some unexpected regions as nodata if they do not drain to a stream.  This
     may be confusing behavior, so this mask is intended to locate what drains
-    to a stream and what does not.
+    to a stream and what does not. A pixel doesn't drain to a stream if it has
+    a defined flow direction but undefined distance to stream.
 
     Args:
         flow_dir_mfd_path (string): The path to an MFD flow direction raster.

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -723,8 +723,8 @@ def _calculate_what_drains_to_stream(
         Returns:
             A ``numpy.array`` of dtype ``numpy.uint8`` with pixels where:
 
-                * ``255`` where both ``flow_dir_mfd`` and ``dist_to_channel``
-                  are nodata.
+                * ``255`` where ``flow_dir_mfd`` is nodata (and thus 
+                  ``dist_to_channel`` is also nodata).
                 * ``0`` where ``flow_dir_mfd`` has data and ``dist_to_channel``
                   does not
                 * ``1`` where ``flow_dir_mfd`` has data, and

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -7,8 +7,7 @@ import unittest
 
 import numpy
 import pygeoprocessing
-from osgeo import gdal
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data', 'ndr')
@@ -246,10 +245,18 @@ class NDRTests(unittest.TestCase):
         if mismatch_list:
             raise RuntimeError("results not expected: %s" % mismatch_list)
 
+        # We only need to test that the drainage mask exists.  Functionality
+        # for that raster is tested in SDR.
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    args['workspace_dir'], 'intermediate_outputs',
+                    'what_drains_to_stream.tif')))
+
     def test_validation(self):
         """NDR test argument validation."""
-        from natcap.invest.ndr import ndr
         from natcap.invest import validation
+        from natcap.invest.ndr import ndr
 
         # use predefined directory so test can clean up files during teardown
         args = NDRTests.generate_base_args(self.workspace_dir)

--- a/tests/test_sdr.py
+++ b/tests/test_sdr.py
@@ -217,6 +217,14 @@ class SDRTests(unittest.TestCase):
             args['workspace_dir'], 'watershed_results_sdr.shp')
         assert_expected_results_in_vector(expected_results, vector_path)
 
+        # We only need to test that the drainage mask exists.  Functionality
+        # for that raster is tested elsewhere
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    args['workspace_dir'], 'intermediate_outputs',
+                    'what_drains_to_stream.tif')))
+
     def test_regression_with_undefined_nodata(self):
         """SDR base regression test with undefined nodata values.
 


### PR DESCRIPTION
This PR introduces a new raster output to the SDR and NDR models, really just a `raster_calculator` call indicating which pixels do and do not flow to the stream.

Fixes #621

This is a draft PR until I've finished the UG updates.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
