### PR TITLE
Bugfix/738 nodata nan isclose

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,8 @@ Unreleased Changes (3.10)
     * Updating the ``taskgraph`` requirement to ``0.11.0`` to resolve an issue
       where modifying a file within a roughly 2-second window would fool
       ``taskgraph`` into believing that the file had not been modified.
+    * Fixed a bug where some input rasters with NaN nodata values would cause
+      bad behavior.
 * Annual Water Yield
     * Renamed the Windows start menu shortcut from "Water Yield" to
       "Annual Water Yield".

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -50,8 +50,8 @@ Unreleased Changes (3.10)
     * Updating the ``taskgraph`` requirement to ``0.11.0`` to resolve an issue
       where modifying a file within a roughly 2-second window would fool
       ``taskgraph`` into believing that the file had not been modified.
-    * Fixed a bug where some input rasters with NaN nodata values would cause
-      bad behavior.
+    * Fixed a bug where some input rasters with NaN nodata values would go
+      undetected as nodata and yield unexpected behavior.
 * Annual Water Yield
     * Renamed the Windows start menu shortcut from "Water Yield" to
       "Annual Water Yield".

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -798,7 +798,7 @@ def aet_op(fractp, precip, precip_nodata, output_nodata):
     # and the nodata value is a large negative number.
     valid_mask = fractp >= 0
     if precip_nodata is not None:
-        valid_mask &= ~numpy.isclose(precip, precip_nodata)
+        valid_mask &= ~numpy.isclose(precip, precip_nodata, equal_nan=True)
     result[valid_mask] = fractp[valid_mask] * precip[valid_mask]
     return result
 
@@ -820,9 +820,9 @@ def wyield_op(fractp, precip, precip_nodata, output_nodata):
     result = numpy.empty_like(fractp)
     result[:] = output_nodata
     # output_nodata is defined above, should never be None
-    valid_mask = ~numpy.isclose(fractp, output_nodata)
+    valid_mask = ~numpy.isclose(fractp, output_nodata, equal_nan=True)
     if precip_nodata is not None:
-        valid_mask &= ~numpy.isclose(precip, precip_nodata)
+        valid_mask &= ~numpy.isclose(precip, precip_nodata, equal_nan=True)
     result[valid_mask] = (1.0 - fractp[valid_mask]) * precip[valid_mask]
     return result
 
@@ -863,18 +863,20 @@ def fractp_op(
     # and retain their original nodata values.
     # out_nodata is defined above and should never be None.
     valid_mask = (
-        ~numpy.isclose(Kc, nodata_dict['out_nodata']) &
-        ~numpy.isclose(root, nodata_dict['out_nodata']) &
-        ~numpy.isclose(veg, nodata_dict['out_nodata']) &
-        ~numpy.isclose(precip, 0.0))
+        ~numpy.isclose(Kc, nodata_dict['out_nodata'], equal_nan=True) &
+        ~numpy.isclose(root, nodata_dict['out_nodata'], equal_nan=True) &
+        ~numpy.isclose(veg, nodata_dict['out_nodata'], equal_nan=True) &
+        ~numpy.isclose(precip, 0.0, equal_nan=True))
     if nodata_dict['eto'] is not None:
-        valid_mask &= ~numpy.isclose(eto, nodata_dict['eto'])
+        valid_mask &= ~numpy.isclose(eto, nodata_dict['eto'], equal_nan=True)
     if nodata_dict['precip'] is not None:
-        valid_mask &= ~numpy.isclose(precip, nodata_dict['precip'])
+        valid_mask &= ~numpy.isclose(
+            precip, nodata_dict['precip'], equal_nan=True)
     if nodata_dict['depth_root'] is not None:
-        valid_mask &= ~numpy.isclose(soil, nodata_dict['depth_root'])
+        valid_mask &= ~numpy.isclose(
+            soil, nodata_dict['depth_root'], equal_nan=True)
     if nodata_dict['pawc'] is not None:
-        valid_mask &= ~numpy.isclose(pawc, nodata_dict['pawc'])
+        valid_mask &= ~numpy.isclose(pawc, nodata_dict['pawc'], equal_nan=True)
 
     # Compute Budyko Dryness index
     # Use the original AET equation if the land cover type is vegetation
@@ -938,9 +940,9 @@ def pet_op(eto_pix, Kc_pix, eto_nodata, output_nodata):
     result = numpy.empty(eto_pix.shape, dtype=numpy.float32)
     result[:] = output_nodata
 
-    valid_mask = ~numpy.isclose(Kc_pix, output_nodata)
+    valid_mask = ~numpy.isclose(Kc_pix, output_nodata, equal_nan=True)
     if eto_nodata is not None:
-        valid_mask &= ~numpy.isclose(eto_pix, eto_nodata)
+        valid_mask &= ~numpy.isclose(eto_pix, eto_nodata, equal_nan=True)
     result[valid_mask] = eto_pix[valid_mask] * Kc_pix[valid_mask]
     return result
 

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -798,7 +798,7 @@ def aet_op(fractp, precip, precip_nodata, output_nodata):
     # and the nodata value is a large negative number.
     valid_mask = fractp >= 0
     if precip_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(precip, precip_nodata)
+        valid_mask &= ~utils.array_equals_nodata(precip, precip_nodata)
     result[valid_mask] = fractp[valid_mask] * precip[valid_mask]
     return result
 
@@ -820,9 +820,9 @@ def wyield_op(fractp, precip, precip_nodata, output_nodata):
     result = numpy.empty_like(fractp)
     result[:] = output_nodata
     # output_nodata is defined above, should never be None
-    valid_mask = ~utils.check_array_for_nodata(fractp, output_nodata)
+    valid_mask = ~utils.array_equals_nodata(fractp, output_nodata)
     if precip_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(precip, precip_nodata)
+        valid_mask &= ~utils.array_equals_nodata(precip, precip_nodata)
     result[valid_mask] = (1.0 - fractp[valid_mask]) * precip[valid_mask]
     return result
 
@@ -863,22 +863,19 @@ def fractp_op(
     # and retain their original nodata values.
     # out_nodata is defined above and should never be None.
     valid_mask = (
-        ~utils.check_array_for_nodata(Kc, nodata_dict['out_nodata']) &
-        ~utils.check_array_for_nodata(root, nodata_dict['out_nodata']) &
-        ~utils.check_array_for_nodata(veg, nodata_dict['out_nodata']) &
-        ~utils.check_array_for_nodata(precip, 0.0))
+        ~utils.array_equals_nodata(Kc, nodata_dict['out_nodata']) &
+        ~utils.array_equals_nodata(root, nodata_dict['out_nodata']) &
+        ~utils.array_equals_nodata(veg, nodata_dict['out_nodata']) &
+        ~utils.array_equals_nodata(precip, 0.0))
     if nodata_dict['eto'] is not None:
-        valid_mask &= ~utils.check_array_for_nodata(
-            eto, nodata_dict['eto'])
+        valid_mask &= ~utils.array_equals_nodata(eto, nodata_dict['eto'])
     if nodata_dict['precip'] is not None:
-        valid_mask &= ~utils.check_array_for_nodata(
-            precip, nodata_dict['precip'])
+        valid_mask &= ~utils.array_equals_nodata(precip, nodata_dict['precip'])
     if nodata_dict['depth_root'] is not None:
