### PR TITLE
Stormwater: aggregate runoff fields

### DIFF
--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -474,8 +474,10 @@ def execute(args):
     aggregation_task_dependencies = [retention_volume_task]
     data_to_aggregate = [
         # tuple of (raster path, output field name, op) for aggregation
-        (final_retention_ratio_path, 'RR_mean', 'mean'),
-        (files['retention_volume_path'], 'RV_sum', 'sum')]
+        (final_retention_ratio_path, 'mean_retention_ratio', 'mean'),
+        (files['retention_volume_path'], 'total_retention_volume', 'sum'),
+        (files['runoff_ratio_path'], 'mean_runoff_ratio', 'mean'),
+        (files['runoff_volume_path'], 'total_runoff_volume', 'sum')]
 
     # (Optional) Calculate stormwater infiltration ratio and volume from
     # LULC, soil groups, biophysical table, and precipitation
@@ -515,10 +517,10 @@ def execute(args):
             task_name='calculate stormwater retention volume'
         )
         aggregation_task_dependencies.append(infiltration_volume_task)
-        data_to_aggregate.append(
-            (files['infiltration_ratio_path'], 'IR_mean', 'mean'))
-        data_to_aggregate.append(
-            (files['infiltration_volume_path'], 'IV_sum', 'sum'))
+        data_to_aggregate.append((files['infiltration_ratio_path'],
+                                 'mean_infiltration_ratio', 'mean'))
+        data_to_aggregate.append((files['infiltration_volume_path'],
+                                 'total_infiltration_volume', 'sum'))
 
     # get all EMC columns from an arbitrary row in the dictionary
     # strip the first four characters off 'EMC_pollutant' to get pollutant name
@@ -578,10 +580,10 @@ def execute(args):
             task_name=f'calculate actual pollutant {pollutant} load'
         )
         aggregation_task_dependencies += [avoided_load_task, actual_load_task]
+        data_to_aggregate.append((avoided_pollutant_load_path,
+                                 f'{pollutant}_total_avoided_load', 'sum'))
         data_to_aggregate.append(
-            (avoided_pollutant_load_path, f'avoided_{pollutant}', 'sum'))
-        data_to_aggregate.append(
-            (actual_pollutant_load_path, f'load_{pollutant}', 'mean'))
+            (actual_pollutant_load_path, f'{pollutant}_mean_load', 'mean'))
 
     # (Optional) Do valuation if a replacement cost is defined
     # you could theoretically have a cost of 0 which should be allowed
@@ -602,7 +604,7 @@ def execute(args):
         )
         aggregation_task_dependencies.append(valuation_task)
         data_to_aggregate.append(
-            (files['retention_value_path'], 'val_sum', 'sum'))
+            (files['retention_value_path'], 'total_retention_value', 'sum'))
 
     # (Optional) Aggregate to watersheds if an aggregate vector is defined
     if 'aggregate_areas_path' in args and args['aggregate_areas_path']:

--- a/tests/test_stormwater.py
+++ b/tests/test_stormwater.py
@@ -448,7 +448,7 @@ class StormwaterTests(unittest.TestCase):
          precipitation_array,
          precipitation_path,
          retention_cost,
-         pixel_area) = self.basic_setup(self.workspace_dir)
+         pixel_area) = self.basic_setup(self.workspace_dir, ir=True)
 
         args = {
             'workspace_dir': self.workspace_dir,
@@ -466,30 +466,42 @@ class StormwaterTests(unittest.TestCase):
 
         expected_feature_fields = {
             1: {
-                'RR_mean': 0.825,
-                'RV_sum': 8.5,
-                'avoided_pollutant1': .0085,
-                'load_pollutant1': .000375,
-                'val_sum': 21.505
+                'mean_retention_ratio': 0.825,
+                'mean_runoff_ratio': 0.175,
+                'mean_infiltration_ratio': 0.575,
+                'total_retention_volume': 8.5,
+                'total_runoff_volume': 1.5,
+                'total_infiltration_volume': 5.5,
+                'pollutant1_total_avoided_load': .0085,
+                'pollutant1_mean_load': .000375,
+                'total_retention_value': 21.505
             },
             2: {
-                'RR_mean': 0.5375,
-                'RV_sum': 7.5,
-                'avoided_pollutant1': .0075,
-                'load_pollutant1': .006875,
-                'val_sum': 18.975
+                'mean_retention_ratio': 0.5375,
+                'mean_runoff_ratio': 0.4625,
+                'mean_infiltration_ratio': 0.7625,
+                'total_retention_volume': 7.5,
+                'total_runoff_volume': 7.5,
+                'total_infiltration_volume': 11.5,
+                'pollutant1_total_avoided_load': .0075,
+                'pollutant1_mean_load': .006875,
+                'total_retention_value': 18.975
             },
             3: {
-                'RR_mean': 0,
-                'RV_sum': 0,
-                'avoided_pollutant1': 0,
-                'load_pollutant1': 0,
-                'val_sum': 0
+                'mean_retention_ratio': 0,
+                'total_retention_volume': 0,
+                'mean_runoff_ratio': 0,
+                'total_runoff_volume': 0,
+                'mean_infiltration_ratio': 0,
+                'total_infiltration_volume': 0,
+                'pollutant1_total_avoided_load': 0,
+                'pollutant1_mean_load': 0,
+                'total_retention_value': 0
             }
         }
 
         aggregate_data_path = os.path.join(
-            self.workspace_dir,
+            args['workspace_dir'],
             stormwater.FINAL_OUTPUTS['reprojected_aggregate_areas_path'])
         aggregate_vector = gdal.OpenEx(aggregate_data_path, gdal.OF_VECTOR)
         aggregate_layer = aggregate_vector.GetLayer()


### PR DESCRIPTION
# Description
Fixes #756 

I also renamed the aggregate fields to be more understandable. Since the output is a geopackage, we're not limited to 10 character names. The [geopackage spec](https://www.geopackage.org/spec/) recommends keeping identifiers shorter than 30 bytes. The names are still shorter than 30 characters (though could be longer if the user provides a lengthy pollutant name). And they're unique within the first 10 characters, so would still be usable if it was converted to shapefile and names were truncated.

No update to HISTORY.rst needed, since the model hasn't been released yet. User's guide was updated in the draft on google docs.

# Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~

- [x] Updated the user's guide (if needed)
