### PR TITLE
minor changes to various start menu shortcut names and model titles

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,22 +2,20 @@
   Changes should be grouped for readability.
 
   InVEST model names:
-  - Carbon
+  - Annual Water Yield
+  - Carbon Storage and Sequestration
   - Coastal Blue Carbon
   - Coastal Vulnerability
+  - Crop Pollination
   - Crop Production
   - DelineateIt
-  - Finfish
-  - Fisheries
   - Forest Carbon Edge Effects
   - Globio
   - Habitat Quality
   - HRA
-  - Annual Water Yield
   - NDR
-  - Pollination
-  - Recreation
-  - Routedem
+  - Visitation: Recreation and Tourism
+  - RouteDEM
   - Scenario Generator
   - Scenic Quality
   - SDR
@@ -37,7 +35,7 @@
 
 Unreleased Changes (3.10)
 -------------------------
-* General:
+* General
     * Added ``invest serve`` entry-point to the CLI. This launches a Flask app
       and server on the localhost, to support the workbench.
     * Major updates to each model's ``ARGS_SPEC`` (and some related validation)
@@ -45,11 +43,17 @@ Unreleased Changes (3.10)
     * Standardized and de-duplicated text in ``ARGS_SPEC`` ``about`` and
       ``name`` strings.
     * Update to FontAwesome 5 icons in the QT interface.
-* Coastal Vulnerability:
+* Annual Water Yield
+    * Renamed the Windows start menu shortcut from "Water Yield" to
+      "Annual Water Yield".
+* Coastal Vulnerability
     * Fixed bug where shore points were created on interior landmass holes
       (i.e. lakes).
     * Added feature to accept raster (in addition to vector) habitat layers.
     * Changed one intermediate output (geomorphology) from SHP to GPKG.
+* Crop Pollination
+    * Renamed the Windows start menu shortcut from "Pollination" to
+      "Crop Pollination".
 * Fisheries and Fisheries HST
     * The Fisheries models were deprecated due to lack of use,
       lack of scientific support staff, and maintenance costs.
@@ -65,6 +69,12 @@ Unreleased Changes (3.10)
       of 0.5 indicate same abundance between baseline and current/future
       LULC; values 0.5 to 1 indicate less abundance in current/future LULC
       and therefore higher rarity.
+* Scenic Quality
+    * Renamed the model title from
+      "Unobstructed Views: Scenic Quality Provision" to "Scenic Quality".
+* Visitation: Recreation and Tourism
+    * Renamed the Windows start menu shortcut from "Recreation" to
+      "Visitation: Recreation and Tourism".
 
 3.9.2 (2021-10-29)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := fc2fe9dc216cbfb351f4973b9cff832835ebf4d2
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := b2ec6b79e26cb8852ab8cdbf69fd31e4eabf4a2b
+GIT_UG_REPO_REV             := f638bec18b2f7262cb1f3c671fea20b9dd39dc9e
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := fc2fe9dc216cbfb351f4973b9cff832835ebf4d2
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := f638bec18b2f7262cb1f3c671fea20b9dd39dc9e
+GIT_UG_REPO_REV             := 18ab4a688bf217b55615cc295726db36f5670a31
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -435,21 +435,21 @@ Section "InVEST Tools" Section_InVEST_Tools
         !insertmacro StartMenuLink "${SMPATH}\Crop Production (Regression)" "crop_production_regression"
         !insertmacro StartMenuLink "${SMPATH}\Scenic Quality" "scenic_quality"
         !insertmacro StartMenuLink "${SMPATH}\Habitat Quality" "habitat_quality"
-        !insertmacro StartMenuLink "${SMPATH}\Carbon" "carbon"
+        !insertmacro StartMenuLink "${SMPATH}\Carbon Storage and Sequestration" "carbon"
         !insertmacro StartMenuLink "${SMPATH}\Forest Carbon Edge Effect" "forest_carbon_edge_effect"
         !insertmacro StartMenuLink "${SMPATH}\GLOBIO" "globio"
