### PR TITLE
Update Qt plugins path in pyinstaller binaries

### DIFF
--- a/exe/qt.conf
+++ b/exe/qt.conf
@@ -1,4 +1,4 @@
 # solves problem with binaries not launching on mac.
 # Suggested in https://github.com/pyinstaller/pyinstaller/issues/2857
 [Paths]
-Prefix = PyQt5/Qt
+Prefix = PySide2/Qt


### PR DESCRIPTION
This just updates the Qt plugins path to use the _actual_ plugins path.  This path has been broken for well over a year (probably a fair bit longer) and should probably have broken whenever we pinned our builds to always use PySide2 rather than PyQt.  I don't know why this stopped working ... there isn't anything material in the usual suspects (package versions, pyinstaller versions, etc.) that should have caused this failure.  So since that's a mystery, there's always a chance that the builds working on my fork here as a result of this change is just a fluke ... but it _did_ seem to be working.  It's not a particularly satisfying fix, but I'm willing to run with it if you are.

Fixes #773 ?


# Checklist
- ~~[ ] Updated HISTORY.rst (if these changes are user-facing)~~
- ~~[ ] Updated the user's guide (if needed)~~
