### PR TITLE
Deprecate direct setup.py invocation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,13 +91,13 @@ jobs:
               run: |
                   conda install nomkl # make sure numpy is w/out MKL
                   conda upgrade -y pip setuptools
-                  conda install ${{ matrix.numpy }} ${{ matrix.gdal }} toml twine
+                  conda install ${{ matrix.numpy }} ${{ matrix.gdal }} toml twine build
                   conda install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
 
             - name: Build wheel
               shell: bash -l {0}
               run: |
-                  python setup.py bdist_wheel
+                  python -m build --wheel
                   python -m twine check dist/*
 
             - name: Install runtime dependencies
@@ -196,7 +196,7 @@ jobs:
               run: |
                   conda install nomkl # make sure numpy is w/out MKL
                   conda upgrade -y pip setuptools
-                  conda install toml twine
+                  conda install toml twine build
                   conda install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
                   python ./scripts/convert-requirements-to-conda-yml.py \
                     requirements.txt > requirements-all.yml
@@ -205,7 +205,8 @@ jobs:
             - name: Build source distribution
               shell: bash -l {0}
               run: |
-                  python setup.py build_ext sdist
+                  python -m build --wheel
+                  python -m build --sdist
                   python -m twine check dist/*
 
             - name: Install from source distribution
@@ -280,12 +281,12 @@ jobs:
               shell: bash -l {0}
               run: |
                   conda install nomkl # make sure numpy w/out mkl
-                  conda install pytest requests
+                  conda install pytest requests build
                   conda install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")
                   conda upgrade -y pip wheel
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt > requirements.yml
                   conda env update --file requirements.yml
-                  python setup.py install
+                  make install
 
             - name: Validate sample data
               shell: bash -l {0}
@@ -340,7 +341,7 @@ jobs:
                     requirements.txt requirements-dev.txt \
                     requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
-                  python setup.py install
+                  make install
 
             - name: Run UI tests
               shell: bash -l {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -205,7 +205,10 @@ jobs:
             - name: Build source distribution
               shell: bash -l {0}
               run: |
-                  python -m build --wheel
+                  # Because we're using PEP518 build requirements, the user's
+                  # computer is guaranteed to have cython available at build
+                  # time.  Thus, it is no longer necessary to distribute the
+                  # .cpp files in addition to the .pyx files.
                   python -m build --sdist
                   python -m twine check dist/*
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,6 +44,10 @@ Unreleased Changes
       should be done via ``pip``.  The ``README`` has been updated to reflect
       this change, and this should only be noticeable for those installing
       ``natcap.invest`` from source.
+    * A bug has been fixed in ``make install`` so that now the current version
+      of ``natcap.invest`` is built and installed.  The former (buggy) version
+      of ``make install`` would install whatever the latest version was in your
+      ``dist`` folder.
 * Habitat Quality
     * Changed how Habitat Rarity outputs are calculated to be less confusing.
       Values now represent a 0 to 1 index where before there could be

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,12 @@ Unreleased Changes
 ------------------
 * General
     * Update to FontAwesome 5 icons in the QT interface.
+    * In response to the deprecation of ``setup.py``-based commands in Python
+      3.10, the recommended way to build python distributions of
+      ``natcap.invest`` is now with the ``build`` package, and installation
+      should be done via ``pip``.  The ``README`` has been updated to reflect
+      this change, and this should only be noticeable for those installing
+      ``natcap.invest`` from source.
 * Habitat Quality
     * Changed how Habitat Rarity outputs are calculated to be less confusing.
       Values now represent a 0 to 1 index where before there could be

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ env:
 # of pip don't think CWD is a valid package.
 install: $(DIST_DIR)/natcap.invest%.whl
 	-$(RMDIR) natcap.invest.egg-info
-	$(PIP) install --isolated --upgrade --no-index --only-binary natcap.invest --find-links=dist natcap.invest
+	$(PIP) install --isolated --upgrade --no-index --only-binary natcap.invest --find-links=dist "natcap.invest==$(VERSION)"
 
 
 # Build python packages and put them in dist/

--- a/Makefile
+++ b/Makefile
@@ -238,12 +238,12 @@ install: $(DIST_DIR)/natcap.invest%.whl
 
 
 # Build python packages and put them in dist/
-python_packages: $(DIST_DIR)/natcap.invest%.whl $(DIST_DIR)/natcap.invest%.zip
+python_packages: $(DIST_DIR)/natcap.invest%.whl $(DIST_DIR)/natcap.invest%.tar.gz
 $(DIST_DIR)/natcap.invest%.whl: | $(DIST_DIR)
-	$(PYTHON) setup.py bdist_wheel
+	$(PYTHON) -m build --wheel
 
-$(DIST_DIR)/natcap.invest%.zip: | $(DIST_DIR)
-	$(PYTHON) setup.py sdist --formats=zip
+$(DIST_DIR)/natcap.invest%.tar.gz: | $(DIST_DIR)
+	$(PYTHON) -m build --sdist
 
 
 # Build binaries and put them in dist/invest

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,6 @@ validate_sampledata: $(GIT_SAMPLE_DATA_REPO_PATH)
 	$(DATAVALIDATOR)
 
 clean:
-	$(PYTHON) setup.py clean
 	-$(RMDIR) $(BUILD_DIR)
 	-$(RMDIR) natcap.invest.egg-info
 	-$(RMDIR) cover
@@ -261,9 +260,11 @@ $(INVEST_BINARIES_DIR): | $(DIST_DIR) $(BUILD_DIR)
 # Documentation.
 # API docs are built in build/sphinx and copied to dist/apidocs
 apidocs: $(APIDOCS_TARGET_DIR) $(APIDOCS_ZIP_FILE)
-$(APIDOCS_TARGET_DIR): | $(DIST_DIR)
+$(APIDOCS_TARGET_DIR): | $(DIST_DIR) $(APIDOCS_TARGET_DIR)
 	# -a: always build all files
-	$(PYTHON) setup.py build_sphinx -a --source-dir doc/api-docs --build-dir $(APIDOCS_BUILD_DIR)
+	$(PYTHON) -m sphinx -a -b html \
+		-d $(APIDOCS_BUILD_DIR) \
+		doc/api-docs $(APIDOCS_BUILD_DIR)
 	# only copy over the built html files, not the doctrees
 	$(COPYDIR) $(APIDOCS_BUILD_DIR)/html $(APIDOCS_TARGET_DIR)
 

--- a/README.rst
+++ b/README.rst
@@ -113,8 +113,9 @@ Building python packages without GNU make
 """""""""""""""""""""""""""""""""""""""""
 Python distributions may be built with the standard distutils/setuptools commands::
 
-    $ python setup.py bdist_wheel
-    $ python setup.py sdist
+    $ python -m pip install build
+    $ python -m build --wheel
+    $ python -m build --sdist
 
 InVEST Standalone Binaries
 ++++++++++++++++++++++++++
@@ -232,9 +233,9 @@ To run tests for user interface functionality::
 Changing how GNU make runs tests
 ++++++++++++++++++++++++++++++++
 
-The InVEST Makefile setup depends on ``pytest`` and ``coverage`` to display 
+The InVEST Makefile setup depends on ``pytest`` and ``coverage`` to display
 line coverage and produce HTML and XML reports.  You can force ``make`` to use
-``coverage`` with a different test runner by setting a parameter at the 
+``coverage`` with a different test runner by setting a parameter at the
 command line.  For example, to run the tests with ``nose``::
 
     $ make TESTRUNNER=nose test

--- a/exe/invest.spec
+++ b/exe/invest.spec
@@ -27,8 +27,6 @@ kwargs = {
         'natcap.invest',
         'natcap.invest.ui.launcher',
         'yaml',
-        'distutils',
-        'distutils.dist',
         'rtree',  # mac builds aren't picking up rtree by default.
         'pkg_resources.py2_warn',
         'cmath',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,8 @@
 # will dynamically import GDAL via python's import system.  This behavior means
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
-requires = ['setuptools', 'wheel', 'setuptools_scm', 'numpy', 'cython']
+requires = ['setuptools', 'wheel', 'setuptools_scm>=45', 'numpy', 'cython']
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # will dynamically import GDAL via python's import system.  This behavior means
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
-requires = ['setuptools', 'wheel', 'setuptools_scm>=45', 'numpy', 'cython']
+requires = ['setuptools>=45', 'wheel', 'setuptools_scm>=6.2', 'numpy', 'cython']
 
 [tool.setuptools_scm]
 version_scheme = "post-release"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,4 @@ requests
 coverage
 xlwt
 dmgbuild==1.4.2; sys_platform == 'darwin'  # pip-only
+build

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(
     package_dir={
         'natcap': 'src/natcap'
     },
-    use_scm_version={'version_scheme': 'post-release',
-                     'local_scheme': 'node-and-date'},
     include_package_data=True,
     install_requires=_REQUIREMENTS,
     setup_requires=['setuptools_scm', 'numpy', 'cython'],

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,10 @@ For other commands, try `python setup.py --help-commands`
 """
 import platform
 
-from setuptools.extension import Extension
-from setuptools import setup
 import Cython.Build
 import numpy
-
+from setuptools import setup
+from setuptools.extension import Extension
 
 # Read in requirements.txt and populate the python readme with the
 # non-comment, non-environment-specifier contents.
@@ -138,12 +137,6 @@ setup(
             language="c++"),
     ],
     cmdclass={'build_ext': Cython.Build.build_ext},
-    command_options={
-        'build_sphinx': {
-            'source_dir': ('setup.py', 'doc/api-docs'),
-            'build_dir': ('setup.py', 'doc/api-docs-build'),
-            'config_dir': ('setup.py', 'doc/api-docs')}},
-
     entry_points={
         'console_scripts': [
             'invest = natcap.invest.cli:main'

--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -1,5 +1,4 @@
 # coding=UTF-8
-# distutils: language=c++
 # cython: language_level=2
 """
 Implements the Wang et al (2000) viewshed based on reference planes.


### PR DESCRIPTION
This PR replaces direct `setup.py` invocation across the repository with PyPA-recommended alternatives `build` and `pip`.

This also includes the update to `make install` we discussed on the team slack, where it will now install the specific version that is in the CWD.

Fixes #717

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [x] Updated the user's guide (if needed) _no changes needed to the UG_