-        !insertmacro StartMenuLink "${SMPATH}\Pollination" "pollination"
+        !insertmacro StartMenuLink "${SMPATH}\Crop Pollination" "pollination"
         !insertmacro StartMenuLink "${SMPATH}\Wave Energy" "wave_energy"
         !insertmacro StartMenuLink "${SMPATH}\Wind Energy" "wind_energy"
         !insertmacro StartMenuLink "${SMPATH}\Coastal Vulnerability" "cv"
         !insertmacro StartMenuLink "${SMPATH}\SDR: Sediment Delivery Ratio" "sdr"
         !insertmacro StartMenuLink "${SMPATH}\NDR: Nutrient Delivery Ratio" "ndr"
         !insertmacro StartMenuLink "${SMPATH}\Scenario Generator: Proximity Based" "sgp"
-        !insertmacro StartMenuLink "${SMPATH}\Water Yield" "hwy"
+        !insertmacro StartMenuLink "${SMPATH}\Annual Water Yield" "hwy"
         !insertmacro StartMenuLink "${SMPATH}\Seasonal Water Yield" "swy"
         !insertmacro StartMenuLink "${SMPATH}\RouteDEM" "routedem"
         !insertmacro StartMenuLink "${SMPATH}\DelineateIt" "delineateit"
-        !insertmacro StartMenuLink "${SMPATH}\Recreation" "recreation"
+        !insertmacro StartMenuLink "${SMPATH}\Visitation: Recreation and Tourism" "recreation"
         !insertmacro StartMenuLink "${SMPATH}\Urban Flood Risk Mitigation" "ufrm"
         !insertmacro StartMenuLink "${SMPATH}\Urban Cooling Model" "ucm"
         !insertmacro StartMenuLink "${SMPATH}\Urban Stormwater Retention Model" "stormwater"
@@ -559,7 +559,7 @@ SectionGroup /e "InVEST Datasets" SEC_DATA
     ;they were calculated by hand by decompressing all the .zip files and recording
     ;the size by hand.
     !insertmacro downloadData "Annual Water Yield (optional)" "Annual_Water_Yield.zip" 20513
-    !insertmacro downloadData "Carbon (optional)" "Carbon.zip" 17748
+    !insertmacro downloadData "Carbon Storage and Sequestration (optional)" "Carbon.zip" 17748
     !insertmacro downloadData "Coastal Blue Carbon (optional)" "CoastalBlueCarbon.zip" 332
     !insertmacro downloadData "Coastal Vulnerability (optional)" "CoastalVulnerability.zip" 169918
     !insertmacro downloadData "Crop Production (optional)" "CropProduction.zip" 111898
@@ -569,8 +569,8 @@ SectionGroup /e "InVEST Datasets" SEC_DATA
     !insertmacro downloadData "Habitat Quality (optional)" "HabitatQuality.zip" 1880
     !insertmacro downloadData "Habitat Risk Assessment (optional)" "HabitatRiskAssess.zip" 7791
     !insertmacro downloadData "Nutrient Delivery Ratio (optional)" "NDR.zip" 10973
-    !insertmacro downloadData "Pollination (optional)" "pollination.zip" 687
-    !insertmacro downloadData "Recreation (optional)" "recreation.zip" 5826
+    !insertmacro downloadData "Crop Pollination (optional)" "pollination.zip" 687
+    !insertmacro downloadData "Visitation: Recreation and Tourism (optional)" "recreation.zip" 5826
     !insertmacro downloadData "RouteDEM (optional)" "RouteDEM.zip" 532
     !insertmacro downloadData "Scenario Generator: Proximity Based (optional)" "scenario_proximity.zip" 7508
     !insertmacro downloadData "Scenic Quality (optional)" "ScenicQuality.zip" 165792

--- a/src/natcap/invest/__init__.py
+++ b/src/natcap/invest/__init__.py
@@ -132,7 +132,7 @@ MODEL_METADATA = {
         userguide='scenario_gen_proximity.html',
         aliases=('sgp',)),
     'scenic_quality': _MODELMETA(
-        model_title='Unobstructed Views: Scenic Quality Provision',
+        model_title='Scenic Quality',
         pyname='natcap.invest.scenic_quality.scenic_quality',
         gui='scenic_quality.ScenicQuality',
         userguide='scenic_quality.html',


### PR DESCRIPTION
This PR unifies start menu names with model titles, according to what we discussed recently.

Fixes #718

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)  - I renamed the Scenic Quality and Crop Pollination chapters to better match these names. I did that on the `release/3.10` branch of the UG.
