### PR TITLE
CV: create 2D geometries instead of 2.5D

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -51,6 +51,8 @@ Unreleased Changes (3.10)
       (i.e. lakes).
     * Added feature to accept raster (in addition to vector) habitat layers.
     * Changed one intermediate output (geomorphology) from SHP to GPKG.
+    * Fixed bug where output vectors had coordinates with an unncessary 
+      z-dimension. Output vectors now have 2D geometry.
 * Crop Pollination
     * Renamed the Windows start menu shortcut from "Pollination" to
       "Crop Pollination".

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -810,7 +810,7 @@ def prepare_landmass_line_index_and_interpolate_shore_points(
             target_layer.StartTransaction()
             for point_feature in point_list:
                 geometry = ogr.Geometry(ogr.wkbPoint)
-                geometry.AddPoint(
+                geometry.AddPoint_2D(
                     point_feature.coords[0][0], point_feature.coords[0][1])
                 feature = ogr.Feature(target_defn)
                 feature.SetGeometry(geometry)
@@ -1219,8 +1219,8 @@ def calculate_wind_exposure(
 
             # build ray geometry so we can intersect it later
             ray_geometry = ogr.Geometry(ogr.wkbLineString)
-            ray_geometry.AddPoint(point_a_x, point_a_y)
-            ray_geometry.AddPoint(point_b_x, point_b_y)
+            ray_geometry.AddPoint_2D(point_a_x, point_a_y)
+            ray_geometry.AddPoint_2D(point_b_x, point_b_y)
 
             # keep a shapely version of the ray so we can do fast intersection
             # with it and the entire landmass
@@ -1261,8 +1261,8 @@ def calculate_wind_exposure(
                                 line_segment)
                             # replace the ray geometry with the new endpoint
                             ray_geometry = ogr.Geometry(ogr.wkbLineString)
-                            ray_geometry.AddPoint(point_a_x, point_a_y)
-                            ray_geometry.AddPoint(
+                            ray_geometry.AddPoint_2D(point_a_x, point_a_y)
+                            ray_geometry.AddPoint_2D(
                                 intersection_point.GetX(),
                                 intersection_point.GetY())
                             intersection = True
@@ -3016,7 +3016,7 @@ def _copy_point_vector_geom_to_gpkg(
     for feature in base_layer:
         target_geometry = ogr.Geometry(ogr.wkbPoint)
         base_geometry = feature.GetGeometryRef()
-        target_geometry.AddPoint(base_geometry.GetX(), base_geometry.GetY())
+        target_geometry.AddPoint_2D(base_geometry.GetX(), base_geometry.GetY())
         target_feature = ogr.Feature(target_layer_defn)
         target_feature.SetGeometry(target_geometry)
         for fieldname in copy_field_list:


### PR DESCRIPTION
Just a matter of using the `ogr` API correctly: `AddPoint_2D` instead of `AddPoint`. The latter creates a default z=0 when given only an x, y pair.

Fixes #749 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] ~~Updated the user's guide (if needed)~~