-        valid_mask &= ~utils.check_array_for_nodata(
+        valid_mask &= ~utils.array_equals_nodata(
             soil, nodata_dict['depth_root'])
     if nodata_dict['pawc'] is not None:
-        valid_mask &= ~utils.check_array_for_nodata(
-            pawc, nodata_dict['pawc'])
+        valid_mask &= ~utils.array_equals_nodata(pawc, nodata_dict['pawc'])
 
     # Compute Budyko Dryness index
     # Use the original AET equation if the land cover type is vegetation
@@ -942,9 +939,9 @@ def pet_op(eto_pix, Kc_pix, eto_nodata, output_nodata):
     result = numpy.empty(eto_pix.shape, dtype=numpy.float32)
     result[:] = output_nodata
 
-    valid_mask = ~utils.check_array_for_nodata(Kc_pix, output_nodata)
+    valid_mask = ~utils.array_equals_nodata(Kc_pix, output_nodata)
     if eto_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(eto_pix, eto_nodata)
+        valid_mask &= ~utils.array_equals_nodata(eto_pix, eto_nodata)
     result[valid_mask] = eto_pix[valid_mask] * Kc_pix[valid_mask]
     return result
 

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -798,7 +798,7 @@ def aet_op(fractp, precip, precip_nodata, output_nodata):
     # and the nodata value is a large negative number.
     valid_mask = fractp >= 0
     if precip_nodata is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(precip, precip_nodata)
+        valid_mask &= ~utils.check_array_for_nodata(precip, precip_nodata)
     result[valid_mask] = fractp[valid_mask] * precip[valid_mask]
     return result
 
@@ -820,9 +820,9 @@ def wyield_op(fractp, precip, precip_nodata, output_nodata):
     result = numpy.empty_like(fractp)
     result[:] = output_nodata
     # output_nodata is defined above, should never be None
-    valid_mask = ~utils.compare_nodata_nan_support(fractp, output_nodata)
+    valid_mask = ~utils.check_array_for_nodata(fractp, output_nodata)
     if precip_nodata is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(precip, precip_nodata)
+        valid_mask &= ~utils.check_array_for_nodata(precip, precip_nodata)
     result[valid_mask] = (1.0 - fractp[valid_mask]) * precip[valid_mask]
     return result
 
@@ -863,21 +863,21 @@ def fractp_op(
     # and retain their original nodata values.
     # out_nodata is defined above and should never be None.
     valid_mask = (
-        ~utils.compare_nodata_nan_support(Kc, nodata_dict['out_nodata']) &
-        ~utils.compare_nodata_nan_support(root, nodata_dict['out_nodata']) &
-        ~utils.compare_nodata_nan_support(veg, nodata_dict['out_nodata']) &
-        ~utils.compare_nodata_nan_support(precip, 0.0))
+        ~utils.check_array_for_nodata(Kc, nodata_dict['out_nodata']) &
+        ~utils.check_array_for_nodata(root, nodata_dict['out_nodata']) &
+        ~utils.check_array_for_nodata(veg, nodata_dict['out_nodata']) &
+        ~utils.check_array_for_nodata(precip, 0.0))
     if nodata_dict['eto'] is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(
+        valid_mask &= ~utils.check_array_for_nodata(
             eto, nodata_dict['eto'])
     if nodata_dict['precip'] is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(
+        valid_mask &= ~utils.check_array_for_nodata(
             precip, nodata_dict['precip'])
     if nodata_dict['depth_root'] is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(
+        valid_mask &= ~utils.check_array_for_nodata(
             soil, nodata_dict['depth_root'])
     if nodata_dict['pawc'] is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(
+        valid_mask &= ~utils.check_array_for_nodata(
             pawc, nodata_dict['pawc'])
 
     # Compute Budyko Dryness index
@@ -942,9 +942,9 @@ def pet_op(eto_pix, Kc_pix, eto_nodata, output_nodata):
     result = numpy.empty(eto_pix.shape, dtype=numpy.float32)
     result[:] = output_nodata
 
-    valid_mask = ~utils.compare_nodata_nan_support(Kc_pix, output_nodata)
+    valid_mask = ~utils.check_array_for_nodata(Kc_pix, output_nodata)
     if eto_nodata is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(eto_pix, eto_nodata)
+        valid_mask &= ~utils.check_array_for_nodata(eto_pix, eto_nodata)
     result[valid_mask] = eto_pix[valid_mask] * Kc_pix[valid_mask]
     return result
 

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -798,7 +798,7 @@ def aet_op(fractp, precip, precip_nodata, output_nodata):
     # and the nodata value is a large negative number.
     valid_mask = fractp >= 0
     if precip_nodata is not None:
-        valid_mask &= ~numpy.isclose(precip, precip_nodata, equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(precip, precip_nodata)
     result[valid_mask] = fractp[valid_mask] * precip[valid_mask]
     return result
 
@@ -820,9 +820,9 @@ def wyield_op(fractp, precip, precip_nodata, output_nodata):
     result = numpy.empty_like(fractp)
     result[:] = output_nodata
     # output_nodata is defined above, should never be None
-    valid_mask = ~numpy.isclose(fractp, output_nodata, equal_nan=True)
+    valid_mask = ~utils.compare_nodata_nan_support(fractp, output_nodata)
     if precip_nodata is not None:
-        valid_mask &= ~numpy.isclose(precip, precip_nodata, equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(precip, precip_nodata)
     result[valid_mask] = (1.0 - fractp[valid_mask]) * precip[valid_mask]
     return result
 
@@ -863,20 +863,22 @@ def fractp_op(
     # and retain their original nodata values.
     # out_nodata is defined above and should never be None.
     valid_mask = (
-        ~numpy.isclose(Kc, nodata_dict['out_nodata'], equal_nan=True) &
-        ~numpy.isclose(root, nodata_dict['out_nodata'], equal_nan=True) &
-        ~numpy.isclose(veg, nodata_dict['out_nodata'], equal_nan=True) &
-        ~numpy.isclose(precip, 0.0, equal_nan=True))
+        ~utils.compare_nodata_nan_support(Kc, nodata_dict['out_nodata']) &
+        ~utils.compare_nodata_nan_support(root, nodata_dict['out_nodata']) &
+        ~utils.compare_nodata_nan_support(veg, nodata_dict['out_nodata']) &
+        ~utils.compare_nodata_nan_support(precip, 0.0))
     if nodata_dict['eto'] is not None:
-        valid_mask &= ~numpy.isclose(eto, nodata_dict['eto'], equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(
+            eto, nodata_dict['eto'])
     if nodata_dict['precip'] is not None:
-        valid_mask &= ~numpy.isclose(
-            precip, nodata_dict['precip'], equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(
+            precip, nodata_dict['precip'])
     if nodata_dict['depth_root'] is not None:
-        valid_mask &= ~numpy.isclose(
-            soil, nodata_dict['depth_root'], equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(
+            soil, nodata_dict['depth_root'])
     if nodata_dict['pawc'] is not None:
-        valid_mask &= ~numpy.isclose(pawc, nodata_dict['pawc'], equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(
+            pawc, nodata_dict['pawc'])
 
     # Compute Budyko Dryness index
     # Use the original AET equation if the land cover type is vegetation
@@ -940,9 +942,9 @@ def pet_op(eto_pix, Kc_pix, eto_nodata, output_nodata):
     result = numpy.empty(eto_pix.shape, dtype=numpy.float32)
     result[:] = output_nodata
 
-    valid_mask = ~numpy.isclose(Kc_pix, output_nodata, equal_nan=True)
+    valid_mask = ~utils.compare_nodata_nan_support(Kc_pix, output_nodata)
     if eto_nodata is not None:
-        valid_mask &= ~numpy.isclose(eto_pix, eto_nodata, equal_nan=True)
+        valid_mask &= ~utils.compare_nodata_nan_support(eto_pix, eto_nodata)
     result[valid_mask] = eto_pix[valid_mask] * Kc_pix[valid_mask]
     return result
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -441,7 +441,8 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~numpy.isclose(block, nodata)], dtype=numpy.float64)
+            block[~utils.check_array_for_nodata(
+                    block, nodata)], dtype=numpy.float64)
     return raster_sum
 
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -34,28 +34,28 @@ ARGS_SPEC = {
             **spec_utils.LULC,
             "projected": True,
             "projection_units": u.meter,
-            "about": (
+            "about": _(
                 "A map of LULC for the current scenario. "
                 "All values in this raster must have corresponding "
                 "entries in the Carbon Pools table."),
-            "name": "current LULC"
+            "name": _("current LULC")
         },
         "calc_sequestration": {
             "type": "boolean",
             "required": "do_valuation | do_redd",
-            "about": (
+            "about": _(
                 "Run sequestration analysis. This requires inputs "
                 "of LULC maps for both current and future "
                 "scenarios. Required if REDD scenario analysis or "
                 "run valuation model is selected."),
-            "name": "calculate sequestration"
+            "name": _("calculate sequestration")
         },
         "lulc_fut_path": {
             **spec_utils.LULC,
             "projected": True,
             "projection_units": u.meter,
             "required": "calc_sequestration",
-            "about": (
+            "about": _(
                 "A map of LULC for the future scenario. "
                 "If run valuation model is "
                 "selected, this should be the reference, or baseline, future "
@@ -63,36 +63,36 @@ ARGS_SPEC = {
                 "All values in this raster must have corresponding entries in "
                 "the Carbon Pools table. Required if Calculate Sequestration "
                 "is selected."),
-            "name": "future LULC"
+            "name": _("future LULC")
         },
         "do_redd": {
             "type": "boolean",
             "required": False,
-            "about": (
+            "about": _(
                 "Run REDD scenario analysis. This requires three "
                 "LULC maps: one for the current scenario, one "
                 "for the future baseline scenario, and one for the future "
                 "REDD policy scenario."),
-            "name": "REDD scenario analysis"
+            "name": _("REDD scenario analysis")
         },
         "lulc_redd_path": {
             **spec_utils.LULC,
             "projected": True,
             "projection_units": u.meter,
             "required": "do_redd",
-            "about": (
+            "about": _(
                 "A map of LULC for the REDD policy scenario. "
                 "All values in this raster must have corresponding entries in "
                 "the Carbon Pools table. Required if REDD Scenario Analysis "
                 "is selected."),
-            "name": "REDD LULC"
+            "name": _("REDD LULC")
         },
         "carbon_pools_path": {
             "type": "csv",
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": (
+                    "about": _(
                         "LULC code. Every value in the "
                         "LULC maps must have a corresponding entry in "
                         "this column.")
@@ -100,41 +100,41 @@ ARGS_SPEC = {
                 "c_above": {
                     "type": "number",
                     "units": u.metric_ton/u.hectare,
-                    "about": "Carbon density of aboveground biomass."},
+                    "about": _("Carbon density of aboveground biomass.")},
                 "c_below": {
                     "type": "number",
                     "units": u.metric_ton/u.hectare,
-                    "about": "Carbon density of belowground biomass."},
+                    "about": _("Carbon density of belowground biomass.")},
                 "c_soil": {
                     "type": "number",
                     "units": u.metric_ton/u.hectare,
-                    "about": "Carbon density of soil."},
+                    "about": _("Carbon density of soil.")},
                 "c_dead": {
                     "type": "number",
                     "units": u.metric_ton/u.hectare,
-                    "about": "Carbon density of dead matter."}
+                    "about": _("Carbon density of dead matter.")}
             },
-            "about": (
+            "about": _(
                 "A table that maps each LULC code to carbon pool data for "
                 "that LULC type."),
-            "name": "carbon pools"
+            "name": _("carbon pools")
         },
         "lulc_cur_year": {
             "expression": "float(value).is_integer()",
             "type": "number",
             "units": u.year,
             "required": "do_valuation",
-            "about": (
+            "about": _(
                 "The calendar year of the current scenario depicted in the "
                 "current LULC map. Required if Run Valuation model is selected."),
-            "name": "current LULC year"
+            "name": _("current LULC year")
         },
         "lulc_fut_year": {
             "expression": "float(value).is_integer()",
             "type": "number",
             "units": u.year,
             "required": "do_valuation",
-            "about": (
+            "about": _(
                 "The calendar year of the future scenario depicted in the "
                 "future LULC map. Required if Run Valuation model is selected."),
             "name": f"future LULC year"
@@ -142,38 +142,38 @@ ARGS_SPEC = {
         "do_valuation": {
             "type": "boolean",
             "required": False,
-            "about": (
+            "about": _(
                 "Calculate net present value for the future scenario, and the "
                 "REDD scenario if provided, and report it in the final HTML "
                 "document."),
-            "name": "run valuation model"
+            "name": _("run valuation model")
         },
         "price_per_metric_ton_of_c": {
             "type": "number",
             "units": u.currency/u.metric_ton,
             "required": "do_valuation",
-            "about": (
+            "about": _(
                 "The present value of carbon. "
                 "Required if Run Valuation model is selected."),
-            "name": "price of carbon"
+            "name": _("price of carbon")
         },
         "discount_rate": {
             "type": "ratio",
             "required": "do_valuation",
-            "about": (
+            "about": _(
                 "The annual market discount rate in the price of carbon, "
                 "which reflects society's preference for immediate benefits "
                 "over future benefits. Required if Run Valuation model is "
                 "selected."),
-            "name": "annual market discount rate"
+            "name": _("annual market discount rate")
         },
         "rate_change": {
             "type": "ratio",
             "required": "do_valuation",
-            "about": (
+            "about": _(
                 "The relative annual increase of the price of carbon. "
                 "Required if Run Valuation model is selected."),
-            "name": "annual price change"
+            "name": _("annual price change")
         }
     }
 }
@@ -441,8 +441,7 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~utils.check_array_for_nodata(
-                block, nodata)], dtype=numpy.float64)
+            block[~numpy.isclose(block, nodata)], dtype=numpy.float64)
     return raster_sum
 
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -441,8 +441,8 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~numpy.isclose(
-                block, nodata)], dtype=numpy.float64, equal_nan=True)
+            block[~utils.compare_nodata_nan_support(
+                block, nodata)], dtype=numpy.float64)
     return raster_sum
 
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -441,7 +441,7 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~utils.compare_nodata_nan_support(
+            block[~utils.check_array_for_nodata(
                 block, nodata)], dtype=numpy.float64)
     return raster_sum
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -480,7 +480,8 @@ def _sum_rasters(storage_path_list, output_sum_path):
         """Sum all the arrays or nodata a pixel stack if one exists."""
         valid_mask = reduce(
             lambda x, y: x & y, [
-                _ != _CARBON_NODATA for _ in storage_arrays])
+                ~utils.array_equals_nodata(_, _CARBON_NODATA)
+                for _ in storage_arrays])
         result = numpy.empty(storage_arrays[0].shape)
         result[:] = _CARBON_NODATA
         result[valid_mask] = numpy.sum([
@@ -499,8 +500,8 @@ def _diff_rasters(storage_path_list, output_diff_path):
         result = numpy.empty(base_array.shape, dtype=numpy.float32)
         result[:] = _CARBON_NODATA
         valid_mask = (
-            (base_array != _CARBON_NODATA) &
-            (future_array != _CARBON_NODATA))
+            ~utils.array_equals_nodata(base_array, _CARBON_NODATA) &
+            ~utils.array_equals_nodata(future_array, _CARBON_NODATA))
         result[valid_mask] = (
             future_array[valid_mask] - base_array[valid_mask])
         return result
@@ -561,7 +562,7 @@ def _calculate_npv(delta_carbon_path, valuation_constant, npv_out_path):
         """Calculate the NPV given carbon storage or loss values."""
         result = numpy.empty(carbon_array.shape, dtype=numpy.float32)
         result[:] = _VALUE_NODATA
-        valid_mask = carbon_array != _CARBON_NODATA
+        valid_mask = ~utils.array_equals_nodata(carbon_array,  _CARBON_NODATA)
         result[valid_mask] = carbon_array[valid_mask] * valuation_constant
         return result
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -441,7 +441,8 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~numpy.isclose(block, nodata)], dtype=numpy.float64)
+            block[~numpy.isclose(
+                block, nodata)], dtype=numpy.float64, equal_nan=True)
     return raster_sum
 
 

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -441,7 +441,7 @@ def _accumulate_totals(raster_path):
         # the sum.  Users calculated the sum with ArcGIS zonal statistics,
         # noticed a difference and wrote to us about it on the forum.
         raster_sum += numpy.sum(
-            block[~utils.check_array_for_nodata(
+            block[~utils.array_equals_nodata(
                     block, nodata)], dtype=numpy.float64)
     return raster_sum
 

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1409,7 +1409,7 @@ def _calculate_npv(
             matrix_sum = numpy.zeros(npv.shape, dtype=numpy.float32)
             valid_pixels = numpy.ones(npv.shape, dtype=bool)
             for matrix in sequestration_matrices:
-                valid_pixels &= ~numpy.isclose(matrix, NODATA_FLOAT32_MIN)
+                valid_pixels &= ~utils.array_equals_nodata(matrix, NODATA_FLOAT32_MIN)
                 matrix_sum[valid_pixels] += matrix[valid_pixels]
 
             npv[valid_pixels] = (
@@ -1502,9 +1502,9 @@ def _calculate_accumulation_over_time(
     target_matrix[:] = NODATA_FLOAT32_MIN
 
     valid_pixels = (
-        ~numpy.isclose(annual_biomass_matrix, NODATA_FLOAT32_MIN) &
-        ~numpy.isclose(annual_soil_matrix, NODATA_FLOAT32_MIN) &
-        ~numpy.isclose(annual_litter_matrix, NODATA_FLOAT32_MIN))
+        ~utils.array_equals_nodata(annual_biomass_matrix, NODATA_FLOAT32_MIN) &
+        ~utils.array_equals_nodata(annual_soil_matrix, NODATA_FLOAT32_MIN) &
+        ~utils.array_equals_nodata(annual_litter_matrix, NODATA_FLOAT32_MIN))
 
     target_matrix[valid_pixels] = (
         (annual_biomass_matrix[valid_pixels] +
@@ -1602,7 +1602,7 @@ def _track_disturbance(
             disturbance_magnitude_matrix.shape, dtype=numpy.float32)
         disturbed_carbon_volume[:] = NODATA_FLOAT32_MIN
         disturbed_carbon_volume[
-            ~numpy.isclose(disturbance_magnitude_matrix,
+            ~utils.array_equals_nodata(disturbance_magnitude_matrix,
                            NODATA_FLOAT32_MIN)] = 0.0
 
         if year_of_disturbance_band:
@@ -1621,9 +1621,9 @@ def _track_disturbance(
 
         stock_matrix = stock_band.ReadAsArray(**block_info)
         pixels_changed_this_year = (
-            ~numpy.isclose(disturbance_magnitude_matrix, NODATA_FLOAT32_MIN) &
-            ~numpy.isclose(disturbance_magnitude_matrix, 0.0) &
-            ~numpy.isclose(stock_matrix, NODATA_FLOAT32_MIN)
+            ~utils.array_equals_nodata(disturbance_magnitude_matrix, NODATA_FLOAT32_MIN) &
+            ~utils.array_equals_nodata(disturbance_magnitude_matrix, 0.0) &
+            ~utils.array_equals_nodata(stock_matrix, NODATA_FLOAT32_MIN)
         )
 
         disturbed_carbon_volume[pixels_changed_this_year] = (
@@ -1737,10 +1737,11 @@ def _calculate_emissions(
     zero_half_life = numpy.isclose(carbon_half_life_matrix, 0.0)
 
     valid_pixels = (
-        (~numpy.isclose(carbon_disturbed_matrix, NODATA_FLOAT32_MIN)) &
+        ~utils.array_equals_nodata(
+            carbon_disturbed_matrix, NODATA_FLOAT32_MIN) &
         ~utils.array_equals_nodata(
             year_of_last_disturbance_matrix, NODATA_UINT16_MAX) &
-        (~zero_half_life))
+        ~zero_half_life)
 
     # Emissions happen immediately.
     # This means that if the transition happens in year 2020, the emissions in

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1609,7 +1609,8 @@ def _track_disturbance(
             known_transition_years_matrix = (
                 year_of_disturbance_band.ReadAsArray(**block_info))
             pixels_previously_disturbed = (
-                known_transition_years_matrix != (NODATA_UINT16_MAX))
+                ~utils.array_equals_nodata(
+                    known_transition_years_matrix, NODATA_UINT16_MAX))
             year_last_disturbed[pixels_previously_disturbed] = (
                 known_transition_years_matrix[pixels_previously_disturbed])
 
@@ -1737,7 +1738,8 @@ def _calculate_emissions(
 
     valid_pixels = (
         (~numpy.isclose(carbon_disturbed_matrix, NODATA_FLOAT32_MIN)) &
-        (year_of_last_disturbance_matrix != NODATA_UINT16_MAX) &
+        ~utils.array_equals_nodata(
+            year_of_last_disturbance_matrix, NODATA_UINT16_MAX) &
         (~zero_half_life))
 
     # Emissions happen immediately.
@@ -2018,10 +2020,12 @@ def _reclassify_accumulation_transition(
         valid_pixels = numpy.ones(landuse_transition_from_matrix.shape,
                                   dtype=bool)
         if from_nodata is not None:
-            valid_pixels &= (landuse_transition_from_matrix != from_nodata)
+            valid_pixels &= ~utils.array_equals_nodata(
+                landuse_transition_from_matrix, from_nodata)
 
         if to_nodata is not None:
-            valid_pixels &= (landuse_transition_to_matrix != to_nodata)
+            valid_pixels &= ~utils.array_equals_nodata(
+                landuse_transition_to_matrix, to_nodata)
 
         output_matrix[valid_pixels] = accumulation_rate_matrix[
             landuse_transition_from_matrix[valid_pixels],
@@ -2080,10 +2084,12 @@ def _reclassify_disturbance_magnitude(
         valid_pixels = numpy.ones(landuse_transition_from_matrix.shape,
                                   dtype=bool)
         if from_nodata is not None:
-            valid_pixels &= (landuse_transition_from_matrix != from_nodata)
+            valid_pixels &= ~utils.array_equals_nodata(
+                landuse_transition_from_matrix, from_nodata)
 
         if to_nodata is not None:
-            valid_pixels &= (landuse_transition_to_matrix != to_nodata)
+            valid_pixels &= ~utils.array_equals_nodata(
+                landuse_transition_to_matrix, to_nodata)
 
         disturbance_magnitude = disturbance_magnitude_matrix[
             landuse_transition_from_matrix[valid_pixels],

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1806,7 +1806,7 @@ def _sum_n_rasters(
             array = band.ReadAsArray(**block_info)
             valid_pixels = slice(None)
             if nodata is not None:
-                valid_pixels = ~utils.compare_nodata_nan_support(array, nodata)
+                valid_pixels = ~utils.check_array_for_nodata(array, nodata)
 
             sum_array[valid_pixels] += array[valid_pixels]
             pixels_touched[valid_pixels] = 1

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1461,8 +1461,8 @@ def _calculate_stocks_after_baseline_period(
         target_matrix[:] = NODATA_FLOAT32_MIN
 
         valid_pixels = (
-            ~utils.check_array_for_nodata(baseline_matrix, baseline_nodata) &
-            ~utils.check_array_for_nodata(accum_matrix, accum_nodata))
+            ~utils.array_equals_nodata(baseline_matrix, baseline_nodata) &
+            ~utils.array_equals_nodata(accum_matrix, accum_nodata))
 
         target_matrix[valid_pixels] = (
             baseline_matrix[valid_pixels] + (
@@ -1687,14 +1687,15 @@ def _calculate_net_sequestration(
                                                dtype=bool)
         if accumulation_nodata is not None:
             valid_accumulation_pixels &= (
-                ~utils.check_array_for_nodata(accumulation_matrix, accumulation_nodata))
+                ~utils.array_equals_nodata(
+                    accumulation_matrix, accumulation_nodata))
         target_matrix[valid_accumulation_pixels] += (
             accumulation_matrix[valid_accumulation_pixels])
 
         valid_emissions_pixels = ~numpy.isclose(emissions_matrix, 0.0)
         if emissions_nodata is not None:
             valid_emissions_pixels &= (
-                ~utils.check_array_for_nodata(emissions_matrix, emissions_nodata))
+                ~utils.array_equals_nodata(emissions_matrix, emissions_nodata))
 
         target_matrix[valid_emissions_pixels] = emissions_matrix[
             valid_emissions_pixels] * -1
@@ -1820,7 +1821,7 @@ def _sum_n_rasters(
             array = band.ReadAsArray(**block_info)
             valid_pixels = slice(None)
             if nodata is not None:
-                valid_pixels = ~utils.check_array_for_nodata(array, nodata)
+                valid_pixels = ~utils.array_equals_nodata(array, nodata)
 
             sum_array[valid_pixels] += array[valid_pixels]
             pixels_touched[valid_pixels] = 1

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1461,8 +1461,8 @@ def _calculate_stocks_after_baseline_period(
         target_matrix[:] = NODATA_FLOAT32_MIN
 
         valid_pixels = (
-            ~utils.isclose(baseline_matrix, baseline_nodata) &
-            ~utils.isclose(accum_matrix, accum_nodata))
+            ~utils.check_array_for_nodata(baseline_matrix, baseline_nodata) &
+            ~utils.check_array_for_nodata(accum_matrix, accum_nodata))
 
         target_matrix[valid_pixels] = (
             baseline_matrix[valid_pixels] + (
@@ -1687,14 +1687,14 @@ def _calculate_net_sequestration(
                                                dtype=bool)
         if accumulation_nodata is not None:
             valid_accumulation_pixels &= (
-                ~utils.isclose(accumulation_matrix, accumulation_nodata))
+                ~utils.check_array_for_nodata(accumulation_matrix, accumulation_nodata))
         target_matrix[valid_accumulation_pixels] += (
             accumulation_matrix[valid_accumulation_pixels])
 
         valid_emissions_pixels = ~numpy.isclose(emissions_matrix, 0.0)
         if emissions_nodata is not None:
             valid_emissions_pixels &= (
-                ~utils.isclose(emissions_matrix, emissions_nodata))
+                ~utils.check_array_for_nodata(emissions_matrix, emissions_nodata))
 
         target_matrix[valid_emissions_pixels] = emissions_matrix[
             valid_emissions_pixels] * -1

--- a/src/natcap/invest/coastal_blue_carbon/preprocessor.py
+++ b/src/natcap/invest/coastal_blue_carbon/preprocessor.py
@@ -224,8 +224,9 @@ def _create_transition_table(landcover_table, lulc_snapshot_list,
             # This comparison assumes that our landcover rasters are of an
             # integer type.  When int matrices, we can compare directly to
             # None.
-            valid_pixels = ((from_array != from_nodata) &
-                            (to_array != to_nodata))
+            valid_pixels = (
+                ~utils.array_equals_nodata(from_array, from_nodata) &
+                ~utils.array_equals_nodata(to_array, to_nodata))
             transition_pairs = transition_pairs.union(
                 set(zip(from_array[valid_pixels].flatten(),
                         to_array[valid_pixels].flatten())))

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -29,6 +29,9 @@ from . import MODEL_METADATA
 
 LOGGER = logging.getLogger(__name__)
 
+POLYLINE_VECTOR_MSG = _('Must be a polyline vector')
+POINT_GEOMETRY_MSG = _('Must be a point or multipoint geometry.')
+
 ARGS_SPEC = {
     "model_name": MODEL_METADATA["coastal_vulnerability"].model_title,
     "pyname": MODEL_METADATA["coastal_vulnerability"].pyname,
@@ -53,63 +56,63 @@ ARGS_SPEC = {
             **spec_utils.AOI,
             "projected": True,
             "projection_units": u.meter,
-            "about": "Map of the region over which to run the model."
+            "about": _("Map of the region over which to run the model.")
         },
         "model_resolution": {
             "type": "number",
             "expression": "value > 0",
             "units": u.meter,
-            "about": (
+            "about": _(
                 "Interval at which to space shore points along the coastline."),
-            "name": "model resolution"
+            "name": _("model resolution")
         },
         "landmass_vector_path": {
             "type": "vector",
             "fields": {},
             "geometries": spec_utils.POLYGONS,
-            "about": (
+            "about": _(
                 "Map of all landmasses in and around the region of interest. "
                 "It is not recommended to clip this landmass to the AOI "
                 "polygon because some functions in the model require "
                 "searching for landmasses around shore points up to the "
                 "distance defined in Maximum Fetch Distance, which likely "
                 "extends beyond the AOI polygon."),
-            "name": "landmasses"
+            "name": _("landmasses")
         },
         "wwiii_vector_path": {
             "type": "vector",
             "fields": {
                 "rei_pct[SECTOR]": {
                     "type": "percent",
-                    "about": (
+                    "about": _(
                         "Proportion of the highest 10% of wind speeds in "
                         "the record of interest that blow in the direction of "
                         "each sector.")},
                 "rei_v[SECTOR]": {
                     "type": "number",
                     "units": u.meter/u.second,
-                    "about": (
+                    "about": _(
                         "Average of the highest 10% of wind speeds that blow "
                         "in the direction of each sector.")},
                 "wavppct[SECTOR]": {
                     "type": "percent",
-                    "about": (
+                    "about": _(
                         "Proportion of the highest 10% of wave power values "
                         "on record that are in each sector.")},
                 "wavp_[SECTOR]": {
                     "type": "number",
                     "units": u.kilowatt/u.meter,
-                    "about": (
+                    "about": _(
                         "Average of the highest 10% of wave power values on "
                         "record in the direction of each sector.")},
                 "v10pct_[SECTOR]": {
                     "type": "percent",
-                    "about": (
+                    "about": _(
                         "Average of the highest 10% of wind speeds that are "
                         "centered on each main sector direction X.")}
             },
             "geometries": spec_utils.POINT,
-            "about": (
+            "about": _(
                 "Map of gridded wind and wave data that represent storm "
                 "conditions. This global dataset is provided with the InVEST "
                 "sample data. There are 80 required columns; each of the 5 "
@@ -117,18 +120,18 @@ ARGS_SPEC = {
                 "compass: "
                 "[0,22,45,67,90,112,135,157,180,202,225,247,270,292,315,337]. "
                 "For example: REI_PCT0, V10PCT_90."),
-            "name": "WaveWatchIII"
+            "name": _("WaveWatchIII")
         },
         "max_fetch_distance": {
             "type": "number",
             "units": u.meter,
             "expression": "value > 0",
-            "about": (
+            "about": _(
                 "Maximum distance in meters to extend rays from shore points. "
                 "Points with rays equal to this distance accumulate ocean- "
                 "driven wave exposure along those rays and local-wind-driven "
                 "wave exposure along the shorter rays."),
-            "name": "maximum fetch distance"
+            "name": _("maximum fetch distance")
         },
         "bathymetry_raster_path": {
             "type": "raster",
@@ -136,22 +139,22 @@ ARGS_SPEC = {
                 "type": "number",
                 "units": u.meter
             }},
-            "about": (
+            "about": _(
                 "Map of bathymetry (ocean depth). Bathymetry values "
                 "should be negative, and any positive values will be ignored. This "
                 "should cover the area extending beyond the AOI to the "
                 "maximum fetch distance."),
 
-            "name": "Bathymetry"
+            "name": _("Bathymetry")
         },
         "shelf_contour_vector_path": {
             "type": "vector",
             "fields": {},
             "geometries": spec_utils.LINES,
-            "about": (
+            "about": _(
                 "Map of the edges of the continental shelf or other locally "
                 "relevant bathymetry contour."),
-            "name": "continental shelf contour"
+            "name": _("continental shelf contour")
         },
         "dem_path": {
             **spec_utils.DEM,
@@ -159,7 +162,7 @@ ARGS_SPEC = {
                 "type": "number",
                 "units": u.none  # any unit of length is ok
             }},
-            "about": (
+            "about": _(
                 "Map of elevation above sea level on land. This should cover "
                 "the area extending beyond the AOI by at least the elevation "
                 "averaging radius. Elevation may be measured in any unit.")
@@ -168,23 +171,23 @@ ARGS_SPEC = {
             "type": "number",
             "units": u.meter,
             "expression": "value > 0",
-            "about": (
+            "about": _(
                 "A radius around each shore point within which to average the "
                 "elevation values in the DEM raster."),
-            "name": "elevation averaging radius"
+            "name": _("elevation averaging radius")
         },
         "habitat_table_path": {
             "type": "csv",
             "columns": {
                 "id": {
                     "type": "freestyle_string",
-                    "about": "Unique name for the habitat. No spaces allowed."},
+                    "about": _("Unique name for the habitat. No spaces allowed.")},
                 "path": {
                     "type": {"vector", "raster"},
                     "fields": {},
                     "geometries": {"POLYGON", "MULTIPOLYGON"},
                     "bands": {1: {"type": "number", "units": u.none}},
-                    "about": (
+                    "about": _(
                         "Map of area(s) where the habitat is present. "
                         "If raster, presence of the habitat can be "
                         "represented by any value and absence of the habitat "
@@ -192,13 +195,13 @@ ARGS_SPEC = {
                 "rank": {
                     "type": "option_string",
                     "options": {
-                        "1": "very high protection",
-                        "2": "high protection",
-                        "3": "moderate protection",
-                        "4": "low protection",
-                        "5": "very low protection"
+                        "1": {"description": _("very high protection")},
+                        "2": {"description": _("high protection")},
+                        "3": {"description": _("moderate protection")},
+                        "4": {"description": _("low protection")},
+                        "5": {"description": _("very low protection")}
                     },
-                    "about": (
+                    "about": _(
                         "Relative amount of coastline protection this habitat "
                         "provides.")
                 },
@@ -206,14 +209,14 @@ ARGS_SPEC = {
                     "type": "number",
                     "units": u.meter,
                     "expression": "value >= 0",
-                    "about": (
+                    "about": _(
                         "The distance beyond which this habitat will provide "
                         "no protection to the coastline.")
                 },
             },
-            "about": (
+            "about": _(
                 "Table that specifies spatial habitat data and parameters."),
-            "name": "habitats table"
+            "name": _("habitats table")
         },
         "geomorphology_vector_path": {
             "type": "vector",
@@ -221,35 +224,35 @@ ARGS_SPEC = {
                 "rank": {
                     "type": "option_string",
                     "options": {
-                        "1": "very low exposure",
-                        "2": "low exposure",
-                        "3": "moderate exposure",
-                        "4": "high exposure",
-                        "5": "very high exposure"
+                        "1": {"description": _("very low exposure")},
+                        "2": {"description": _("low exposure")},
+                        "3": {"description": _("moderate exposure")},
+                        "4": {"description": _("high exposure")},
+                        "5": {"description": _("very high exposure")}
                     },
-                    "about": "Relative exposure of the segment of coastline."
+                    "about": _("Relative exposure of the segment of coastline.")
                 }
             },
             "geometries": spec_utils.LINES,
             "required": False,
-            "about": "Map of relative exposure of each segment of coastline.",
-            "name": "geomorphology"
+            "about": _("Map of relative exposure of each segment of coastline."),
+            "name": _("geomorphology")
         },
         "geomorphology_fill_value": {
             "type": "option_string",
             "options": {
-                "1": "very low exposure",
-                "2": "low exposure",
-                "3": "moderate exposure",
-                "4": "high exposure",
-                "5": "very high exposure"
+                "1": {"display_name": _("1: very low exposure")},
+                "2": {"display_name": _("2: low exposure")},
+                "3": {"display_name": _("3: moderate exposure")},
+                "4": {"display_name": _("4: high exposure")},
+                "5": {"display_name": _("5: very high exposure")}
             },
             "required": "geomorphology_vector_path",
-            "about": (
+            "about": _(
                 "Exposure rank to assign to any shore points that are not "
                 "near to any segment in the geomorphology vector. "
                 "Required if a Geomorphology vector is provided."),
-            "name": "geomorphology fill value"
+            "name": _("geomorphology fill value")
         },
         "population_raster_path": {
             "type": "raster",
@@ -257,25 +260,25 @@ ARGS_SPEC = {
                 1: {"type": "number", "units": u.none}
             },
             "required": False,
-            "about": "Map of total human population on each pixel.",
-            "name": "human population"
+            "about": _("Map of total human population on each pixel."),
+            "name": _("human population")
         },
         "population_radius": {
             "type": "number",
             "units": u.meter,
             "expression": "value > 0",
             "required": "population_raster_path",
-            "about": (
+            "about": _(
                 "The radius around each shore point within which to compute "
                 "the average population density. "
                 "Required if a Human Population map is provided."),
-            "name": "population search radius"
+            "name": _("population search radius")
         },
         "slr_vector_path": {
             "type": "vector",
             "fields": {
                 "[SLR_FIELD]": {
-                    "about": (
+                    "about": _(
                         "Sea level rise rate or amount. This field name must "
                         "be chosen as the Sea Level Rise Field."),
                     "type": "number",
@@ -284,20 +287,20 @@ ARGS_SPEC = {
             },
             "geometries": spec_utils.POINT,
             "required": False,
-            "about": (
+            "about": _(
                 "Map of sea level rise rates or amounts. May be any sea level "
                 "rise metric of interest, such as rate, or net rise/fall."),
-            "name": "sea level rise"
+            "name": _("sea level rise")
         },
         "slr_field": {
             "type": "option_string",
             "options": {},
             "required": "slr_vector_path",
-            "about": (
+            "about": _(
                 "Name of the field in the sea level rise vector which "
                 "contains the sea level rise metric of interest. "
                 "Required if a Sea Level Rise vector is provided."),
-            "name": "sea level rise field"
+            "name": _("sea level rise field")
         }
     }
 }
@@ -1397,8 +1400,7 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(
-                values, bathy_nodata)
+            valid_mask = ~numpy.isclose(values, bathy_nodata)
         if numpy.any(valid_mask):
             # take mean of valids and move on
             value = numpy.mean(values[valid_mask])
@@ -1765,7 +1767,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(depth_array, nodata)
+        valid_mask = ~numpy.isclose(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2843,7 +2845,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~utils.check_array_for_nodata(array, nodata)
+            kernel_mask &= ~numpy.isclose(array, nodata)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 
@@ -3139,8 +3141,7 @@ def validate(args, limit_to=None):
                 ogr.wkbLineStringZM, ogr.wkbMultiLineStringZM,
                 ogr.wkbLineString25D, ogr.wkbMultiLineString25D]:
             validation_warnings.append(
-                (['shelf_contour_vector_path'],
-                 'Must be a polyline vector'))
+                (['shelf_contour_vector_path'], POLYLINE_VECTOR_MSG))
 
     if ('slr_vector_path' in sufficient_keys and
             'slr_vector_path' not in invalid_keys):
@@ -3152,8 +3153,8 @@ def validate(args, limit_to=None):
                 ogr.wkbPointM, ogr.wkbMultiPointM,
                 ogr.wkbPointZM, ogr.wkbMultiPointZM,
                 ogr.wkbPoint25D, ogr.wkbMultiPoint25D]:
-            validation_warnings.append((['slr_vector_path'],
-                                        f'Must be a point or multipoint geometry.'))
+            validation_warnings.append(
+                (['slr_vector_path'], POINT_GEOMETRY_MSG))
 
     if ('slr_vector_path' not in invalid_keys and
             'slr_field' not in invalid_keys and

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1400,7 +1400,7 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(values, bathy_nodata)
+            valid_mask = ~utils.array_equals_nodata(values, bathy_nodata)
         if numpy.any(valid_mask):
             # take mean of valids and move on
             value = numpy.mean(values[valid_mask])
@@ -1767,7 +1767,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(depth_array, nodata)
+        valid_mask = ~utils.array_equals_nodata(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2845,7 +2845,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~utils.check_array_for_nodata(array, nodata)
+            kernel_mask &= ~utils.array_equals_nodata(array, nodata)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1397,7 +1397,7 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~utils.compare_nodata_nan_support(
+            valid_mask = ~utils.check_array_for_nodata(
                 values, bathy_nodata)
         if numpy.any(valid_mask):
             # take mean of valids and move on
@@ -1765,7 +1765,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~utils.compare_nodata_nan_support(depth_array, nodata)
+        valid_mask = ~utils.check_array_for_nodata(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2843,7 +2843,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~utils.compare_nodata_nan_support(array, nodata)
+            kernel_mask &= ~utils.check_array_for_nodata(array, nodata)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1400,7 +1400,7 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~numpy.isclose(values, bathy_nodata)
+            valid_mask = ~utils.check_array_for_nodata(values, bathy_nodata)
         if numpy.any(valid_mask):
             # take mean of valids and move on
             value = numpy.mean(values[valid_mask])
@@ -1767,7 +1767,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~numpy.isclose(depth_array, nodata)
+        valid_mask = ~utils.check_array_for_nodata(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2845,7 +2845,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~numpy.isclose(array, nodata)
+            kernel_mask &= ~utils.check_array_for_nodata(array, nodata)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1360,8 +1360,7 @@ def extract_bathymetry_along_ray(
                 'bathymetry input fully cover the fetch ray area?'
                 % (value, {'xoff': ix, 'yoff': iy,
                            'win_xsize': win_size, 'win_ysize': win_size}))
-        if bathy_nodata is None or not math.isclose(
-                value[0][0], bathy_nodata, equal_nan=True):
+        if bathy_nodata is None or not math.isclose(value[0][0], bathy_nodata):
             bathy_values.append(value)
 
     # Gaps between shoreline and bathymetry input datasets could result in no
@@ -1398,7 +1397,8 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~numpy.isclose(values, bathy_nodata, equal_nan=True)
+            valid_mask = ~utils.compare_nodata_nan_support(
+                values, bathy_nodata)
         if numpy.any(valid_mask):
             # take mean of valids and move on
             value = numpy.mean(values[valid_mask])
@@ -1765,7 +1765,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~numpy.isclose(depth_array, nodata, equal_nan=True)
+        valid_mask = ~utils.compare_nodata_nan_support(depth_array, nodata)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2843,7 +2843,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~numpy.isclose(array, nodata, equal_nan=True)
+            kernel_mask &= ~utils.compare_nodata_nan_support(array, nodata)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1360,7 +1360,8 @@ def extract_bathymetry_along_ray(
                 'bathymetry input fully cover the fetch ray area?'
                 % (value, {'xoff': ix, 'yoff': iy,
                            'win_xsize': win_size, 'win_ysize': win_size}))
-        if bathy_nodata is None or not math.isclose(value[0][0], bathy_nodata):
+        if bathy_nodata is None or not math.isclose(
+                value[0][0], bathy_nodata, equal_nan=True):
             bathy_values.append(value)
 
     # Gaps between shoreline and bathymetry input datasets could result in no
@@ -1397,7 +1398,7 @@ def extract_bathymetry_along_ray(
         # if nodata value is undefined, all pixels are valid
         valid_mask = slice(None)
         if bathy_nodata is not None:
-            valid_mask = ~numpy.isclose(values, bathy_nodata)
+            valid_mask = ~numpy.isclose(values, bathy_nodata, equal_nan=True)
         if numpy.any(valid_mask):
             # take mean of valids and move on
             value = numpy.mean(values[valid_mask])
@@ -1764,7 +1765,7 @@ def zero_negative_values(depth_array, nodata):
     """Convert negative values to zero for relief."""
     result_array = numpy.empty_like(depth_array)
     if nodata is not None:
-        valid_mask = ~numpy.isclose(depth_array, nodata)
+        valid_mask = ~numpy.isclose(depth_array, nodata, equal_nan=True)
         result_array[:] = nodata
         result_array[valid_mask] = 0
     else:
@@ -2842,7 +2843,7 @@ def _aggregate_raster_values_in_radius(
             xoff=pixel_x, yoff=pixel_y, win_xsize=win_xsize,
             win_ysize=win_ysize)
         if nodata is not None:
-            kernel_mask &= ~numpy.isclose(array, nodata)
+            kernel_mask &= ~numpy.isclose(array, nodata, equal_nan=True)
 
         result[shore_id] = aggregation_op(array, kernel_mask)
 

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -633,10 +633,10 @@ def calculate_crop_production(lulc_path, yield_path, crop_lucode,
 
         valid_mask = numpy.full(lulc_array.shape, True)
         if lulc_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(
+            valid_mask &= ~utils.check_array_for_nodata(
                 lulc_array, lulc_nodata)
         if yield_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(
+            valid_mask &= ~utils.check_array_for_nodata(
                 yield_array, yield_nodata)
         result[valid_mask] = 0
 
@@ -668,7 +668,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
@@ -694,7 +694,7 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
@@ -770,7 +770,7 @@ def tabulate_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~utils.compare_nodata_nan_support(
+                    valid_mask = ~utils.check_array_for_nodata(
                         yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0))
@@ -790,7 +790,7 @@ def tabulate_results(
                         (yield_percentile_raster_path, 1)):
                     # _NODATA_YIELD will always have a value (defined above)
                     yield_sum += numpy.sum(
-                        yield_block[~utils.compare_nodata_nan_support(
+                        yield_block[~utils.check_array_for_nodata(
                             yield_block, _NODATA_YIELD)])
                 production_lookup[yield_percentile_id] = yield_sum
                 result_table.write(",%f" % yield_sum)
@@ -817,7 +817,7 @@ def tabulate_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~utils.compare_nodata_nan_support(
+                    ~utils.check_array_for_nodata(
                         band_values, landcover_nodata))
             else:
                 total_area += band_values.size

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -633,11 +633,11 @@ def calculate_crop_production(lulc_path, yield_path, crop_lucode,
 
         valid_mask = numpy.full(lulc_array.shape, True)
         if lulc_nodata is not None:
-            valid_mask &= ~numpy.isclose(
-                lulc_array, lulc_nodata, equal_nan=True)
+            valid_mask &= ~utils.compare_nodata_nan_support(
+                lulc_array, lulc_nodata)
         if yield_nodata is not None:
-            valid_mask &= ~numpy.isclose(
-                yield_array, yield_nodata, equal_nan=True)
+            valid_mask &= ~utils.compare_nodata_nan_support(
+                yield_array, yield_nodata)
         result[valid_mask] = 0
 
         lulc_mask = lulc_array == crop_lucode
@@ -668,8 +668,8 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~numpy.isclose(
-            observed_yield_array, observed_yield_nodata, equal_nan=True)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
 
@@ -694,8 +694,8 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~numpy.isclose(
-            lulc_array, landcover_nodata, equal_nan=True)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
         result[:] = 0
@@ -770,8 +770,8 @@ def tabulate_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~numpy.isclose(
-                        yield_block, observed_yield_nodata, equal_nan=True)
+                    valid_mask = ~utils.compare_nodata_nan_support(
+                        yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0))
                 yield_sum += numpy.sum(yield_block[valid_mask])
@@ -790,8 +790,8 @@ def tabulate_results(
                         (yield_percentile_raster_path, 1)):
                     # _NODATA_YIELD will always have a value (defined above)
                     yield_sum += numpy.sum(
-                        yield_block[~numpy.isclose(
-                            yield_block, _NODATA_YIELD, equal_nan=True)])
+                        yield_block[~utils.compare_nodata_nan_support(
+                            yield_block, _NODATA_YIELD)])
                 production_lookup[yield_percentile_id] = yield_sum
                 result_table.write(",%f" % yield_sum)
 
@@ -817,8 +817,8 @@ def tabulate_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~numpy.isclose(
-                        band_values, landcover_nodata, equal_nan=True))
+                    ~utils.compare_nodata_nan_support(
+                        band_values, landcover_nodata))
             else:
                 total_area += band_values.size
         result_table.write(

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -636,11 +636,9 @@ def calculate_crop_production(lulc_path, yield_path, crop_lucode,
 
         valid_mask = numpy.full(lulc_array.shape, True)
         if lulc_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(
-                lulc_array, lulc_nodata)
+            valid_mask &= ~utils.array_equals_nodata(lulc_array, lulc_nodata)
         if yield_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(
-                yield_array, yield_nodata)
+            valid_mask &= ~utils.array_equals_nodata(yield_array, yield_nodata)
         result[valid_mask] = 0
 
         lulc_mask = lulc_array == crop_lucode
@@ -671,7 +669,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(
+        valid_mask = ~utils.array_equals_nodata(
             observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
@@ -697,8 +695,7 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~utils.check_array_for_nodata(
-            lulc_array, landcover_nodata)
+        valid_mask = ~utils.array_equals_nodata(lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
         result[:] = 0
@@ -773,7 +770,7 @@ def tabulate_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~utils.check_array_for_nodata(
+                    valid_mask = ~utils.array_equals_nodata(
                         yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0))
@@ -793,7 +790,7 @@ def tabulate_results(
                         (yield_percentile_raster_path, 1)):
                     # _NODATA_YIELD will always have a value (defined above)
                     yield_sum += numpy.sum(
-                        yield_block[~utils.check_array_for_nodata(
+                        yield_block[~utils.array_equals_nodata(
                             yield_block, _NODATA_YIELD)])
                 production_lookup[yield_percentile_id] = yield_sum
                 result_table.write(",%f" % yield_sum)
@@ -820,8 +817,7 @@ def tabulate_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~utils.check_array_for_nodata(
-                        band_values, landcover_nodata))
+                    ~utils.array_equals_nodata(band_values, landcover_nodata))
             else:
                 total_area += band_values.size
         result_table.write(

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -633,9 +633,11 @@ def calculate_crop_production(lulc_path, yield_path, crop_lucode,
 
         valid_mask = numpy.full(lulc_array.shape, True)
         if lulc_nodata is not None:
-            valid_mask &= ~numpy.isclose(lulc_array, lulc_nodata)
+            valid_mask &= ~numpy.isclose(
+                lulc_array, lulc_nodata, equal_nan=True)
         if yield_nodata is not None:
-            valid_mask &= ~numpy.isclose(yield_array, yield_nodata)
+            valid_mask &= ~numpy.isclose(
+                yield_array, yield_nodata, equal_nan=True)
         result[valid_mask] = 0
 
         lulc_mask = lulc_array == crop_lucode
@@ -667,7 +669,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
         valid_mask = ~numpy.isclose(
-            observed_yield_array, observed_yield_nodata)
+            observed_yield_array, observed_yield_nodata, equal_nan=True)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
 
@@ -692,7 +694,8 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~numpy.isclose(lulc_array, landcover_nodata)
+        valid_mask = ~numpy.isclose(
+            lulc_array, landcover_nodata, equal_nan=True)
         result[valid_mask] = 0
     else:
         result[:] = 0
@@ -768,7 +771,7 @@ def tabulate_results(
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
                     valid_mask = ~numpy.isclose(
-                        yield_block, observed_yield_nodata)
+                        yield_block, observed_yield_nodata, equal_nan=True)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0))
                 yield_sum += numpy.sum(yield_block[valid_mask])
@@ -788,7 +791,7 @@ def tabulate_results(
                     # _NODATA_YIELD will always have a value (defined above)
                     yield_sum += numpy.sum(
                         yield_block[~numpy.isclose(
-                            yield_block, _NODATA_YIELD)])
+                            yield_block, _NODATA_YIELD, equal_nan=True)])
                 production_lookup[yield_percentile_id] = yield_sum
                 result_table.write(",%f" % yield_sum)
 
@@ -814,7 +817,8 @@ def tabulate_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~numpy.isclose(band_values, landcover_nodata))
+                    ~numpy.isclose(
+                        band_values, landcover_nodata, equal_nan=True))
             else:
                 total_area += band_values.size
         result_table.write(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -725,7 +725,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~numpy.isclose(
+        valid_mask = ~utils.compare_nodata_nan_support(
             observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
@@ -751,7 +751,8 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~numpy.isclose(lulc_array, landcover_nodata)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
         result[:] = 0
@@ -814,7 +815,7 @@ def tabulate_regression_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~numpy.isclose(
+                    valid_mask = ~utils.compare_nodata_nan_support(
                         yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0.0))
@@ -832,7 +833,8 @@ def tabulate_regression_results(
                     (crop_production_raster_path, 1)):
                 yield_sum += numpy.sum(
                     # _NODATA_YIELD will always have a value (defined above)
-                    yield_block[~numpy.isclose(yield_block, _NODATA_YIELD)])
+                    yield_block[~utils.compare_nodata_nan_support(
+                        yield_block, _NODATA_YIELD)])
             production_lookup['modeled'] = yield_sum
             result_table.write(",%f" % yield_sum)
 
@@ -857,7 +859,8 @@ def tabulate_regression_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~numpy.isclose(band_values, landcover_nodata))
+                    ~utils.compare_nodata_nan_support(
+                        band_values, landcover_nodata))
             else:
                 total_area += band_values.size
         result_table.write(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -734,7 +734,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(
+        valid_mask = ~utils.array_equals_nodata(
             observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
@@ -760,8 +760,7 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~utils.check_array_for_nodata(
-            lulc_array, landcover_nodata)
+        valid_mask = ~utils.array_equals_nodata(lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
         result[:] = 0
@@ -824,7 +823,7 @@ def tabulate_regression_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~utils.check_array_for_nodata(
+                    valid_mask = ~utils.array_equals_nodata(
                         yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0.0))
@@ -842,7 +841,7 @@ def tabulate_regression_results(
                     (crop_production_raster_path, 1)):
                 yield_sum += numpy.sum(
                     # _NODATA_YIELD will always have a value (defined above)
-                    yield_block[~utils.check_array_for_nodata(
+                    yield_block[~utils.array_equals_nodata(
                         yield_block, _NODATA_YIELD)])
             production_lookup['modeled'] = yield_sum
             result_table.write(",%f" % yield_sum)
@@ -868,8 +867,7 @@ def tabulate_regression_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~utils.check_array_for_nodata(
-                        band_values, landcover_nodata))
+                    ~utils.array_equals_nodata(band_values, landcover_nodata))
             else:
                 total_area += band_values.size
         result_table.write(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -694,8 +694,9 @@ def _x_yield_op(
     result = numpy.empty(b_x.shape, dtype=numpy.float32)
     result[:] = _NODATA_YIELD
     valid_mask = (
-        (y_max != _NODATA_YIELD) &
-        (b_x != _NODATA_YIELD) & (c_x != _NODATA_YIELD) &
+        ~utils.array_equals_nodata(y_max,  _NODATA_YIELD) &
+        ~utils.array_equals_nodata(b_x, _NODATA_YIELD) &
+        ~utils.array_equals_nodata(c_x, _NODATA_YIELD) &
         (lulc_array == crop_lucode))
     result[valid_mask] = pixel_area_ha * y_max[valid_mask] * (
         1 - b_x[valid_mask] * numpy.exp(
@@ -709,8 +710,9 @@ def _min_op(y_n, y_p, y_k):
     result = numpy.empty(y_n.shape, dtype=numpy.float32)
     result[:] = _NODATA_YIELD
     valid_mask = (
-        (y_n != _NODATA_YIELD) & (y_k != _NODATA_YIELD) &
-        (y_p != _NODATA_YIELD))
+        ~utils.array_equals_nodata(y_n, _NODATA_YIELD) &
+        ~utils.array_equals_nodata(y_k, _NODATA_YIELD) &
+        ~utils.array_equals_nodata(y_p, _NODATA_YIELD))
     result[valid_mask] = (
         numpy.min(
             [y_n[valid_mask], y_k[valid_mask], y_p[valid_mask]],

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -725,7 +725,7 @@ def _zero_observed_yield_op(observed_yield_array, observed_yield_nodata):
     result[:] = 0
     valid_mask = slice(None)
     if observed_yield_nodata is not None:
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             observed_yield_array, observed_yield_nodata)
     result[valid_mask] = observed_yield_array[valid_mask]
     return result
@@ -751,7 +751,7 @@ def _mask_observed_yield_op(
     result = numpy.empty(lulc_array.shape, dtype=numpy.float32)
     if landcover_nodata is not None:
         result[:] = observed_yield_nodata
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             lulc_array, landcover_nodata)
         result[valid_mask] = 0
     else:
@@ -815,7 +815,7 @@ def tabulate_regression_results(
                 # if nodata value undefined, assume all pixels are valid
                 valid_mask = slice(None)
                 if observed_yield_nodata is not None:
-                    valid_mask = ~utils.compare_nodata_nan_support(
+                    valid_mask = ~utils.check_array_for_nodata(
                         yield_block, observed_yield_nodata)
                 production_pixel_count += numpy.count_nonzero(
                     valid_mask & (yield_block > 0.0))
@@ -833,7 +833,7 @@ def tabulate_regression_results(
                     (crop_production_raster_path, 1)):
                 yield_sum += numpy.sum(
                     # _NODATA_YIELD will always have a value (defined above)
-                    yield_block[~utils.compare_nodata_nan_support(
+                    yield_block[~utils.check_array_for_nodata(
                         yield_block, _NODATA_YIELD)])
             production_lookup['modeled'] = yield_sum
             result_table.write(",%f" % yield_sum)
@@ -859,7 +859,7 @@ def tabulate_regression_results(
                 (landcover_raster_path, 1)):
             if landcover_nodata is not None:
                 total_area += numpy.count_nonzero(
-                    ~utils.compare_nodata_nan_support(
+                    ~utils.check_array_for_nodata(
                         band_values, landcover_nodata))
             else:
                 total_area += band_values.size

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -316,8 +316,7 @@ def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
 
     valid_pixels = slice(None)
     if src_nodata is not None:
-        valid_pixels = ~utils.check_array_for_nodata(
-            flow_accum, src_nodata)
+        valid_pixels = ~utils.array_equals_nodata(flow_accum, src_nodata)
 
     over_threshold = flow_accum > threshold
     out_matrix[valid_pixels & over_threshold] = 1

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -317,7 +317,8 @@ def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
 
     valid_pixels = slice(None)
     if src_nodata is not None:
-        valid_pixels = ~numpy.isclose(flow_accum, src_nodata)
+        valid_pixels = ~utils.compare_nodata_nan_support(
+            flow_accum, src_nodata)
 
     over_threshold = flow_accum > threshold
     out_matrix[valid_pixels & over_threshold] = 1

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -317,7 +317,7 @@ def _threshold_streams(flow_accum, src_nodata, out_nodata, threshold):
 
     valid_pixels = slice(None)
     if src_nodata is not None:
-        valid_pixels = ~utils.compare_nodata_nan_support(
+        valid_pixels = ~utils.check_array_for_nodata(
             flow_accum, src_nodata)
 
     over_threshold = flow_accum > threshold

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -696,11 +696,10 @@ def _map_distance_from_tropical_forest_edge(
         # where LULC has nodata, overwrite edge distance with nodata value
         lulc_block = lulc_band.ReadAsArray(**offset_dict)
         distance_block = edge_distance_band.ReadAsArray(**offset_dict)
-        valid_mask = ~utils.array_equals_nodata(lulc_block, lulc_nodata)
-        masked_distance_block[:] = lulc_nodata
-        masked_distance_block[valid_mask] = distance_block[valid_mask]
+        nodata_mask = utils.array_equals_nodata(lulc_block, lulc_nodata)
+        distance_block[nodata_mask] = lulc_nodata
         edge_distance_band.WriteArray(
-            masked_distance_block,
+            distance_block,
             xoff=offset_dict['xoff'],
             yoff=offset_dict['yoff'])
 

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -462,7 +462,7 @@ def combine_carbon_maps(*carbon_maps):
     nodata_mask = numpy.empty(carbon_maps[0].shape, dtype=bool)
     nodata_mask[:] = True
     for carbon_map in carbon_maps:
-        valid_mask = carbon_map != NODATA_VALUE
+        valid_mask = ~utils.array_equals_nodata(carbon_map, NODATA_VALUE)
         nodata_mask &= ~valid_mask
         result[valid_mask] += carbon_map[valid_mask]
     result[nodata_mask] = NODATA_VALUE
@@ -696,8 +696,9 @@ def _map_distance_from_tropical_forest_edge(
         # where LULC has nodata, overwrite edge distance with nodata value
         lulc_block = lulc_band.ReadAsArray(**offset_dict)
         distance_block = edge_distance_band.ReadAsArray(**offset_dict)
-        masked_distance_block = numpy.where(
-            lulc_block == lulc_nodata, NODATA_VALUE, distance_block)
+        valid_mask = ~utils.array_equals_nodata(lulc_block, lulc_nodata)
+        masked_distance_block[:] = lulc_nodata
+        masked_distance_block[valid_mask] = distance_block[valid_mask]
         edge_distance_band.WriteArray(
             masked_distance_block,
             xoff=offset_dict['xoff'],

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -503,7 +503,7 @@ def _primary_veg_mask_op(lulc_array, globio_nodata, primary_veg_mask_nodata):
     result[:] = primary_veg_mask_nodata
     valid_mask = slice(None)
     if globio_nodata is not None:
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             lulc_array, globio_nodata)
     result[valid_mask] = lulc_array[valid_mask] == 1
     return result
@@ -567,7 +567,7 @@ def _msa_f_calculation(
                 less_than[1])
 
         if msa_nodata is not None:
-            nodata_mask = utils.compare_nodata_nan_support(
+            nodata_mask = utils.check_array_for_nodata(
                 primary_veg_smooth, primary_veg_mask_nodata)
             msa_f[nodata_mask] = msa_nodata
 
@@ -636,7 +636,7 @@ def _msa_i_calculation(
             lulc_array, msa_nodata, dtype=numpy.float32)
         msa_i_other = numpy.full_like(
             lulc_array, msa_nodata, dtype=numpy.float32)
-        nodata_mask = utils.compare_nodata_nan_support(lulc_array, lulc_nodata)
+        nodata_mask = utils.check_array_for_nodata(lulc_array, lulc_nodata)
 
         if primary_greater_than:
             msa_i_primary[distance_to_infrastructure > primary_greater_than[0]] = (
@@ -693,7 +693,7 @@ def _msa_calculation(
         valid_mask = numpy.ones(msa_f.shape, dtype=bool)
         for msa_array, nodata_val in zip([msa_f, msa_lu, msa_i], nodata_array):
             if nodata_val is not None:
-                valid_mask &= ~utils.compare_nodata_nan_support(
+                valid_mask &= ~utils.check_array_for_nodata(
                     msa_array, nodata_val)
         result[valid_mask] = (
             msa_f[valid_mask] * msa_lu[valid_mask] * msa_i[valid_mask])
@@ -1083,7 +1083,7 @@ def _collapse_infrastructure_layers(
             infrastructure_mask |= infrastructure_array_list[index] > 0
             if infrastructure_nodata_list[index] is not None:
                 # update nodata mask: intersection with this layer
-                nodata_mask &= utils.compare_nodata_nan_support(
+                nodata_mask &= utils.check_array_for_nodata(
                     infrastructure_array_list[index],
                     infrastructure_nodata_list[index])
             # if nodata is None, every pixel in this layer has data,

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -503,7 +503,8 @@ def _primary_veg_mask_op(lulc_array, globio_nodata, primary_veg_mask_nodata):
     result[:] = primary_veg_mask_nodata
     valid_mask = slice(None)
     if globio_nodata is not None:
-        valid_mask = ~numpy.isclose(lulc_array, globio_nodata)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            lulc_array, globio_nodata)
     result[valid_mask] = lulc_array[valid_mask] == 1
     return result
 
@@ -566,7 +567,7 @@ def _msa_f_calculation(
                 less_than[1])
 
         if msa_nodata is not None:
-            nodata_mask = numpy.isclose(
+            nodata_mask = utils.compare_nodata_nan_support(
                 primary_veg_smooth, primary_veg_mask_nodata)
             msa_f[nodata_mask] = msa_nodata
 
@@ -635,7 +636,7 @@ def _msa_i_calculation(
             lulc_array, msa_nodata, dtype=numpy.float32)
         msa_i_other = numpy.full_like(
             lulc_array, msa_nodata, dtype=numpy.float32)
-        nodata_mask = numpy.isclose(lulc_array, lulc_nodata)
+        nodata_mask = utils.compare_nodata_nan_support(lulc_array, lulc_nodata)
 
         if primary_greater_than:
             msa_i_primary[distance_to_infrastructure > primary_greater_than[0]] = (
@@ -692,7 +693,8 @@ def _msa_calculation(
         valid_mask = numpy.ones(msa_f.shape, dtype=bool)
         for msa_array, nodata_val in zip([msa_f, msa_lu, msa_i], nodata_array):
             if nodata_val is not None:
-                valid_mask &= ~numpy.isclose(msa_array, nodata_val)
+                valid_mask &= ~utils.compare_nodata_nan_support(
+                    msa_array, nodata_val)
         result[valid_mask] = (
             msa_f[valid_mask] * msa_lu[valid_mask] * msa_i[valid_mask])
         return result
@@ -1081,8 +1083,9 @@ def _collapse_infrastructure_layers(
             infrastructure_mask |= infrastructure_array_list[index] > 0
             if infrastructure_nodata_list[index] is not None:
                 # update nodata mask: intersection with this layer
-                nodata_mask &= numpy.isclose(infrastructure_array_list[index],
-                                             infrastructure_nodata_list[index])
+                nodata_mask &= utils.compare_nodata_nan_support(
+                    infrastructure_array_list[index],
+                    infrastructure_nodata_list[index])
             # if nodata is None, every pixel in this layer has data,
             # so the nodata_mask should be all False
             else:

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -520,7 +520,8 @@ def _ffqi_op(forest_areas_array, smoothed_forest_areas, forest_areas_nodata):
     result = numpy.empty_like(forest_areas_array, dtype=numpy.float32)
     result[:] = forest_areas_nodata
     # forest_areas_array and _nodata are integer types and not user-defined
-    valid_mask = forest_areas_array != forest_areas_nodata
+    valid_mask = ~utils.array_equals_nodata(
+        forest_areas_array, forest_areas_nodata)
     result[valid_mask] = (
         forest_areas_array[valid_mask] * smoothed_forest_areas[valid_mask])
     return result
@@ -943,7 +944,7 @@ def _calculate_globio_lulc_map(
 def _forest_area_mask_op(lulc_array, globio_nodata, forest_areas_nodata):
     """Masking out forest areas."""
     # comparing integers, numpy.isclose not needed
-    valid_mask = lulc_array != globio_nodata
+    valid_mask = ~utils.array_equals_nodata(lulc_array, globio_nodata)
     # landcover code 130 represents all MODIS forest codes which originate
     # as 1-5
     result = numpy.empty_like(lulc_array, dtype=numpy.int16)
@@ -958,7 +959,7 @@ def _create_globio_lulc_op(
     """Construct GLOBIO lulc given relevant biophysical parameters."""
     result = numpy.empty_like(lulc_array, dtype=numpy.int16)
     result[:] = globio_nodata
-    valid_mask = lulc_array != globio_nodata
+    valid_mask = ~utils.array_equals_nodata(lulc_array, globio_nodata)
     valid_result = result[valid_mask]
 
     # Split Shrublands and grasslands into primary vegetations,

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -510,8 +510,7 @@ def _primary_veg_mask_op(lulc_array, globio_nodata, primary_veg_mask_nodata):
     result[:] = primary_veg_mask_nodata
     valid_mask = slice(None)
     if globio_nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(
-            lulc_array, globio_nodata)
+        valid_mask = ~utils.array_equals_nodata(lulc_array, globio_nodata)
     result[valid_mask] = lulc_array[valid_mask] == 1
     return result
 
@@ -574,7 +573,7 @@ def _msa_f_calculation(
                 less_than[1])
 
         if msa_nodata is not None:
-            nodata_mask = utils.check_array_for_nodata(
+            nodata_mask = utils.array_equals_nodata(
                 primary_veg_smooth, primary_veg_mask_nodata)
             msa_f[nodata_mask] = msa_nodata
 
@@ -643,7 +642,7 @@ def _msa_i_calculation(
             lulc_array, msa_nodata, dtype=numpy.float32)
         msa_i_other = numpy.full_like(
             lulc_array, msa_nodata, dtype=numpy.float32)
-        nodata_mask = utils.check_array_for_nodata(lulc_array, lulc_nodata)
+        nodata_mask = utils.array_equals_nodata(lulc_array, lulc_nodata)
 
         if primary_greater_than:
             msa_i_primary[distance_to_infrastructure > primary_greater_than[0]] = (
@@ -700,8 +699,7 @@ def _msa_calculation(
         valid_mask = numpy.ones(msa_f.shape, dtype=bool)
         for msa_array, nodata_val in zip([msa_f, msa_lu, msa_i], nodata_array):
             if nodata_val is not None:
-                valid_mask &= ~utils.check_array_for_nodata(
-                    msa_array, nodata_val)
+                valid_mask &= ~utils.array_equals_nodata(msa_array, nodata_val)
         result[valid_mask] = (
             msa_f[valid_mask] * msa_lu[valid_mask] * msa_i[valid_mask])
         return result
@@ -1090,7 +1088,7 @@ def _collapse_infrastructure_layers(
             infrastructure_mask |= infrastructure_array_list[index] > 0
             if infrastructure_nodata_list[index] is not None:
                 # update nodata mask: intersection with this layer
-                nodata_mask &= utils.check_array_for_nodata(
+                nodata_mask &= utils.array_equals_nodata(
                     infrastructure_array_list[index],
                     infrastructure_nodata_list[index])
             # if nodata is None, every pixel in this layer has data,

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -674,8 +674,8 @@ def _calculate_habitat_quality(deg_hab_raster_list, quality_out_path, ksq):
         # interpreted as nodata.
         # _OUT_NODATA (defined above) should never be None, so this is okay
         valid_pixels = ~(
-            utils.compare_nodata_nan_support(degradation, _OUT_NODATA) |
-            utils.compare_nodata_nan_support(habitat, _OUT_NODATA))
+            utils.check_array_for_nodata(degradation, _OUT_NODATA) |
+            utils.check_array_for_nodata(habitat, _OUT_NODATA))
 
         out_array[valid_pixels] = (
             habitat[valid_pixels] *
@@ -735,7 +735,7 @@ def _calculate_total_degradation(
         nodata_mask = numpy.empty(raster[0].shape, dtype=numpy.int8)
         nodata_mask[:] = 0
         for array in raster:
-            nodata_mask = nodata_mask | utils.compare_nodata_nan_support(
+            nodata_mask = nodata_mask | utils.check_array_for_nodata(
                 array, _OUT_NODATA)
 
         # the last element in raster is access
@@ -984,7 +984,7 @@ def _raster_values_in_bounds(raster_path_band, lower_bound, upper_bound):
     values_valid = True
 
     for _, raster_block in pygeoprocessing.iterblocks(raster_path_band):
-        nodata_mask = ~utils.compare_nodata_nan_support(
+        nodata_mask = ~utils.check_array_for_nodata(
             raster_block, raster_nodata)
         if ((raster_block[nodata_mask] < lower_bound) |
                 (raster_block[nodata_mask] > upper_bound)).any():

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -673,8 +673,9 @@ def _calculate_habitat_quality(deg_hab_raster_list, quality_out_path, ksq):
         # might be *slightly* off of _OUT_NODATA but should still be
         # interpreted as nodata.
         # _OUT_NODATA (defined above) should never be None, so this is okay
-        valid_pixels = ~(numpy.isclose(
-            degradation, _OUT_NODATA) | numpy.isclose(habitat, _OUT_NODATA))
+        valid_pixels = ~(
+            utils.compare_nodata_nan_support(degradation, _OUT_NODATA) |
+            utils.compare_nodata_nan_support(habitat, _OUT_NODATA))
 
         out_array[valid_pixels] = (
             habitat[valid_pixels] *
@@ -734,7 +735,8 @@ def _calculate_total_degradation(
         nodata_mask = numpy.empty(raster[0].shape, dtype=numpy.int8)
         nodata_mask[:] = 0
         for array in raster:
-            nodata_mask = nodata_mask | numpy.isclose(array, _OUT_NODATA)
+            nodata_mask = nodata_mask | utils.compare_nodata_nan_support(
+                array, _OUT_NODATA)
 
         # the last element in raster is access
         return numpy.where(
@@ -982,7 +984,8 @@ def _raster_values_in_bounds(raster_path_band, lower_bound, upper_bound):
     values_valid = True
 
     for _, raster_block in pygeoprocessing.iterblocks(raster_path_band):
-        nodata_mask = ~numpy.isclose(raster_block, raster_nodata)
+        nodata_mask = ~utils.compare_nodata_nan_support(
+            raster_block, raster_nodata)
         if ((raster_block[nodata_mask] < lower_bound) |
                 (raster_block[nodata_mask] > upper_bound)).any():
             values_valid = False

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -813,7 +813,7 @@ def _compute_rarity_operation(
         Returns:
             _OUT_NODATA where either array has nodata, otherwise cover_x.
         """
-        result_array = numpy.full(base.shape, base_nodata)
+        result_array = numpy.full(cover_x.shape, _OUT_NODATA)
         valid_mask = (
             ~utils.array_equals_nodata(base, base_nodata) &
             ~utils.array_equals_nodata(cover_x, lulc_nodata))

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -688,8 +688,8 @@ def _calculate_habitat_quality(deg_hab_raster_list, quality_out_path, ksq):
         # interpreted as nodata.
         # _OUT_NODATA (defined above) should never be None, so this is okay
         valid_pixels = ~(
-            utils.check_array_for_nodata(degradation, _OUT_NODATA) |
-            utils.check_array_for_nodata(habitat, _OUT_NODATA))
+            utils.array_equals_nodata(degradation, _OUT_NODATA) |
+            utils.array_equals_nodata(habitat, _OUT_NODATA))
 
         out_array[valid_pixels] = (
             habitat[valid_pixels] *
@@ -749,7 +749,7 @@ def _calculate_total_degradation(
         nodata_mask = numpy.empty(raster[0].shape, dtype=numpy.int8)
         nodata_mask[:] = 0
         for array in raster:
-            nodata_mask = nodata_mask | utils.check_array_for_nodata(
+            nodata_mask = nodata_mask | utils.array_equals_nodata(
                 array, _OUT_NODATA)
 
         # the last element in raster is access
@@ -998,8 +998,7 @@ def _raster_values_in_bounds(raster_path_band, lower_bound, upper_bound):
     values_valid = True
 
     for _, raster_block in pygeoprocessing.iterblocks(raster_path_band):
-        nodata_mask = ~utils.check_array_for_nodata(
-            raster_block, raster_nodata)
+        nodata_mask = ~utils.array_equals_nodata(raster_block, raster_nodata)
         if ((raster_block[nodata_mask] < lower_bound) |
                 (raster_block[nodata_mask] > upper_bound)).any():
             values_valid = False

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -813,9 +813,12 @@ def _compute_rarity_operation(
         Returns:
             _OUT_NODATA where either array has nodata, otherwise cover_x.
         """
-        return numpy.where(
-            (base == base_nodata) | (cover_x == lulc_nodata),
-            base_nodata, cover_x)
+        result_array = numpy.full(base.shape, base_nodata)
+        valid_mask = (
+            ~utils.array_equals_nodata(base, base_nodata) &
+            ~utils.array_equals_nodata(cover_x, lulc_nodata))
+        result_array[valid_mask] = cover_x[valid_mask]
+        return result_array
 
     pygeoprocessing.raster_calculator(
         [base_lulc_path_band, lulc_path_band], trim_op, new_cover_path[0],

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -949,9 +949,7 @@ def _calculate_load(
         result = numpy.empty(lucode_array.shape)
         result[:] = _TARGET_NODATA
         for lucode in numpy.unique(lucode_array):
-            lucode_is_nodata = utils.array_equals_nodata(
-                numpy.array([lucode]), nodata_landuse).any()
-            if not lucode_is_nodata:
+            if lucode != nodata_landuse:
                 try:
                     result[lucode_array == lucode] = (
                         lucode_to_parameters[lucode][load_type] *

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -1136,8 +1136,8 @@ def _map_lulc_to_val_mask_stream(
     def _map_eff_op(lucode_array, stream_array):
         """Map efficiency from LULC and handle nodata/streams."""
         valid_mask = (
-            ~utils.array_equals_nodata(lucode_array != nodata_landuse) &
-            ~utils.array_equals_nodata(stream_array != nodata_stream))
+            ~utils.array_equals_nodata(lucode_array, nodata_landuse) &
+            ~utils.array_equals_nodata(stream_array, nodata_stream))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
         index = numpy.digitize(

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -887,8 +887,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
             base_raster_path_band):
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(
-                raster_block, base_nodata)
+            valid_mask = ~utils.array_equals_nodata(raster_block, base_nodata)
 
         valid_block = raster_block[valid_mask]
         value_sum += numpy.sum(valid_block)
@@ -905,7 +904,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
 
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(array, base_nodata)
+            valid_mask = ~utils.array_equals_nodata(array, base_nodata)
         result[valid_mask] = array[valid_mask]
         if value_mean != 0:
             result[valid_mask] /= value_mean
@@ -986,7 +985,7 @@ def _multiply_rasters(raster_path_list, target_nodata, target_result_path):
         valid_mask = numpy.full(result.shape, True)
         for array, nodata in zip(*[iter(array_nodata_list)]*2):
             if nodata is not None:
-                valid_mask &= ~utils.check_array_for_nodata(array, nodata)
+                valid_mask &= ~utils.array_equals_nodata(array, nodata)
         result[valid_mask] = array_nodata_list[0][valid_mask]
         for array in array_nodata_list[2::2]:
             result[valid_mask] *= array[valid_mask]
@@ -1219,8 +1218,7 @@ def invert_raster_values(base_raster_path, target_raster_path):
         result[:] = _TARGET_NODATA
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(
-                base_val, base_nodata)
+            valid_mask = ~utils.array_equals_nodata(base_val, base_nodata)
 
         zero_mask = base_val == 0.0
         result[valid_mask & ~zero_mask] = (
@@ -1295,7 +1293,7 @@ def _calculate_sub_ndr(
         """Calculate subsurface NDR."""
         # nodata value from this intermediate output should always be
         # defined by pygeoprocessing, not None
-        valid_mask = ~utils.check_array_for_nodata(
+        valid_mask = ~utils.array_equals_nodata(
             dist_to_channel_array, dist_to_channel_nodata)
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
@@ -1328,12 +1326,11 @@ def _calculate_export(
         # these intermediate outputs should always have defined nodata
         # values assigned by pygeoprocessing
         valid_mask = ~(
-            utils.check_array_for_nodata(
-                modified_load_array, load_nodata) |
-            utils.check_array_for_nodata(ndr_array, ndr_nodata) |
-            utils.check_array_for_nodata(
+            utils.array_equals_nodata(modified_load_array, load_nodata) |
+            utils.array_equals_nodata(ndr_array, ndr_nodata) |
+            utils.array_equals_nodata(
                 modified_sub_load_array, subsurface_load_nodata) |
-            utils.check_array_for_nodata(sub_ndr_array, sub_ndr_nodata))
+            utils.array_equals_nodata(sub_ndr_array, sub_ndr_nodata))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
         result[valid_mask] = (

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -873,7 +873,8 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
             base_raster_path_band):
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~numpy.isclose(raster_block, base_nodata)
+            valid_mask = ~utils.compare_nodata_nan_support(
+                raster_block, base_nodata)
 
         valid_block = raster_block[valid_mask]
         value_sum += numpy.sum(valid_block)
@@ -890,7 +891,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
 
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~numpy.isclose(array, base_nodata)
+            valid_mask = ~utils.compare_nodata_nan_support(array, base_nodata)
         result[valid_mask] = array[valid_mask]
         if value_mean != 0:
             result[valid_mask] /= value_mean
@@ -971,7 +972,7 @@ def _multiply_rasters(raster_path_list, target_nodata, target_result_path):
         valid_mask = numpy.full(result.shape, True)
         for array, nodata in zip(*[iter(array_nodata_list)]*2):
             if nodata is not None:
-                valid_mask &= ~numpy.isclose(array, nodata)
+                valid_mask &= ~utils.compare_nodata_nan_support(array, nodata)
         result[valid_mask] = array_nodata_list[0][valid_mask]
         for array in array_nodata_list[2::2]:
             result[valid_mask] *= array[valid_mask]
@@ -1204,7 +1205,8 @@ def invert_raster_values(base_raster_path, target_raster_path):
         result[:] = _TARGET_NODATA
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~numpy.isclose(base_val, base_nodata)
+            valid_mask = ~utils.compare_nodata_nan_support(
+                base_val, base_nodata)
 
         zero_mask = base_val == 0.0
         result[valid_mask & ~zero_mask] = (
@@ -1279,7 +1281,7 @@ def _calculate_sub_ndr(
         """Calculate subsurface NDR."""
         # nodata value from this intermediate output should always be
         # defined by pygeoprocessing, not None
-        valid_mask = ~numpy.isclose(
+        valid_mask = ~utils.compare_nodata_nan_support(
             dist_to_channel_array, dist_to_channel_nodata)
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
@@ -1312,10 +1314,12 @@ def _calculate_export(
         # these intermediate outputs should always have defined nodata
         # values assigned by pygeoprocessing
         valid_mask = ~(
-            numpy.isclose(modified_load_array, load_nodata) |
-            numpy.isclose(ndr_array, ndr_nodata) |
-            numpy.isclose(modified_sub_load_array, subsurface_load_nodata) |
-            numpy.isclose(sub_ndr_array, sub_ndr_nodata))
+            utils.compare_nodata_nan_support(
+                modified_load_array, load_nodata) |
+            utils.compare_nodata_nan_support(ndr_array, ndr_nodata) |
+            utils.compare_nodata_nan_support(
+                modified_sub_load_array, subsurface_load_nodata) |
+            utils.compare_nodata_nan_support(sub_ndr_array, sub_ndr_nodata))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
         result[valid_mask] = (

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -873,7 +873,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
             base_raster_path_band):
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.compare_nodata_nan_support(
+            valid_mask = ~utils.check_array_for_nodata(
                 raster_block, base_nodata)
 
         valid_block = raster_block[valid_mask]
@@ -891,7 +891,7 @@ def _normalize_raster(base_raster_path_band, target_normalized_raster_path):
 
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.compare_nodata_nan_support(array, base_nodata)
+            valid_mask = ~utils.check_array_for_nodata(array, base_nodata)
         result[valid_mask] = array[valid_mask]
         if value_mean != 0:
             result[valid_mask] /= value_mean
@@ -972,7 +972,7 @@ def _multiply_rasters(raster_path_list, target_nodata, target_result_path):
         valid_mask = numpy.full(result.shape, True)
         for array, nodata in zip(*[iter(array_nodata_list)]*2):
             if nodata is not None:
-                valid_mask &= ~utils.compare_nodata_nan_support(array, nodata)
+                valid_mask &= ~utils.check_array_for_nodata(array, nodata)
         result[valid_mask] = array_nodata_list[0][valid_mask]
         for array in array_nodata_list[2::2]:
             result[valid_mask] *= array[valid_mask]
@@ -1205,7 +1205,7 @@ def invert_raster_values(base_raster_path, target_raster_path):
         result[:] = _TARGET_NODATA
         valid_mask = slice(None)
         if base_nodata is not None:
-            valid_mask = ~utils.compare_nodata_nan_support(
+            valid_mask = ~utils.check_array_for_nodata(
                 base_val, base_nodata)
 
         zero_mask = base_val == 0.0
@@ -1281,7 +1281,7 @@ def _calculate_sub_ndr(
         """Calculate subsurface NDR."""
         # nodata value from this intermediate output should always be
         # defined by pygeoprocessing, not None
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             dist_to_channel_array, dist_to_channel_nodata)
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
@@ -1314,12 +1314,12 @@ def _calculate_export(
         # these intermediate outputs should always have defined nodata
         # values assigned by pygeoprocessing
         valid_mask = ~(
-            utils.compare_nodata_nan_support(
+            utils.check_array_for_nodata(
                 modified_load_array, load_nodata) |
-            utils.compare_nodata_nan_support(ndr_array, ndr_nodata) |
-            utils.compare_nodata_nan_support(
+            utils.check_array_for_nodata(ndr_array, ndr_nodata) |
+            utils.check_array_for_nodata(
                 modified_sub_load_array, subsurface_load_nodata) |
-            utils.compare_nodata_nan_support(sub_ndr_array, sub_ndr_nodata))
+            utils.check_array_for_nodata(sub_ndr_array, sub_ndr_nodata))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
         result[:] = _TARGET_NODATA
         result[valid_mask] = (

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -137,7 +137,7 @@ def _threshold_flow(flow_accum_pixels, threshold, in_nodata, out_nodata):
 
     valid_mask = slice(None)
     if in_nodata is not None:
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             flow_accum_pixels, in_nodata)
 
     out_matrix[valid_mask & stream_mask] = 1

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -137,7 +137,8 @@ def _threshold_flow(flow_accum_pixels, threshold, in_nodata, out_nodata):
 
     valid_mask = slice(None)
     if in_nodata is not None:
-        valid_mask = ~numpy.isclose(flow_accum_pixels, in_nodata)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            flow_accum_pixels, in_nodata)
 
     out_matrix[valid_mask & stream_mask] = 1
     out_matrix[valid_mask & ~stream_mask] = 0

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -145,8 +145,7 @@ def _threshold_flow(flow_accum_pixels, threshold, in_nodata, out_nodata):
 
     valid_mask = slice(None)
     if in_nodata is not None:
-        valid_mask = ~utils.check_array_for_nodata(
-            flow_accum_pixels, in_nodata)
+        valid_mask = ~utils.array_equals_nodata(flow_accum_pixels, in_nodata)
 
     out_matrix[valid_mask & stream_mask] = 1
     out_matrix[valid_mask & ~stream_mask] = 0

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -421,7 +421,7 @@ def _convert_landscape(
                 if invert_mask:
                     base_mask = ~base_mask
                 return numpy.where(
-                    lulc_array == lulc_nodata,
+                    utils.array_equals_nodata(lulc_array, lulc_nodata),
                     mask_nodata, base_mask)
             pygeoprocessing.raster_calculator(
                 [(output_landscape_raster_path, 1)], _mask_base_op,

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -987,7 +987,7 @@ def _calculate_visual_quality(source_raster_path, working_dir, target_path):
         """Assign zeros to nodata, excluding them from percentile calc."""
         valid_mask = ~numpy.isclose(valuation_matrix, 0.0)
         if raster_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(
+            valid_mask &= ~utils.array_equals_nodata(
                 valuation_matrix, raster_nodata)
         visual_quality = numpy.empty(valuation_matrix.shape,
                                      dtype=numpy.float64)

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -993,7 +993,8 @@ def _calculate_visual_quality(source_raster_path, working_dir, target_path):
         """Assign zeros to nodata, excluding them from percentile calc."""
         valid_mask = ~numpy.isclose(valuation_matrix, 0.0)
         if raster_nodata is not None:
-            valid_mask &= ~numpy.isclose(valuation_matrix, raster_nodata)
+            valid_mask &= ~utils.compare_nodata_nan_support(
+                valuation_matrix, raster_nodata)
         visual_quality = numpy.empty(valuation_matrix.shape,
                                      dtype=numpy.float64)
         visual_quality[:] = _VALUATION_NODATA

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -993,7 +993,7 @@ def _calculate_visual_quality(source_raster_path, working_dir, target_path):
         """Assign zeros to nodata, excluding them from percentile calc."""
         valid_mask = ~numpy.isclose(valuation_matrix, 0.0)
         if raster_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(
+            valid_mask &= ~utils.check_array_for_nodata(
                 valuation_matrix, raster_nodata)
         visual_quality = numpy.empty(valuation_matrix.shape,
                                      dtype=numpy.float64)

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -774,8 +774,7 @@ def _calculate_ls_factor(
         # avg aspect intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = (
-            (~utils.check_array_for_nodata(
-                avg_aspect, avg_aspect_nodata)) &
+            (~utils.array_equals_nodata(avg_aspect, avg_aspect_nodata)) &
             (percent_slope != slope_nodata) &
             (flow_accumulation != flow_accumulation_nodata))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
@@ -882,10 +881,10 @@ def _calculate_rkls(
         nodata_mask = (
             (ls_factor != _TARGET_NODATA) & (stream != stream_nodata))
         if erosivity_nodata is not None:
-            nodata_mask &= ~utils.check_array_for_nodata(
+            nodata_mask &= ~utils.array_equals_nodata(
                 erosivity, erosivity_nodata)
         if erodibility_nodata is not None:
-            nodata_mask &= ~utils.check_array_for_nodata(
+            nodata_mask &= ~utils.array_equals_nodata(
                 erodibility, erodibility_nodata)
 
         valid_mask = nodata_mask & (stream == 0)
@@ -1109,9 +1108,8 @@ def _calculate_bar_factor(
         # flow accumulation intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = ~(
-            utils.check_array_for_nodata(
-                base_accumulation, _TARGET_NODATA) |
-            utils.check_array_for_nodata(
+            utils.array_equals_nodata(base_accumulation, _TARGET_NODATA) |
+            utils.array_equals_nodata(
                 flow_accumulation, flow_accumulation_nodata))
         result[:] = _TARGET_NODATA
         result[valid_mask] = (

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -697,7 +697,7 @@ def _calculate_ls_factor(
         # avg aspect intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = (
-            (~utils.compare_nodata_nan_support(
+            (~utils.check_array_for_nodata(
                 avg_aspect, avg_aspect_nodata)) &
             (percent_slope != slope_nodata) &
             (flow_accumulation != flow_accumulation_nodata))
@@ -805,10 +805,10 @@ def _calculate_rkls(
         nodata_mask = (
             (ls_factor != _TARGET_NODATA) & (stream != stream_nodata))
         if erosivity_nodata is not None:
-            nodata_mask &= ~utils.compare_nodata_nan_support(
+            nodata_mask &= ~utils.check_array_for_nodata(
                 erosivity, erosivity_nodata)
         if erodibility_nodata is not None:
-            nodata_mask &= ~utils.compare_nodata_nan_support(
+            nodata_mask &= ~utils.check_array_for_nodata(
                 erodibility, erodibility_nodata)
 
         valid_mask = nodata_mask & (stream == 0)
@@ -1032,9 +1032,9 @@ def _calculate_bar_factor(
         # flow accumulation intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = ~(
-            utils.compare_nodata_nan_support(
+            utils.check_array_for_nodata(
                 base_accumulation, _TARGET_NODATA) |
-            utils.compare_nodata_nan_support(
+            utils.check_array_for_nodata(
                 flow_accumulation, flow_accumulation_nodata))
         result[:] = _TARGET_NODATA
         result[valid_mask] = (

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -697,7 +697,8 @@ def _calculate_ls_factor(
         # avg aspect intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = (
-            (~numpy.isclose(avg_aspect, avg_aspect_nodata)) &
+            (~utils.compare_nodata_nan_support(
+                avg_aspect, avg_aspect_nodata)) &
             (percent_slope != slope_nodata) &
             (flow_accumulation != flow_accumulation_nodata))
         result = numpy.empty(valid_mask.shape, dtype=numpy.float32)
@@ -804,9 +805,11 @@ def _calculate_rkls(
         nodata_mask = (
             (ls_factor != _TARGET_NODATA) & (stream != stream_nodata))
         if erosivity_nodata is not None:
-            nodata_mask &= ~numpy.isclose(erosivity, erosivity_nodata)
+            nodata_mask &= ~utils.compare_nodata_nan_support(
+                erosivity, erosivity_nodata)
         if erodibility_nodata is not None:
-            nodata_mask &= ~numpy.isclose(erodibility, erodibility_nodata)
+            nodata_mask &= ~utils.compare_nodata_nan_support(
+                erodibility, erodibility_nodata)
 
         valid_mask = nodata_mask & (stream == 0)
         rkls[:] = _TARGET_NODATA
@@ -1029,8 +1032,10 @@ def _calculate_bar_factor(
         # flow accumulation intermediate output should always have a defined
         # nodata value from pygeoprocessing
         valid_mask = ~(
-            numpy.isclose(base_accumulation, _TARGET_NODATA) |
-            numpy.isclose(flow_accumulation, flow_accumulation_nodata))
+            utils.compare_nodata_nan_support(
+                base_accumulation, _TARGET_NODATA) |
+            utils.compare_nodata_nan_support(
+                flow_accumulation, flow_accumulation_nodata))
         result[:] = _TARGET_NODATA
         result[valid_mask] = (
             base_accumulation[valid_mask] / flow_accumulation[valid_mask])

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -703,9 +703,11 @@ def _calculate_what_drains_to_stream(
         """
         drains_to_stream = numpy.full(
             flow_dir_mfd.shape, _BYTE_NODATA, dtype=numpy.uint8)
-        valid_flow_dir = ~numpy.isclose(flow_dir_mfd, flow_dir_mfd_nodata)
+        valid_flow_dir = ~utils.array_equals_nodata(
+            flow_dir_mfd, flow_dir_mfd_nodata)
         valid_dist_to_channel = (
-            ~numpy.isclose(dist_to_channel, dist_to_channel_nodata) &
+            ~utils.array_equals_nodata(
+                dist_to_channel, dist_to_channel_nodata) &
             valid_flow_dir)
 
         # Nodata where both flow_dir and dist_to_channel are nodata

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -943,16 +943,16 @@ def _calculate_monthly_quick_flow(
         valid_mask = ((p_im != 0.0) &
                       (stream_array != 1) &
                       (n_events > 0) &
-                      ~utils.compare_nodata_nan_support(s_i, si_nodata))
+                      ~utils.check_array_for_nodata(s_i, si_nodata))
         if p_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(p_im, p_nodata)
+            valid_mask &= ~utils.check_array_for_nodata(p_im, p_nodata)
         if n_events_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(
+            valid_mask &= ~utils.check_array_for_nodata(
                 n_events, n_events_nodata)
         # stream_nodata is the only input that carry over nodata values from
         # the aligned DEM.
         if stream_nodata is not None:
-            valid_mask &= ~utils.compare_nodata_nan_support(
+            valid_mask &= ~utils.check_array_for_nodata(
                 stream_array, stream_nodata)
 
         valid_n_events = n_events[valid_mask]
@@ -988,14 +988,14 @@ def _calculate_monthly_quick_flow(
         # if we're on a stream, set quickflow to the precipitation
         valid_stream_precip_mask = stream_array == 1
         if p_nodata is not None:
-            valid_stream_precip_mask &= ~utils.compare_nodata_nan_support(
+            valid_stream_precip_mask &= ~utils.check_array_for_nodata(
                 p_im, p_nodata)
         qf_im[valid_stream_precip_mask] = p_im[valid_stream_precip_mask]
 
         # this handles some user cases where they don't have data defined on
         # their landcover raster. It otherwise crashes later with some NaNs.
         # more intermediate outputs with nodata values guaranteed to be defined
-        qf_im[utils.compare_nodata_nan_support(qf_im, qf_nodata) &
+        qf_im[utils.check_array_for_nodata(qf_im, qf_nodata) &
               (stream_array != stream_nodata)] = 0.0
         return qf_im
 

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -837,7 +837,8 @@ def _calculate_vri(l_path, target_vri_path):
 
     for _, block in pygeoprocessing.iterblocks((l_path, 1)):
         valid_mask = (
-            ~utils.array_equals_nodata(block, l_nodata) & (~numpy.isinf(block))
+            ~utils.array_equals_nodata(block, l_nodata) &
+            (~numpy.isinf(block)))
         qb_sum += numpy.sum(block[valid_mask])
         qb_valid_count += numpy.count_nonzero(valid_mask)
     li_nodata = pygeoprocessing.get_raster_info(l_path)['nodata'][0]

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1044,7 +1044,7 @@ def _calculate_curve_number_raster(
         }
 
         for lucode in sorted(lucodes):
-            if ~utils.array_equals_nodata(numpy.array(lucode), lulc_nodata).any():
+            if lucode != lulc_nodata:
                 lulc_to_soil[soil_id]['cn_values'].append(
                     biophysical_table[lucode][soil_column])
                 lulc_to_soil[soil_id]['lulc_values'].append(lucode)
@@ -1085,7 +1085,7 @@ def _calculate_curve_number_raster(
             raise ValueError(error_message)
 
         for soil_group_id in numpy.unique(soil_group_array):
-            if utils.array_equals_nodata(numpy.array(soil_group_id), soil_nodata).any():
+            if soil_group_id == soil_nodata:
                 continue
             current_soil_mask = (soil_group_array == soil_group_id)
             index = numpy.digitize(

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -937,16 +937,15 @@ def _calculate_monthly_quick_flow(
         valid_mask = ((p_im != 0.0) &
                       (stream_array != 1) &
                       (n_events > 0) &
-                      ~utils.check_array_for_nodata(s_i, si_nodata))
+                      ~utils.array_equals_nodata(s_i, si_nodata))
         if p_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(p_im, p_nodata)
+            valid_mask &= ~utils.array_equals_nodata(p_im, p_nodata)
         if n_events_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(
-                n_events, n_events_nodata)
+            valid_mask &= ~utils.array_equals_nodata(n_events, n_events_nodata)
         # stream_nodata is the only input that carry over nodata values from
         # the aligned DEM.
         if stream_nodata is not None:
-            valid_mask &= ~utils.check_array_for_nodata(
+            valid_mask &= ~utils.array_equals_nodata(
                 stream_array, stream_nodata)
 
         valid_n_events = n_events[valid_mask]
@@ -982,14 +981,14 @@ def _calculate_monthly_quick_flow(
         # if we're on a stream, set quickflow to the precipitation
         valid_stream_precip_mask = stream_array == 1
         if p_nodata is not None:
-            valid_stream_precip_mask &= ~utils.check_array_for_nodata(
+            valid_stream_precip_mask &= ~utils.array_equals_nodata(
                 p_im, p_nodata)
         qf_im[valid_stream_precip_mask] = p_im[valid_stream_precip_mask]
 
         # this handles some user cases where they don't have data defined on
         # their landcover raster. It otherwise crashes later with some NaNs.
         # more intermediate outputs with nodata values guaranteed to be defined
-        qf_im[utils.check_array_for_nodata(qf_im, qf_nodata) &
+        qf_im[utils.array_equals_nodata(qf_im, qf_nodata) &
               (stream_array != stream_nodata)] = 0.0
         return qf_im
 

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -943,15 +943,17 @@ def _calculate_monthly_quick_flow(
         valid_mask = ((p_im != 0.0) &
                       (stream_array != 1) &
                       (n_events > 0) &
-                      ~numpy.isclose(s_i, si_nodata))
+                      ~utils.compare_nodata_nan_support(s_i, si_nodata))
         if p_nodata is not None:
-            valid_mask &= ~numpy.isclose(p_im, p_nodata)
+            valid_mask &= ~utils.compare_nodata_nan_support(p_im, p_nodata)
         if n_events_nodata is not None:
-            valid_mask &= ~numpy.isclose(n_events, n_events_nodata)
+            valid_mask &= ~utils.compare_nodata_nan_support(
+                n_events, n_events_nodata)
         # stream_nodata is the only input that carry over nodata values from
         # the aligned DEM.
         if stream_nodata is not None:
-            valid_mask &= ~numpy.isclose(stream_array, stream_nodata)
+            valid_mask &= ~utils.compare_nodata_nan_support(
+                stream_array, stream_nodata)
 
         valid_n_events = n_events[valid_mask]
         valid_si = s_i[valid_mask]
@@ -986,13 +988,14 @@ def _calculate_monthly_quick_flow(
         # if we're on a stream, set quickflow to the precipitation
         valid_stream_precip_mask = stream_array == 1
         if p_nodata is not None:
-            valid_stream_precip_mask &= ~numpy.isclose(p_im, p_nodata)
+            valid_stream_precip_mask &= ~utils.compare_nodata_nan_support(
+                p_im, p_nodata)
         qf_im[valid_stream_precip_mask] = p_im[valid_stream_precip_mask]
 
         # this handles some user cases where they don't have data defined on
         # their landcover raster. It otherwise crashes later with some NaNs.
         # more intermediate outputs with nodata values guaranteed to be defined
-        qf_im[numpy.isclose(qf_im, qf_nodata) &
+        qf_im[utils.compare_nodata_nan_support(qf_im, qf_nodata) &
               (stream_array != stream_nodata)] = 0.0
         return qf_im
 

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -693,9 +693,10 @@ def volume_op(ratio_array, precip_array, precip_nodata, pixel_area):
     """
     volume_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~numpy.isclose(ratio_array, FLOAT_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(ratio_array, FLOAT_NODATA)
     if precip_nodata is not None:
-        valid_mask &= ~numpy.isclose(precip_array, precip_nodata)
+        valid_mask &= ~utils.compare_nodata_nan_support(
+            precip_array, precip_nodata)
 
     # precipitation (mm/yr) * pixel area (m^2) *
     # 0.001 (m/mm) * ratio = volume (m^3/yr)
@@ -718,7 +719,8 @@ def retention_to_runoff_op(retention_array):
     """
     runoff_array = numpy.full(retention_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~numpy.isclose(retention_array, FLOAT_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(
+        retention_array, FLOAT_NODATA)
     runoff_array[valid_mask] = 1 - retention_array[valid_mask]
     return runoff_array
 
@@ -750,7 +752,7 @@ def pollutant_load_op(lulc_array, lulc_nodata, volume_array, sorted_lucodes,
     """
     load_array = numpy.full(
         lulc_array.shape, FLOAT_NODATA, dtype=numpy.float32)
-    valid_mask = ~numpy.isclose(volume_array, FLOAT_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(volume_array, FLOAT_NODATA)
     if lulc_nodata is not None:
         valid_mask &= (lulc_array != lulc_nodata)
 
@@ -782,7 +784,8 @@ def retention_value_op(retention_volume_array, replacement_cost):
     """
     value_array = numpy.full(retention_volume_array.shape, FLOAT_NODATA,
                              dtype=numpy.float32)
-    valid_mask = ~numpy.isclose(retention_volume_array, FLOAT_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(
+        retention_volume_array, FLOAT_NODATA)
 
     # retention (m^3/yr) * replacement cost ($/m^3) = retention value ($/yr)
     value_array[valid_mask] = (
@@ -814,8 +817,8 @@ def adjust_op(ratio_array, avg_ratio_array, near_connected_lulc_array,
     adjustment_factor_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                                          dtype=numpy.float32)
     valid_mask = (
-        ~numpy.isclose(ratio_array, FLOAT_NODATA) &
-        ~numpy.isclose(avg_ratio_array, FLOAT_NODATA) &
+        ~utils.compare_nodata_nan_support(ratio_array, FLOAT_NODATA) &
+        ~utils.compare_nodata_nan_support(avg_ratio_array, FLOAT_NODATA) &
         (near_connected_lulc_array != UINT8_NODATA) &
         (near_road_array != UINT8_NODATA))
 

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -693,10 +693,9 @@ def volume_op(ratio_array, precip_array, precip_nodata, pixel_area):
     """
     volume_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~utils.check_array_for_nodata(ratio_array, FLOAT_NODATA)
+    valid_mask = ~utils.array_equals_nodata(ratio_array, FLOAT_NODATA)
     if precip_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(
-            precip_array, precip_nodata)
+        valid_mask &= ~utils.array_equals_nodata(precip_array, precip_nodata)
 
     # precipitation (mm/yr) * pixel area (m^2) *
     # 0.001 (m/mm) * ratio = volume (m^3/yr)
@@ -719,8 +718,7 @@ def retention_to_runoff_op(retention_array):
     """
     runoff_array = numpy.full(retention_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~utils.check_array_for_nodata(
-        retention_array, FLOAT_NODATA)
+    valid_mask = ~utils.array_equals_nodata(retention_array, FLOAT_NODATA)
     runoff_array[valid_mask] = 1 - retention_array[valid_mask]
     return runoff_array
 
@@ -752,7 +750,7 @@ def pollutant_load_op(lulc_array, lulc_nodata, volume_array, sorted_lucodes,
     """
     load_array = numpy.full(
         lulc_array.shape, FLOAT_NODATA, dtype=numpy.float32)
-    valid_mask = ~utils.check_array_for_nodata(volume_array, FLOAT_NODATA)
+    valid_mask = ~utils.array_equals_nodata(volume_array, FLOAT_NODATA)
     if lulc_nodata is not None:
         valid_mask &= (lulc_array != lulc_nodata)
 
@@ -784,7 +782,7 @@ def retention_value_op(retention_volume_array, replacement_cost):
     """
     value_array = numpy.full(retention_volume_array.shape, FLOAT_NODATA,
                              dtype=numpy.float32)
-    valid_mask = ~utils.check_array_for_nodata(
+    valid_mask = ~utils.array_equals_nodata(
         retention_volume_array, FLOAT_NODATA)
 
     # retention (m^3/yr) * replacement cost ($/m^3) = retention value ($/yr)
@@ -817,8 +815,8 @@ def adjust_op(ratio_array, avg_ratio_array, near_connected_lulc_array,
     adjustment_factor_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                                          dtype=numpy.float32)
     valid_mask = (
-        ~utils.check_array_for_nodata(ratio_array, FLOAT_NODATA) &
-        ~utils.check_array_for_nodata(avg_ratio_array, FLOAT_NODATA) &
+        ~utils.array_equals_nodata(ratio_array, FLOAT_NODATA) &
+        ~utils.array_equals_nodata(avg_ratio_array, FLOAT_NODATA) &
         (near_connected_lulc_array != UINT8_NODATA) &
         (near_road_array != UINT8_NODATA))
 

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -693,9 +693,9 @@ def volume_op(ratio_array, precip_array, precip_nodata, pixel_area):
     """
     volume_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~utils.compare_nodata_nan_support(ratio_array, FLOAT_NODATA)
+    valid_mask = ~utils.check_array_for_nodata(ratio_array, FLOAT_NODATA)
     if precip_nodata is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(
+        valid_mask &= ~utils.check_array_for_nodata(
             precip_array, precip_nodata)
 
     # precipitation (mm/yr) * pixel area (m^2) *
@@ -719,7 +719,7 @@ def retention_to_runoff_op(retention_array):
     """
     runoff_array = numpy.full(retention_array.shape, FLOAT_NODATA,
                               dtype=numpy.float32)
-    valid_mask = ~utils.compare_nodata_nan_support(
+    valid_mask = ~utils.check_array_for_nodata(
         retention_array, FLOAT_NODATA)
     runoff_array[valid_mask] = 1 - retention_array[valid_mask]
     return runoff_array
@@ -752,7 +752,7 @@ def pollutant_load_op(lulc_array, lulc_nodata, volume_array, sorted_lucodes,
     """
     load_array = numpy.full(
         lulc_array.shape, FLOAT_NODATA, dtype=numpy.float32)
-    valid_mask = ~utils.compare_nodata_nan_support(volume_array, FLOAT_NODATA)
+    valid_mask = ~utils.check_array_for_nodata(volume_array, FLOAT_NODATA)
     if lulc_nodata is not None:
         valid_mask &= (lulc_array != lulc_nodata)
 
@@ -784,7 +784,7 @@ def retention_value_op(retention_volume_array, replacement_cost):
     """
     value_array = numpy.full(retention_volume_array.shape, FLOAT_NODATA,
                              dtype=numpy.float32)
-    valid_mask = ~utils.compare_nodata_nan_support(
+    valid_mask = ~utils.check_array_for_nodata(
         retention_volume_array, FLOAT_NODATA)
 
     # retention (m^3/yr) * replacement cost ($/m^3) = retention value ($/yr)
@@ -817,8 +817,8 @@ def adjust_op(ratio_array, avg_ratio_array, near_connected_lulc_array,
     adjustment_factor_array = numpy.full(ratio_array.shape, FLOAT_NODATA,
                                          dtype=numpy.float32)
     valid_mask = (
-        ~utils.compare_nodata_nan_support(ratio_array, FLOAT_NODATA) &
-        ~utils.compare_nodata_nan_support(avg_ratio_array, FLOAT_NODATA) &
+        ~utils.check_array_for_nodata(ratio_array, FLOAT_NODATA) &
+        ~utils.check_array_for_nodata(avg_ratio_array, FLOAT_NODATA) &
         (near_connected_lulc_array != UINT8_NODATA) &
         (near_road_array != UINT8_NODATA))
 

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -659,9 +659,10 @@ def lookup_ratios(lulc_path, soil_group_path, ratio_lookup, sorted_lucodes,
                                         dtype=numpy.float32)
         valid_mask = numpy.full(lulc_array.shape, True)
         if lulc_nodata is not None:
-            valid_mask &= (lulc_array != lulc_nodata)
+            valid_mask &= ~utils.array_equals_nodata(lulc_array, lulc_nodata)
         if soil_group_nodata is not None:
-            valid_mask &= (soil_group_array != soil_group_nodata)
+            valid_mask &= ~utils.array_equals_nodata(
+                soil_group_array, soil_group_nodata)
         # the index of each lucode in the sorted lucodes array
         lulc_index = numpy.digitize(lulc_array[valid_mask], sorted_lucodes,
                                     right=True)
@@ -752,7 +753,7 @@ def pollutant_load_op(lulc_array, lulc_nodata, volume_array, sorted_lucodes,
         lulc_array.shape, FLOAT_NODATA, dtype=numpy.float32)
     valid_mask = ~utils.array_equals_nodata(volume_array, FLOAT_NODATA)
     if lulc_nodata is not None:
-        valid_mask &= (lulc_array != lulc_nodata)
+        valid_mask &= ~utils.array_equals_nodata(lulc_array, lulc_nodata)
 
     # bin each value in the LULC array such that
     # lulc_array[i,j] == sorted_lucodes[lulc_index[i,j]]. thus,

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -1092,7 +1092,7 @@ def calc_t_air_nomix_op(t_ref_val, hm_array, uhi_max):
     result = numpy.empty(hm_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     # TARGET_NODATA should never be None
-    valid_mask = ~utils.check_array_for_nodata(hm_array, TARGET_NODATA)
+    valid_mask = ~utils.array_equals_nodata(hm_array, TARGET_NODATA)
     result[valid_mask] = t_ref_val + (1-hm_array[valid_mask]) * uhi_max
     return result
 
@@ -1120,9 +1120,9 @@ def calc_cc_op_factors(
     result = numpy.empty(shade_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        utils.check_array_for_nodata(shade_array, TARGET_NODATA) |
-        utils.check_array_for_nodata(albedo_array, TARGET_NODATA) |
-        utils.check_array_for_nodata(eti_array, TARGET_NODATA))
+        utils.array_equals_nodata(shade_array, TARGET_NODATA) |
+        utils.array_equals_nodata(albedo_array, TARGET_NODATA) |
+        utils.array_equals_nodata(eti_array, TARGET_NODATA))
     result[valid_mask] = (
         cc_weight_shade*shade_array[valid_mask] +
         cc_weight_albedo*albedo_array[valid_mask] +
@@ -1142,7 +1142,7 @@ def calc_cc_op_intensity(intensity_array):
     """
     result = numpy.empty(intensity_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~utils.check_array_for_nodata(intensity_array, TARGET_NODATA)
+    valid_mask = ~utils.array_equals_nodata(intensity_array, TARGET_NODATA)
     result[valid_mask] = 1.0 - intensity_array[valid_mask]
     return result
 
@@ -1153,9 +1153,9 @@ def calc_eti_op(
     result = numpy.empty(kc_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     # kc intermediate output should always have a nodata value defined
-    valid_mask = ~utils.check_array_for_nodata(kc_array, kc_nodata)
+    valid_mask = ~utils.array_equals_nodata(kc_array, kc_nodata)
     if et0_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(et0_array, et0_nodata)
+        valid_mask &= ~utils.array_equals_nodata(et0_array, et0_nodata)
     result[valid_mask] = (
         kc_array[valid_mask] * et0_array[valid_mask] / et_max)
     return result
@@ -1187,8 +1187,7 @@ def calculate_wbgt(
 
         valid_mask = slice(None)
         if t_air_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(
-                t_air_array, t_air_nodata)
+            valid_mask = ~utils.array_equals_nodata(t_air_array, t_air_nodata)
         wbgt[:] = TARGET_NODATA
         t_air_valid = t_air_array[valid_mask]
         e_i = (
@@ -1301,8 +1300,8 @@ def hm_op(cc_array, green_area_sum, cc_park_array, green_area_threshold):
     """
     result = numpy.empty(cc_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~(utils.check_array_for_nodata(cc_array, TARGET_NODATA) &
-                   utils.check_array_for_nodata(cc_park_array, TARGET_NODATA))
+    valid_mask = ~(utils.array_equals_nodata(cc_array, TARGET_NODATA) &
+                   utils.array_equals_nodata(cc_park_array, TARGET_NODATA))
     cc_mask = ((cc_array >= cc_park_array) |
                (green_area_sum < green_area_threshold))
     result[cc_mask & valid_mask] = cc_array[cc_mask & valid_mask]
@@ -1334,7 +1333,7 @@ def map_work_loss(
     def classify_to_percent_op(temperature_array):
         result = numpy.empty(temperature_array.shape)
         result[:] = byte_target_nodata
-        valid_mask = ~utils.check_array_for_nodata(
+        valid_mask = ~utils.array_equals_nodata(
             temperature_array, TARGET_NODATA)
         result[
             valid_mask &

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -1088,7 +1088,7 @@ def calc_t_air_nomix_op(t_ref_val, hm_array, uhi_max):
     result = numpy.empty(hm_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     # TARGET_NODATA should never be None
-    valid_mask = ~numpy.isclose(hm_array, TARGET_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(hm_array, TARGET_NODATA)
     result[valid_mask] = t_ref_val + (1-hm_array[valid_mask]) * uhi_max
     return result
 
@@ -1116,9 +1116,9 @@ def calc_cc_op_factors(
     result = numpy.empty(shade_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        numpy.isclose(shade_array, TARGET_NODATA) |
-        numpy.isclose(albedo_array, TARGET_NODATA) |
-        numpy.isclose(eti_array, TARGET_NODATA))
+        utils.compare_nodata_nan_support(shade_array, TARGET_NODATA) |
+        utils.compare_nodata_nan_support(albedo_array, TARGET_NODATA) |
+        utils.compare_nodata_nan_support(eti_array, TARGET_NODATA))
     result[valid_mask] = (
         cc_weight_shade*shade_array[valid_mask] +
         cc_weight_albedo*albedo_array[valid_mask] +
@@ -1138,7 +1138,8 @@ def calc_cc_op_intensity(intensity_array):
     """
     result = numpy.empty(intensity_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~numpy.isclose(intensity_array, TARGET_NODATA)
+    valid_mask = ~utils.compare_nodata_nan_support(
+        intensity_array, TARGET_NODATA)
     result[valid_mask] = 1.0 - intensity_array[valid_mask]
     return result
 
@@ -1149,9 +1150,9 @@ def calc_eti_op(
     result = numpy.empty(kc_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     # kc intermediate output should always have a nodata value defined
-    valid_mask = ~numpy.isclose(kc_array, kc_nodata)
+    valid_mask = ~utils.compare_nodata_nan_support(kc_array, kc_nodata)
     if et0_nodata is not None:
-        valid_mask &= ~numpy.isclose(et0_array, et0_nodata)
+        valid_mask &= ~utils.compare_nodata_nan_support(et0_array, et0_nodata)
     result[valid_mask] = (
         kc_array[valid_mask] * et0_array[valid_mask] / et_max)
     return result
@@ -1183,7 +1184,8 @@ def calculate_wbgt(
 
         valid_mask = slice(None)
         if t_air_nodata is not None:
-            valid_mask = ~numpy.isclose(t_air_array, t_air_nodata)
+            valid_mask = ~utils.compare_nodata_nan_support(
+                t_air_array, t_air_nodata)
         wbgt[:] = TARGET_NODATA
         t_air_valid = t_air_array[valid_mask]
         e_i = (
@@ -1296,8 +1298,9 @@ def hm_op(cc_array, green_area_sum, cc_park_array, green_area_threshold):
     """
     result = numpy.empty(cc_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~(numpy.isclose(cc_array, TARGET_NODATA) &
-                   numpy.isclose(cc_park_array, TARGET_NODATA))
+    valid_mask = ~(
+        utils.compare_nodata_nan_support(cc_array, TARGET_NODATA) &
+        utils.compare_nodata_nan_support(cc_park_array, TARGET_NODATA))
     cc_mask = ((cc_array >= cc_park_array) |
                (green_area_sum < green_area_threshold))
     result[cc_mask & valid_mask] = cc_array[cc_mask & valid_mask]
@@ -1329,7 +1332,8 @@ def map_work_loss(
     def classify_to_percent_op(temperature_array):
         result = numpy.empty(temperature_array.shape)
         result[:] = byte_target_nodata
-        valid_mask = ~numpy.isclose(temperature_array, TARGET_NODATA)
+        valid_mask = ~utils.compare_nodata_nan_support(
+            temperature_array, TARGET_NODATA)
         result[
             valid_mask &
             (temperature_array < work_temp_threshold_array[0])] = 0

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -1088,7 +1088,7 @@ def calc_t_air_nomix_op(t_ref_val, hm_array, uhi_max):
     result = numpy.empty(hm_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     # TARGET_NODATA should never be None
-    valid_mask = ~utils.compare_nodata_nan_support(hm_array, TARGET_NODATA)
+    valid_mask = ~utils.check_array_for_nodata(hm_array, TARGET_NODATA)
     result[valid_mask] = t_ref_val + (1-hm_array[valid_mask]) * uhi_max
     return result
 
@@ -1116,9 +1116,9 @@ def calc_cc_op_factors(
     result = numpy.empty(shade_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        utils.compare_nodata_nan_support(shade_array, TARGET_NODATA) |
-        utils.compare_nodata_nan_support(albedo_array, TARGET_NODATA) |
-        utils.compare_nodata_nan_support(eti_array, TARGET_NODATA))
+        utils.check_array_for_nodata(shade_array, TARGET_NODATA) |
+        utils.check_array_for_nodata(albedo_array, TARGET_NODATA) |
+        utils.check_array_for_nodata(eti_array, TARGET_NODATA))
     result[valid_mask] = (
         cc_weight_shade*shade_array[valid_mask] +
         cc_weight_albedo*albedo_array[valid_mask] +
@@ -1138,7 +1138,7 @@ def calc_cc_op_intensity(intensity_array):
     """
     result = numpy.empty(intensity_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~utils.compare_nodata_nan_support(
+    valid_mask = ~utils.check_array_for_nodata(
         intensity_array, TARGET_NODATA)
     result[valid_mask] = 1.0 - intensity_array[valid_mask]
     return result
@@ -1150,9 +1150,9 @@ def calc_eti_op(
     result = numpy.empty(kc_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     # kc intermediate output should always have a nodata value defined
-    valid_mask = ~utils.compare_nodata_nan_support(kc_array, kc_nodata)
+    valid_mask = ~utils.check_array_for_nodata(kc_array, kc_nodata)
     if et0_nodata is not None:
-        valid_mask &= ~utils.compare_nodata_nan_support(et0_array, et0_nodata)
+        valid_mask &= ~utils.check_array_for_nodata(et0_array, et0_nodata)
     result[valid_mask] = (
         kc_array[valid_mask] * et0_array[valid_mask] / et_max)
     return result
@@ -1184,7 +1184,7 @@ def calculate_wbgt(
 
         valid_mask = slice(None)
         if t_air_nodata is not None:
-            valid_mask = ~utils.compare_nodata_nan_support(
+            valid_mask = ~utils.check_array_for_nodata(
                 t_air_array, t_air_nodata)
         wbgt[:] = TARGET_NODATA
         t_air_valid = t_air_array[valid_mask]
@@ -1299,8 +1299,8 @@ def hm_op(cc_array, green_area_sum, cc_park_array, green_area_threshold):
     result = numpy.empty(cc_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        utils.compare_nodata_nan_support(cc_array, TARGET_NODATA) &
-        utils.compare_nodata_nan_support(cc_park_array, TARGET_NODATA))
+        utils.check_array_for_nodata(cc_array, TARGET_NODATA) &
+        utils.check_array_for_nodata(cc_park_array, TARGET_NODATA))
     cc_mask = ((cc_array >= cc_park_array) |
                (green_area_sum < green_area_threshold))
     result[cc_mask & valid_mask] = cc_array[cc_mask & valid_mask]
@@ -1332,7 +1332,7 @@ def map_work_loss(
     def classify_to_percent_op(temperature_array):
         result = numpy.empty(temperature_array.shape)
         result[:] = byte_target_nodata
-        valid_mask = ~utils.compare_nodata_nan_support(
+        valid_mask = ~utils.check_array_for_nodata(
             temperature_array, TARGET_NODATA)
         result[
             valid_mask &

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -44,7 +44,7 @@ ARGS_SPEC = {
             **spec_utils.LULC,
             "projected": True,
             "projection_units": u.meter,
-            "about": (
+            "about": _(
                 "Map of LULC for the area of interest. All values in this "
                 "raster must have corresponding entries in the Biophysical "
                 "Table.")
@@ -52,27 +52,27 @@ ARGS_SPEC = {
         "ref_eto_raster_path": spec_utils.ETO,
         "aoi_vector_path": spec_utils.AOI,
         "biophysical_table_path": {
-            "name": "biophysical table",
+            "name": _("biophysical table"),
             "type": "csv",
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": (
+                    "about": _(
                         "LULC code corresponding to those in the LULC map.")},
                 "kc": {
                     "type": "number",
                     "units": u.none,
-                    "about": "Crop coefficient for this LULC class."},
+                    "about": _("Crop coefficient for this LULC class.")},
                 "green_area": {
                     "type": "boolean",
-                    "about": (
+                    "about": _(
                         "Enter 1 to indicate that the LULC is considered a "
                         "green area. Enter 0 to indicate that the LULC is not "
                         "considered a green area.")},
                 "shade":  {
                     "type": "ratio",
                     "required": "cc_method == factors",
-                    "about": (
+                    "about": _(
                         "The proportion of area in this LULC class that is "
                         "covered by tree canopy at least 2 meters high. "
                         "Required if the 'factors' option is selected for "
@@ -80,7 +80,7 @@ ARGS_SPEC = {
                 "albedo": {
                     "type": "ratio",
                     "required": "cc_method == factors",
-                    "about": (
+                    "about": _(
                         "The proportion of solar radiation that is directly "
                         "reflected by this LULC class. Required if the "
                         "'factors' option is selected for the Cooling "
@@ -88,13 +88,13 @@ ARGS_SPEC = {
                 "building_intensity": {
                     "type": "ratio",
                     "required": "cc_method == intensity",
-                    "about": (
+                    "about": _(
                         "The ratio of building floor area to footprint "
                         "area, normalized between 0 and 1. Required if the "
                         "'intensity' option is selected for the Cooling "
                         "Capacity Calculation Method.")}
             },
-            "about": (
+            "about": _(
                 "A table mapping each LULC code to biophysical data for that "
                 "LULC class. All values in the LULC raster must have "
                 "corresponding entries in this table."),
@@ -103,8 +103,8 @@ ARGS_SPEC = {
             "type": "number",
             "units": u.meter,
             "expression": "value >= 0",
-            "name": "maximum cooling distance",
-            "about": (
+            "name": _("maximum cooling distance"),
+            "about": _(
                 "Distance over which green areas larger than 2 hectares have "
                 "a cooling effect."),
         },
@@ -112,76 +112,76 @@ ARGS_SPEC = {
             "type": "number",
             "units": u.meter,
             "expression": "value >= 0",
-            "name": "air blending distance",
-            "about": (
+            "name": _("air blending distance"),
+            "about": _(
                 "Radius over which to average air temperatures to account for "
                 "air mixing.")
         },
         "t_ref": {
-            "name": "reference air temperature",
+            "name": _("reference air temperature"),
             "type": "number",
             "units": u.degree_Celsius,
-            "about": (
+            "about": _(
                 "Air temperature in a rural reference area where the urban "
                 "heat island effect is not observed.")
         },
         "uhi_max": {
-            "name": "UHI effect",
+            "name": _("UHI effect"),
             "type": "number",
             "units": u.degree_Celsius,
-            "about": (
+            "about": _(
                 "The magnitude of the urban heat island effect, i.e., the "
                 "difference between the rural reference temperature and the "
                 "maximum temperature observed in the city.")
         },
         "do_energy_valuation": {
-            "name": "run energy savings valuation",
+            "name": _("run energy savings valuation"),
             "type": "boolean",
-            "about": "Run the energy savings valuation model."
+            "about": _("Run the energy savings valuation model.")
         },
         "do_productivity_valuation": {
-            "name": "run work productivity valuation",
+            "name": _("run work productivity valuation"),
             "type": "boolean",
-            "about": "Run the work productivity valuation model."
+            "about": _("Run the work productivity valuation model.")
         },
         "avg_rel_humidity": {
-            "name": "average relative humidity",
+            "name": _("average relative humidity"),
             "type": "percent",
             "required": "do_productivity_valuation",
-            "about": (
+            "about": _(
                 "The average relative humidity over the time period of "
                 "interest. Required if Run Work Productivity Valuation is "
                 "selected."),
         },
         "building_vector_path": {
-            "name": "buildings",
+            "name": _("buildings"),
             "type": "vector",
             "fields": {
                 "type": {
                     "type": "integer",
-                    "about": (
+                    "about": _(
                         "Code indicating the building type. These codes must "
                         "match those in the Energy Consumption Table.")}},
             "geometries": spec_utils.POLYGONS,
             "required": "do_energy_valuation",
-            "about": (
+            "about": _(
                 "A map of built infrastructure footprints. Required if Run "
                 "Energy Savings Valuation is selected.")
         },
         "energy_consumption_table_path": {
-            "name": "energy consumption table",
+            "name": _("energy consumption table"),
             "type": "csv",
             "columns": {
                 "type": {
                     "type": "integer",
-                    "about": (
+                    "about": _(
                         "Building type codes matching those in the Buildings "
                         "vector.")
                 },
                 "consumption": {
                     "type": "number",
                     "units": u.kilowatt_hour/(u.degree_Celsius * u.meter**2),
-                    "about": (
+                    "about": _(
                         "Energy consumption by footprint area for this "
                         "building type.")
                 },
@@ -189,7 +189,7 @@ ARGS_SPEC = {
                     "type": "number",
                     "units": u.currency/u.kilowatt_hour,
                     "required": False,
-                    "about": (
+                    "about": _(
                         "The cost of electricity for this building type. "
                         "If this column is provided, the energy savings "
                         "outputs will be in the this currency unit rather "
@@ -197,44 +197,48 @@ ARGS_SPEC = {
                 }
             },
             "required": "do_energy_valuation",
-            "about": (
+            "about": _(
                 "A table of energy consumption data for each building type. "
                 "Required if Run Energy Savings Valuation is selected.")
         },
         "cc_method": {
-            "name": "cooling capacity calculation method",
+            "name": _("cooling capacity calculation method"),
             "type": "option_string",
             "options": {
-                "factors": (
-                    "Use the weighted shade, albedo, and ETI factors as a "
-                    "temperature predictor (for daytime temperatures)."),
-                "intensity": (
-                    "Use building intensity as a temperature predictor (for "
-                    "nighttime temperatures).")
+                "factors": {
+                    "display_name": _("factors"),
+                    "description": _(
+                        "Use the weighted shade, albedo, and ETI factors as a "
+                        "temperature predictor (for daytime temperatures).")},
+                "intensity": {
+                    "display_name": _("intensity"),
+                    "description": _(
+                        "Use building intensity as a temperature predictor "
+                        "(for nighttime temperatures).")}
             },
-            "about": "The air temperature predictor method to use."
+            "about": _("The air temperature predictor method to use.")
         },
         "cc_weight_shade": {
-            "name": "shade weight",
+            "name": _("shade weight"),
             "type": "ratio",
             "required": False,
-            "about": (
+            "about": _(
                 "The relative weight to apply to shade when calculating the "
                 "cooling capacity index. If not provided, defaults to 0.6."),
         },
         "cc_weight_albedo": {
-            "name": "albedo weight",
+            "name": _("albedo weight"),
             "type": "ratio",
             "required": False,
-            "about": (
+            "about": _(
                 "The relative weight to apply to albedo when calculating the "
                 "cooling capacity index. If not provided, defaults to 0.2."),
         },
         "cc_weight_eti": {
-            "name": "evapotranspiration weight",
+            "name": _("evapotranspiration weight"),
             "type": "ratio",
             "required": False,
-            "about": (
+            "about": _(
                 "The relative weight to apply to ETI when calculating the "
                 "cooling capacity index. If not provided, defaults to 0.2.")
         },
@@ -1088,7 +1092,7 @@ def calc_t_air_nomix_op(t_ref_val, hm_array, uhi_max):
     result = numpy.empty(hm_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     # TARGET_NODATA should never be None
-    valid_mask = ~utils.check_array_for_nodata(hm_array, TARGET_NODATA)
+    valid_mask = ~numpy.isclose(hm_array, TARGET_NODATA)
     result[valid_mask] = t_ref_val + (1-hm_array[valid_mask]) * uhi_max
     return result
 
@@ -1116,9 +1120,9 @@ def calc_cc_op_factors(
     result = numpy.empty(shade_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        utils.check_array_for_nodata(shade_array, TARGET_NODATA) |
-        utils.check_array_for_nodata(albedo_array, TARGET_NODATA) |
-        utils.check_array_for_nodata(eti_array, TARGET_NODATA))
+        numpy.isclose(shade_array, TARGET_NODATA) |
+        numpy.isclose(albedo_array, TARGET_NODATA) |
+        numpy.isclose(eti_array, TARGET_NODATA))
     result[valid_mask] = (
         cc_weight_shade*shade_array[valid_mask] +
         cc_weight_albedo*albedo_array[valid_mask] +
@@ -1138,8 +1142,7 @@ def calc_cc_op_intensity(intensity_array):
     """
     result = numpy.empty(intensity_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~utils.check_array_for_nodata(
-        intensity_array, TARGET_NODATA)
+    valid_mask = ~numpy.isclose(intensity_array, TARGET_NODATA)
     result[valid_mask] = 1.0 - intensity_array[valid_mask]
     return result
 
@@ -1150,9 +1153,9 @@ def calc_eti_op(
     result = numpy.empty(kc_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     # kc intermediate output should always have a nodata value defined
-    valid_mask = ~utils.check_array_for_nodata(kc_array, kc_nodata)
+    valid_mask = ~numpy.isclose(kc_array, kc_nodata)
     if et0_nodata is not None:
-        valid_mask &= ~utils.check_array_for_nodata(et0_array, et0_nodata)
+        valid_mask &= ~numpy.isclose(et0_array, et0_nodata)
     result[valid_mask] = (
         kc_array[valid_mask] * et0_array[valid_mask] / et_max)
     return result
@@ -1184,8 +1187,7 @@ def calculate_wbgt(
 
         valid_mask = slice(None)
         if t_air_nodata is not None:
-            valid_mask = ~utils.check_array_for_nodata(
-                t_air_array, t_air_nodata)
+            valid_mask = ~numpy.isclose(t_air_array, t_air_nodata)
         wbgt[:] = TARGET_NODATA
         t_air_valid = t_air_array[valid_mask]
         e_i = (
@@ -1298,9 +1300,8 @@ def hm_op(cc_array, green_area_sum, cc_park_array, green_area_threshold):
     """
     result = numpy.empty(cc_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~(
-        utils.check_array_for_nodata(cc_array, TARGET_NODATA) &
-        utils.check_array_for_nodata(cc_park_array, TARGET_NODATA))
+    valid_mask = ~(numpy.isclose(cc_array, TARGET_NODATA) &
+                   numpy.isclose(cc_park_array, TARGET_NODATA))
     cc_mask = ((cc_array >= cc_park_array) |
                (green_area_sum < green_area_threshold))
     result[cc_mask & valid_mask] = cc_array[cc_mask & valid_mask]
@@ -1332,8 +1333,7 @@ def map_work_loss(
     def classify_to_percent_op(temperature_array):
         result = numpy.empty(temperature_array.shape)
         result[:] = byte_target_nodata
-        valid_mask = ~utils.check_array_for_nodata(
-            temperature_array, TARGET_NODATA)
+        valid_mask = ~numpy.isclose(temperature_array, TARGET_NODATA)
         result[
             valid_mask &
             (temperature_array < work_temp_threshold_array[0])] = 0

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -1092,7 +1092,7 @@ def calc_t_air_nomix_op(t_ref_val, hm_array, uhi_max):
     result = numpy.empty(hm_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     # TARGET_NODATA should never be None
-    valid_mask = ~numpy.isclose(hm_array, TARGET_NODATA)
+    valid_mask = ~utils.check_array_for_nodata(hm_array, TARGET_NODATA)
     result[valid_mask] = t_ref_val + (1-hm_array[valid_mask]) * uhi_max
     return result
 
@@ -1120,9 +1120,9 @@ def calc_cc_op_factors(
     result = numpy.empty(shade_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
     valid_mask = ~(
-        numpy.isclose(shade_array, TARGET_NODATA) |
-        numpy.isclose(albedo_array, TARGET_NODATA) |
-        numpy.isclose(eti_array, TARGET_NODATA))
+        utils.check_array_for_nodata(shade_array, TARGET_NODATA) |
+        utils.check_array_for_nodata(albedo_array, TARGET_NODATA) |
+        utils.check_array_for_nodata(eti_array, TARGET_NODATA))
     result[valid_mask] = (
         cc_weight_shade*shade_array[valid_mask] +
         cc_weight_albedo*albedo_array[valid_mask] +
@@ -1142,7 +1142,7 @@ def calc_cc_op_intensity(intensity_array):
     """
     result = numpy.empty(intensity_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~numpy.isclose(intensity_array, TARGET_NODATA)
+    valid_mask = ~utils.check_array_for_nodata(intensity_array, TARGET_NODATA)
     result[valid_mask] = 1.0 - intensity_array[valid_mask]
     return result
 
@@ -1153,9 +1153,9 @@ def calc_eti_op(
     result = numpy.empty(kc_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
     # kc intermediate output should always have a nodata value defined
-    valid_mask = ~numpy.isclose(kc_array, kc_nodata)
+    valid_mask = ~utils.check_array_for_nodata(kc_array, kc_nodata)
     if et0_nodata is not None:
-        valid_mask &= ~numpy.isclose(et0_array, et0_nodata)
+        valid_mask &= ~utils.check_array_for_nodata(et0_array, et0_nodata)
     result[valid_mask] = (
         kc_array[valid_mask] * et0_array[valid_mask] / et_max)
     return result
@@ -1187,7 +1187,8 @@ def calculate_wbgt(
 
         valid_mask = slice(None)
         if t_air_nodata is not None:
-            valid_mask = ~numpy.isclose(t_air_array, t_air_nodata)
+            valid_mask = ~utils.check_array_for_nodata(
+                t_air_array, t_air_nodata)
         wbgt[:] = TARGET_NODATA
         t_air_valid = t_air_array[valid_mask]
         e_i = (
@@ -1300,8 +1301,8 @@ def hm_op(cc_array, green_area_sum, cc_park_array, green_area_threshold):
     """
     result = numpy.empty(cc_array.shape, dtype=numpy.float32)
     result[:] = TARGET_NODATA
-    valid_mask = ~(numpy.isclose(cc_array, TARGET_NODATA) &
-                   numpy.isclose(cc_park_array, TARGET_NODATA))
+    valid_mask = ~(utils.check_array_for_nodata(cc_array, TARGET_NODATA) &
+                   utils.check_array_for_nodata(cc_park_array, TARGET_NODATA))
     cc_mask = ((cc_array >= cc_park_array) |
                (green_area_sum < green_area_threshold))
     result[cc_mask & valid_mask] = cc_array[cc_mask & valid_mask]
@@ -1333,7 +1334,8 @@ def map_work_loss(
     def classify_to_percent_op(temperature_array):
         result = numpy.empty(temperature_array.shape)
         result[:] = byte_target_nodata
-        valid_mask = ~numpy.isclose(temperature_array, TARGET_NODATA)
+        valid_mask = ~utils.check_array_for_nodata(
+            temperature_array, TARGET_NODATA)
         result[
             valid_mask &
             (temperature_array < work_temp_threshold_array[0])] = 0

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -683,7 +683,8 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=bool)
     if q_pi_nodata is not None:
-        valid_mask[:] = ~numpy.isclose(q_pi_array, q_pi_nodata)
+        valid_mask[:] = ~utils.compare_nodata_nan_support(
+            q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
 
@@ -708,7 +709,8 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=bool)
     if s_max_nodata is not None:
-        non_nodata_mask[:] = ~numpy.isclose(s_max_array, s_max_nodata)
+        non_nodata_mask[:] = ~utils.compare_nodata_nan_support(
+            s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
     valid_mask = non_nodata_mask & ~zero_mask
@@ -737,7 +739,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
     if cn_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(cn_array, cn_nodata)
+        valid_mask[:] &= ~utils.compare_nodata_nan_support(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
     return result
@@ -765,9 +767,11 @@ def _lu_to_cn_op(
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=bool)
     if lucode_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(lucode_array, lucode_nodata)
+        valid_mask[:] &= ~utils.compare_nodata_nan_support(
+            lucode_array, lucode_nodata)
     if soil_type_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(soil_type_array, soil_type_nodata)
+        valid_mask[:] &= ~utils.compare_nodata_nan_support(
+            soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover
     # pixel and the rows are the curve number index for the landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -683,7 +683,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=bool)
     if q_pi_nodata is not None:
-        valid_mask[:] = ~utils.check_array_for_nodata(q_pi_array, q_pi_nodata)
+        valid_mask[:] = ~utils.array_equals_nodata(q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
 
@@ -708,7 +708,7 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=bool)
     if s_max_nodata is not None:
-        non_nodata_mask[:] = ~utils.check_array_for_nodata(
+        non_nodata_mask[:] = ~utils.array_equals_nodata(
             s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
@@ -738,7 +738,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
     if cn_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(cn_array, cn_nodata)
+        valid_mask[:] &= ~utils.array_equals_nodata(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
     return result
@@ -766,10 +766,10 @@ def _lu_to_cn_op(
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=bool)
     if lucode_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(
+        valid_mask[:] &= ~utils.array_equals_nodata(
             lucode_array, lucode_nodata)
     if soil_type_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(
+        valid_mask[:] &= ~utils.array_equals_nodata(
             soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -683,7 +683,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=bool)
     if q_pi_nodata is not None:
-        valid_mask[:] = ~numpy.isclose(q_pi_array, q_pi_nodata)
+        valid_mask[:] = ~utils.check_array_for_nodata(q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
 
@@ -708,7 +708,8 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=bool)
     if s_max_nodata is not None:
-        non_nodata_mask[:] = ~numpy.isclose(s_max_array, s_max_nodata)
+        non_nodata_mask[:] = ~utils.check_array_for_nodata(
+            s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
     valid_mask = non_nodata_mask & ~zero_mask
@@ -737,7 +738,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
     if cn_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(cn_array, cn_nodata)
+        valid_mask[:] &= ~utils.check_array_for_nodata(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
     return result
@@ -765,9 +766,11 @@ def _lu_to_cn_op(
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=bool)
     if lucode_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(lucode_array, lucode_nodata)
+        valid_mask[:] &= ~utils.check_array_for_nodata(
+            lucode_array, lucode_nodata)
     if soil_type_nodata is not None:
-        valid_mask[:] &= ~numpy.isclose(soil_type_array, soil_type_nodata)
+        valid_mask[:] &= ~utils.check_array_for_nodata(
+            soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover
     # pixel and the rows are the curve number index for the landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -683,7 +683,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=bool)
     if q_pi_nodata is not None:
-        valid_mask[:] = ~utils.compare_nodata_nan_support(
+        valid_mask[:] = ~utils.check_array_for_nodata(
             q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
@@ -709,7 +709,7 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=bool)
     if s_max_nodata is not None:
-        non_nodata_mask[:] = ~utils.compare_nodata_nan_support(
+        non_nodata_mask[:] = ~utils.check_array_for_nodata(
             s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
@@ -739,7 +739,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
     if cn_nodata is not None:
-        valid_mask[:] &= ~utils.compare_nodata_nan_support(cn_array, cn_nodata)
+        valid_mask[:] &= ~utils.check_array_for_nodata(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
     return result
@@ -767,10 +767,10 @@ def _lu_to_cn_op(
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=bool)
     if lucode_nodata is not None:
-        valid_mask[:] &= ~utils.compare_nodata_nan_support(
+        valid_mask[:] &= ~utils.check_array_for_nodata(
             lucode_array, lucode_nodata)
     if soil_type_nodata is not None:
-        valid_mask[:] &= ~utils.compare_nodata_nan_support(
+        valid_mask[:] &= ~utils.check_array_for_nodata(
             soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -40,8 +40,8 @@ ARGS_SPEC = {
             "expression": "value > 0",
             "type": "number",
             "units": u.millimeter,
-            "about": "Depth of rainfall for the design storm of interest.",
-            "name": "rainfall depth"
+            "about": _("Depth of rainfall for the design storm of interest."),
+            "name": _("rainfall depth")
         },
         "lulc_path": {
             **spec_utils.LULC,
@@ -63,18 +63,18 @@ ARGS_SPEC = {
                 "cn_[SOIL_GROUP]": {
                     "type": "number",
                     "units": u.none,
-                    "about": (
+                    "about": _(
                         "The curve number value for this LULC type in each "
                         "hydrologic soil group. Replace [SOIL_GROUP] with the "
                         "soil group codes A, B, C, D, so that there is a "
                         "column for each soil group.")
                 }
             },
-            "about": (
+            "about": _(
                 "Table of curve number data for each LULC class. All LULC "
                 "codes in the LULC raster must have corresponding entries in "
                 "this table."),
-            "name": "biophysical table"
+            "name": _("biophysical table")
         },
         "built_infrastructure_vector_path": {
             "type": "vector",
@@ -87,8 +87,8 @@ ARGS_SPEC = {
                     )}},
             "geometries": spec_utils.POLYGONS,
             "required": False,
-            "about": "Map of building footprints.",
-            "name": "built infrastructure"
+            "about": _("Map of building footprints."),
+            "name": _("built infrastructure")
         },
         "infrastructure_damage_loss_table_path": {
             "type": "csv",
@@ -102,12 +102,12 @@ ARGS_SPEC = {
                     "about": "Potential damage loss for this building type."}
             },
             "required": "built_infrastructure_vector_path",
-            "about": (
+            "about": _(
                 "Table of potential damage loss data for each building type. "
                 "All values in the Built Infrastructure vector 'type' field "
                 "must have corresponding entries in this table. Required if "
                 "the Built Infrastructure vector is provided."),
-            "name": "damage loss table"
+            "name": _("damage loss table")
         }
     }
 }
@@ -683,8 +683,7 @@ def _runoff_retention_op(q_pi_array, p_value, q_pi_nodata, result_nodata):
     result[:] = result_nodata
     valid_mask = numpy.ones(q_pi_array.shape, dtype=bool)
     if q_pi_nodata is not None:
-        valid_mask[:] = ~utils.check_array_for_nodata(
-            q_pi_array, q_pi_nodata)
+        valid_mask[:] = ~numpy.isclose(q_pi_array, q_pi_nodata)
     result[valid_mask] = 1.0 - (q_pi_array[valid_mask] / p_value)
     return result
 
@@ -709,8 +708,7 @@ def _q_pi_op(p_value, s_max_array, s_max_nodata, result_nodata):
     zero_mask = (p_value <= lam * s_max_array)
     non_nodata_mask = numpy.ones(s_max_array.shape, dtype=bool)
     if s_max_nodata is not None:
-        non_nodata_mask[:] = ~utils.check_array_for_nodata(
-            s_max_array, s_max_nodata)
+        non_nodata_mask[:] = ~numpy.isclose(s_max_array, s_max_nodata)
 
     # valid if not nodata and not going to be set to 0.
     valid_mask = non_nodata_mask & ~zero_mask
@@ -739,7 +737,7 @@ def _s_max_op(cn_array, cn_nodata, result_nodata):
     zero_mask = cn_array == 0
     valid_mask = ~zero_mask
     if cn_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(cn_array, cn_nodata)
+        valid_mask[:] &= ~numpy.isclose(cn_array, cn_nodata)
     result[valid_mask] = 25400.0 / cn_array[valid_mask] - 254.0
     result[zero_mask] = 0.0
     return result
@@ -767,11 +765,9 @@ def _lu_to_cn_op(
     result[:] = cn_nodata
     valid_mask = numpy.ones(lucode_array.shape, dtype=bool)
     if lucode_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(
-            lucode_array, lucode_nodata)
+        valid_mask[:] &= ~numpy.isclose(lucode_array, lucode_nodata)
     if soil_type_nodata is not None:
-        valid_mask[:] &= ~utils.check_array_for_nodata(
-            soil_type_array, soil_type_nodata)
+        valid_mask[:] &= ~numpy.isclose(soil_type_array, soil_type_nodata)
 
     # this is an array where each column represents a valid landcover
     # pixel and the rows are the curve number index for the landcover

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -633,7 +633,7 @@ def _flood_vol_op(
     """
     result = numpy.empty(q_pi_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
-    valid_mask = q_pi_array != q_pi_nodata
+    valid_mask = ~utils.array_equals_nodata(q_pi_array, q_pi_nodata)
     # 0.001 converts mm (quickflow) to m (pixel area units)
     result[valid_mask] = (
         q_pi_array[valid_mask] * pixel_area * 0.001)
@@ -658,7 +658,8 @@ def _runoff_retention_vol_op(
     """
     result = numpy.empty(runoff_retention_array.shape, dtype=numpy.float32)
     result[:] = target_nodata
-    valid_mask = runoff_retention_array != runoff_retention_nodata
+    valid_mask = ~utils.array_equals_nodata(
+        runoff_retention_array, runoff_retention_nodata)
     # the 1e-3 converts the mm of p_value to meters.
     result[valid_mask] = (
         runoff_retention_array[valid_mask] * p_value * cell_area * 1e-3)

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -918,7 +918,7 @@ def reclassify_raster(
         raise ValueError(error_message)
 
 
-def compare_nodata_nan_support(array, nodata):
+def check_array_for_nodata(array, nodata):
     """Check for the presense of ``nodata`` values in ``array``.
 
     The comparison supports ``numpy.nan`` nodata values.

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -932,7 +932,7 @@ def compare_nodata_nan_support(array, nodata):
         ``nodata`` and 0 otherwise.
     """
     # comparing an integer array against numpy.nan works correctly and is
-    # faster than using ``numpy.isclose()``.
+    # faster than using numpy.isclose().
     if numpy.issubdtype(array.dtype, numpy.integer):
         return array == nodata
     return numpy.isclose(array, nodata, equal_nan=True)

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -916,3 +916,23 @@ def reclassify_raster(
             f" {raster_name} raster but not the table are:"
             f" {err.missing_values}.")
         raise ValueError(error_message)
+
+
+def compare_nodata_nan_support(array, nodata):
+    """Check for the presense of ``nodata`` values in ``array``.
+
+    The comparison supports ``numpy.nan`` nodata values.
+
+    Args:
+        array (numpy array): the array to mask for nodata values.
+        nodata (number): the nodata value to check for. Supports ``numpy.nan``.
+
+    Returns:
+        A boolean numpy array with values of 1 where ``array`` is equal to
+        ``nodata`` and 0 otherwise.
+    """
+    # comparing an integer array against numpy.nan works correctly and is
+    # faster than using ``numpy.isclose()``.
+    if numpy.issubdtype(array.dtype, numpy.integer):
+        return array == nodata
+    return numpy.isclose(array, nodata, equal_nan=True)

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -919,7 +919,7 @@ def reclassify_raster(
         raise ValueError(error_message)
 
 
-def check_array_for_nodata(array, nodata):
+def array_equals_nodata(array, nodata):
     """Check for the presense of ``nodata`` values in ``array``.
 
     The comparison supports ``numpy.nan`` nodata values.

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -1459,7 +1459,9 @@ def _create_percentile_rasters(base_raster_path, target_raster_path,
     base_dtype = base_raster_info['datatype']
 
     def _mask_below_start_value(array):
-        valid_mask = (array != base_nodata) & (array >= float(start_value))
+        valid_mask = (
+            ~utils.array_equals_nodata(array, base_nodata) &
+            (array >= float(start_value)))
         result = numpy.empty_like(array)
         result[:] = base_nodata
         result[valid_mask] = array[valid_mask]
@@ -1502,7 +1504,7 @@ def _create_percentile_rasters(base_raster_path, target_raster_path,
     def raster_percentile(band):
         """Group the band pixels together based on _PERCENTILES, starting from 1.
         """
-        valid_data_mask = (band != base_nodata)
+        valid_data_mask = ~utils.array_equals_nodata(band, base_nodata)
         band[valid_data_mask] = numpy.searchsorted(
             percentile_values, band[valid_data_mask]) + 1
         band[~valid_data_mask] = target_nodata

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import math
 
-import numpy as np
+import numpy
 import pandas
 from scipy import integrate
 
@@ -545,7 +545,7 @@ def execute(args):
             inter_dir, 'bathymetry_resampled%s.tif' % suffix)
 
         # Get the minimum absolute value from the bathymetry pixel size tuple
-        mean_pixel_size = np.min(np.absolute(bathy_pixel_size))
+        mean_pixel_size = numpy.min(numpy.absolute(bathy_pixel_size))
         # Use it as the target pixel size for resampling and warping rasters
         target_pixel_size = (mean_pixel_size, -mean_pixel_size)
         LOGGER.debug('Target pixel size: %s' % (target_pixel_size,))
@@ -1327,7 +1327,7 @@ def _calculate_npv_levelized_rasters(
         # Calculate cable cost. The break at 'circuit_break' indicates the
         # difference in using AC and DC current systems
         circuit_mask = (cable_dist_arr <= circuit_break)
-        cable_cost_arr = np.full(target_arr_shape, 0.0, dtype=np.float32)
+        cable_cost_arr = numpy.full(target_arr_shape, 0.0, dtype=numpy.float32)
 
         # Calculate AC cable cost
         cable_cost_arr[circuit_mask] = cable_dist_arr[
@@ -1353,17 +1353,17 @@ def _calculate_npv_levelized_rasters(
 
         # Initialize the summation of the revenue less the ongoing costs,
         # adjusted for discount rate
-        npv_arr = np.full(
-            target_arr_shape, 0.0, dtype=np.float32)
+        npv_arr = numpy.full(
+            target_arr_shape, 0.0, dtype=numpy.float32)
 
         # Initialize the numerator summation part of the levelized cost
-        levelized_num_arr = np.full(
-            target_arr_shape, 0.0, dtype=np.float32)
+        levelized_num_arr = numpy.full(
+            target_arr_shape, 0.0, dtype=numpy.float32)
 
         # Initialize and calculate the denominator summation value for
         # levelized cost of energy at year 0
-        levelized_denom_arr = np.full(
-            target_arr_shape, 0.0, dtype=np.float32)
+        levelized_denom_arr = numpy.full(
+            target_arr_shape, 0.0, dtype=numpy.float32)
         levelized_denom_arr = energy_val_arr / disc_const**0
 
         # Calculate the total NPV and the levelized cost over the lifespan of
@@ -1491,12 +1491,12 @@ def _depth_op(bath, min_depth, max_depth):
         _TARGET_NODATA (int or float): a nodata value set above
 
     Returns:
-        out_array (np.array): an array where values are _TARGET_NODATA
+        out_array (numpy.array): an array where values are _TARGET_NODATA
             if 'bath' does not fall within the range, or 'bath' if it does.
 
     """
-    out_array = np.full(
-        bath.shape, _TARGET_NODATA, dtype=np.float32)
+    out_array = numpy.full(
+        bath.shape, _TARGET_NODATA, dtype=numpy.float32)
     valid_pixels_mask = ((bath >= max_depth) & (bath <= min_depth) &
                          (bath != _TARGET_NODATA))
     out_array[
@@ -1508,19 +1508,19 @@ def _add_avg_dist_op(tmp_dist, mean_pixel_size, avg_grid_distance):
     """Convert distances to meters and add in avg_grid_distance.
 
     Args:
-        tmp_dist (np.array): an array of distances
+        tmp_dist (numpy.array): an array of distances
         mean_pixel_size (float): the minimum absolute value of a pixel in
             meters
         avg_grid_distance (float): the average land cable distance in km
             converted to meters
 
     Returns:
-        out_array (np.array): distance values in meters with average
+        out_array (numpy.array): distance values in meters with average
             grid to land distance factored in
 
     """
-    out_array = np.full(
-        tmp_dist.shape, _TARGET_NODATA, dtype=np.float32)
+    out_array = numpy.full(
+        tmp_dist.shape, _TARGET_NODATA, dtype=numpy.float32)
     valid_pixels_mask = (tmp_dist != _TARGET_NODATA)
     out_array[valid_pixels_mask] = tmp_dist[
         valid_pixels_mask] * mean_pixel_size + avg_grid_distance
@@ -1581,12 +1581,12 @@ def _mask_out_depth_dist(*rasters):
             rasters[2] - the distance mask value (optional)
 
     Returns:
-        out_array (np.array): an array of either _TARGET_NODATA or density
+        out_array (numpy.array): an array of either _TARGET_NODATA or density
             values from rasters[0]
 
     """
-    out_array = np.full(rasters[0].shape, _TARGET_NODATA, dtype=np.float32)
-    nodata_mask = np.full(rasters[0].shape, False, dtype=bool)
+    out_array = numpy.full(rasters[0].shape, _TARGET_NODATA, dtype=numpy.float32)
+    nodata_mask = numpy.full(rasters[0].shape, False, dtype=bool)
     for array in rasters:
         nodata_mask = nodata_mask | (array == _TARGET_NODATA)
     out_array[~nodata_mask] = rasters[0][~nodata_mask]
@@ -1597,16 +1597,16 @@ def _calculate_carbon_op(harvested_arr, carbon_coef):
     """Calculate the carbon offset from harvested array.
 
     Args:
-        harvested_arr (np.array): an array of harvested energy values
+        harvested_arr (numpy.array): an array of harvested energy values
         carbon_coef (float): the amount of CO2 not released into the
                 atmosphere
 
     Returns:
-        out_array (np.array): an array of carbon offset values
+        out_array (numpy.array): an array of carbon offset values
 
     """
-    out_array = np.full(
-        harvested_arr.shape, _TARGET_NODATA, dtype=np.float32)
+    out_array = numpy.full(
+        harvested_arr.shape, _TARGET_NODATA, dtype=numpy.float32)
     valid_pixels_mask = (harvested_arr != _TARGET_NODATA)
 
     # The energy value converted from MWhr/yr (Mega Watt hours as output
@@ -1753,7 +1753,7 @@ def _mask_by_distance(base_raster_path, min_dist, max_dist, out_nodata,
 
     def _dist_mask_op(dist_arr):
         """Mask & multiply distance values by min/max values & cell size."""
-        out_array = np.full(dist_arr.shape, out_nodata, dtype=np.float32)
+        out_array = numpy.full(dist_arr.shape, out_nodata, dtype=numpy.float32)
         valid_pixels_mask = ((dist_arr != raster_nodata) &
                              (dist_arr >= min_dist) & (dist_arr <= max_dist))
         out_array[
@@ -2174,7 +2174,7 @@ def _get_suitable_projection_params(
             'intersection')
 
         # Get the minimum square pixel size
-        min_pixel_size = np.min(np.absolute(base_raster_info['pixel_size']))
+        min_pixel_size = numpy.min(numpy.absolute(base_raster_info['pixel_size']))
         target_pixel_size = (min_pixel_size, -min_pixel_size)
 
     with open(target_pickle_path, 'wb') as pickle_file:
@@ -2250,8 +2250,8 @@ def _convert_degree_pixel_size_to_square_meters(pixel_size, center_lat):
     x_meter_size = longlen * pixel_size[0]
     y_meter_size = latlen * pixel_size[1]
     meter_pixel_size_tuple = (x_meter_size, y_meter_size)
-    if not np.isclose(x_meter_size, y_meter_size):
-        min_meter_size = np.min(np.absolute(meter_pixel_size_tuple))
+    if not numpy.isclose(x_meter_size, y_meter_size):
+        min_meter_size = numpy.min(numpy.absolute(meter_pixel_size_tuple))
         meter_pixel_size_tuple = (min_meter_size, -min_meter_size)
 
     return meter_pixel_size_tuple
@@ -2596,7 +2596,7 @@ def _calculate_distances_land_grid(base_point_vector_path, base_raster_path,
     target_vector = None
     base_point_layer = None
     base_point_vector = None
-    l2g_dist_array = np.array(l2g_dist)
+    l2g_dist_array = numpy.array(l2g_dist)
 
     def _min_land_ocean_dist(*grid_distances):
         """Aggregate each features distance transform output and create one
@@ -2612,8 +2612,8 @@ def _calculate_distances_land_grid(base_point_vector_path, base_raster_path,
         """
         # Get the shape of the incoming numpy arrays
         # Initialize with land to grid distances from the first array
-        min_distances = np.min(grid_distances, axis=0)
-        min_land_grid_dist = l2g_dist_array[np.argmin(grid_distances, axis=0)]
+        min_distances = numpy.min(grid_distances, axis=0)
+        min_land_grid_dist = l2g_dist_array[numpy.argmin(grid_distances, axis=0)]
         return min_distances * mean_pixel_size + min_land_grid_dist
 
     pygeoprocessing.raster_calculator(
@@ -2667,12 +2667,12 @@ def _calculate_grid_dist_on_raster(grid_vector_path, harvested_masked_path,
         """Multiply the pixel value of a raster by the mean pixel size.
 
         Args:
-            tmp_dist (np.array): an nd numpy array
+            tmp_dist (numpy.array): an nd numpy array
 
         Returns:
-            out_array (np.array): an array multiplied by a pixel size
+            out_array (numpy.array): an array multiplied by a pixel size
         """
-        out_array = np.full(tmp_dist.shape, out_nodata, dtype=np.float32)
+        out_array = numpy.full(tmp_dist.shape, out_nodata, dtype=numpy.float32)
         valid_pixels_mask = (tmp_dist != out_nodata)
         out_array[
             valid_pixels_mask] = tmp_dist[valid_pixels_mask] * mean_pixel_size

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1508,7 +1508,7 @@ class ReclassifyRasterOpTests(unittest.TestCase):
             expected_message in str(context.exception), str(context.exception))
 
 class CheckArrayNodataTests(unittest.TestCase):
-    """Tests for natcap.invest.utils.check_array_for_nodata."""
+    """Tests for natcap.invest.utils.array_equals_nodata."""
 
     def test_integer_array(self):
         """Utils: test integer array is returned as expected."""
@@ -1522,7 +1522,7 @@ class CheckArrayNodataTests(unittest.TestCase):
         expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
         for nodata in nodata_values:
-            result_array = utils.check_array_for_nodata(int_array, nodata)
+            result_array = utils.array_equals_nodata(int_array, nodata)
             numpy.testing.assert_array_equal(result_array, expected_array)
 
     def test_nan_nodata_array(self):
@@ -1534,5 +1534,5 @@ class CheckArrayNodataTests(unittest.TestCase):
 
         expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
-        result_array = utils.check_array_for_nodata(array, numpy.nan)
+        result_array = utils.array_equals_nodata(array, numpy.nan)
         numpy.testing.assert_array_equal(result_array, expected_array)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1507,7 +1507,7 @@ class ReclassifyRasterOpTests(unittest.TestCase):
         self.assertTrue(
             expected_message in str(context.exception), str(context.exception))
 
-class CheckArrayNodataTests(unittest.TestCase):
+class ArrayEqualsNodataTests(unittest.TestCase):
     """Tests for natcap.invest.utils.array_equals_nodata."""
 
     def test_integer_array(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1506,3 +1506,33 @@ class ReclassifyRasterOpTests(unittest.TestCase):
             " the LULC raster but not the table are: [3].")
         self.assertTrue(
             expected_message in str(context.exception), str(context.exception))
+
+class CheckArrayNodataTests(unittest.TestCase):
+    """Tests for natcap.invest.utils.check_array_for_nodata."""
+
+    def test_integer_array(self):
+        """Utils: test integer array is returned as expected."""
+        from natcap.invest import utils
+
+        nodata_values = [9, 9.0]
+
+        int_array = numpy.array(
+            [[4, 2, 9], [1, 9, 3], [9, 6, 1]], dtype=numpy.int16)
+
+        expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+
+        for nodata in nodata_values:
+            result_array = utils.check_array_for_nodata(int_array, nodata)
+            numpy.testing.assert_array_equal(result_array, expected_array)
+
+    def test_nan_nodata_array(self):
+        """Utils: test array with numpy.nan nodata values."""
+        from natcap.invest import utils
+
+        array = numpy.array(
+            [[4, 2, numpy.nan], [1, numpy.nan, 3], [numpy.nan, 6, 1]])
+
+        expected_array = numpy.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+
+        result_array = utils.check_array_for_nodata(array, numpy.nan)
+        numpy.testing.assert_array_equal(result_array, expected_array)


### PR DESCRIPTION
# Description
This PR adds support for handling NaN nodata values when masking for raster_calculator style operations. Specifically this PR handled searching for `numpy.isclose` calls and replacing those with a `utils` function described in #738. 

I mostly did a clean replace of `numpy.isclose` calls except for a few cases where the nodata value was obviously not NaN but a model defined nodata value. If it was not clear or required investigation I substituted the call out as I think the idea of this function is to help alleviate those decisions.

Fixes #738 

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed) - Not needed
