### PR TITLE
Restore accidentally-reverted codesigning updates

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -4,6 +4,10 @@ on:
     push:
     pull_request:
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
     check-syntax-errors:
         name: "Check for syntax errors"
@@ -56,7 +60,6 @@ jobs:
                   channels: conda-forge
 
             - name: Install python dependencies
-              shell: bash -l {0}
               run: |
                   conda install nomkl # make sure numpy is w/out MKL
                   conda upgrade -y pip setuptools
@@ -77,7 +80,6 @@ jobs:
                   ./ci/windows-ci-binary-install.ps1
 
             - name: Build userguide, binaries, installer
-              shell: bash -l {0}
               run: |
                   # This builds the users guide, binaries, and installer
                   make windows_installer
@@ -92,34 +94,21 @@ jobs:
             - name: Sign binaries
               # Secrets not available in PR so don't use GCP.
               if: github.event_name != 'pull_request'
-              shell: bash -l {0}
+              env:
+                CERT_FILE: Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
+                CERT_PASS: ${{ secrets.WINDOWS_CODESIGN_CERT_PASS }}
               run: |
                 # figure out the path to signtool.exe (it keeps changing with SDK updates)
                 SIGNTOOL_PATH=$(find 'C:\\Program Files (x86)\\Windows Kits\\10' -type f -name 'signtool.exe*' | head -n 1)
                 INSTALLER_BINARY=$(find "$(pwd)/dist" -type f -name 'InVEST_*.exe' | head -n 1)
 
-                # Specify which python version we want to use (it's the one we're using
-                # in actions/setup-python.
-                export CLOUDSDK_PYTHON=$(which python)
-                export CLOUDSDK_GSUTIL_PYTHON=$(which python)
-
                 # setup-gcloud adds 'gsutil' to PATH
-                make CERT_KEY_PASS=${{ secrets.STANFORD_CERT_KEY_PASS }} \
-                        GSUTIL="gsutil" \
-                        BIN_TO_SIGN="$INSTALLER_BINARY" \
-                        SIGNTOOL="$SIGNTOOL_PATH" \
-                        -s signcode_windows
+                make BIN_TO_SIGN="$INSTALLER_BINARY" SIGNTOOL="$SIGNTOOL_PATH" codesign_windows
 
             - name: Deploy artifacts to GCS
               # Secrets not available in PR so don't use GCP.
               if: github.event_name != 'pull_request'
-              shell: bash -l {0}
               run: |
-                  # Specify which python version we want to use (it's the one
-                  # we're using in actions/setup-miniconda)
-                  export CLOUDSDK_PYTHON=$(which python)
-                  export CLOUDSDK_GSUTIL_PYTHON=$(which python)
-
                   # setup-gcloud adds 'gsutil' to PATH
                   make GSUTIL="gsutil" deploy
 
@@ -178,7 +167,6 @@ jobs:
                   channels: conda-forge
 
             - name: Build conda env with python dependencies
-              shell: bash -l {0}
               run: |
                   conda upgrade -y pip setuptools
                   conda install toml requests
@@ -193,7 +181,6 @@ jobs:
                   conda install --yes libtiff
 
             - name: Build binaries
-              shell: bash -l {0}
               run: |
                   make install
                   make mac_dmg
@@ -208,16 +195,14 @@ jobs:
 
             - name: Sign DMG
               if: github.event_name != 'pull_request'
-              shell: bash -l {0}
               env:
-                CERT_KEY_PASS: ${{ secrets.STANFORD_CERT_KEY_PASS }}
-                KEYCHAIN_PASS: ${{ secrets.KEYCHAIN_PASS }}
-              run: make -s codesign_mac
+                CERT_FILE: 2025-01-16-Expiry-AppStore-App.p12
+                CERT_PASS: ${{ secrets.MACOS_CODESIGN_CERT_PASS }}
+              run: make codesign_mac
 
             - name: Deploy artifacts to GCS
               # Secrets not available in PR so don't use GCP.
               if: github.event_name != 'pull_request'
-              shell: bash -l {0}  # needed for conda activation
               run: make deploy
 
             - name: Upload binaries artifact
@@ -234,7 +219,6 @@ jobs:
 
             - name: Tar the workspace to preserve permissions
               if: ${{ failure() }}
-              shell: bash -l {0}
               run: tar -cvf InVEST-failed-mac-workspace.tar ${{ github.workspace }}
 
             - name: Upload workspace on failure

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ MAC_BINARIES_ZIP_FILE := "$(DIST_DIR)/InVEST-$(VERSION)-mac.zip"
 MAC_APPLICATION_BUNDLE := "$(BUILD_DIR)/mac_app_$(VERSION)/InVEST.app"
 
 
-.PHONY: fetch install binaries apidocs userguide windows_installer mac_dmg sampledata sampledata_single test test_ui clean help check python_packages jenkins purge mac_zipfile deploy signcode $(GIT_SAMPLE_DATA_REPO_PATH) $(GIT_TEST_DATA_REPO_PATH) $(GIT_UG_REPO_REV)
+.PHONY: fetch install binaries apidocs userguide windows_installer mac_dmg sampledata sampledata_single test test_ui clean help check python_packages jenkins purge mac_zipfile deploy codesign_mac codesign_windows $(GIT_SAMPLE_DATA_REPO_PATH) $(GIT_TEST_DATA_REPO_PATH) $(GIT_UG_REPO_REV)
 
 # Very useful for debugging variables!
 # $ make print-FORKNAME, for example, would print the value of the variable $(FORKNAME)
@@ -152,6 +152,8 @@ help:
 	@echo "  python_packages   to build natcap.invest wheel and source distributions"
 	@echo "  windows_installer to build an NSIS installer for distribution"
 	@echo "  mac_dmg           to build a disk image for distribution"
+	@echo "  codesign_mac      to sign the mac disk image using the codesign utility"
+	@echo "  codesign_windows  to sign the windows installer using the SignTool utility"
 	@echo "  sampledata        to build sample data zipfiles"
 	@echo "  sampledata_single to build a single self-contained data zipfile.  Used for advanced NSIS install."
 	@echo "  test              to run pytest on the tests directory"
@@ -356,49 +358,35 @@ $(MAC_BINARIES_ZIP_FILE): $(DIST_DIR) $(MAC_APPLICATION_BUNDLE) $(USERGUIDE_TARG
 build/vcredist_x86.exe: | build
 	powershell.exe -Command "Start-BitsTransfer -Source https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe -Destination build\vcredist_x86.exe"
 
-CERT_FILE := codesigning-2021.crt
-KEY_FILE := Stanford-natcap-code-signing-cert-expires-2024-01-26.key.pem
-P12_FILE := Stanford-natcap-code-signing-cert-expires-2024-01-26.p12
 KEYCHAIN_NAME := codesign_keychain
+# only need password to be able to create the keychain, not for security
+KEYCHAIN_PASS := password
 codesign_mac:
 	# download the p12 certificate file from google cloud
-	$(GSUTIL) cp 'gs://stanford_cert/$(P12_FILE)' '$(BUILD_DIR)/$(P12_FILE)'
+	$(GSUTIL) cp gs://stanford_cert/$(CERT_FILE) $(BUILD_DIR)/$(CERT_FILE)
 	# create a new keychain (so that we can know what the password is)
-	security create-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+	security create-keychain -p $(KEYCHAIN_PASS) $(KEYCHAIN_NAME)
 	# add the keychain to the search list so it can be found
-	security list-keychains -s '$(KEYCHAIN_NAME)'
+	security list-keychains -s $(KEYCHAIN_NAME)
 	# unlock the keychain so we can import to it (stays unlocked 5 minutes by default)
-	security unlock-keychain -p '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
+	security unlock-keychain -p $(KEYCHAIN_PASS) $(KEYCHAIN_NAME)
 	# add the certificate to the keychain
 	# -T option says that the codesign executable can access the keychain
 	# for some reason this alone is not enough, also need the following step
-	security import $(BUILD_DIR)/$(P12_FILE) -k '$(KEYCHAIN_NAME)' -P '$(CERT_KEY_PASS)' -T /usr/bin/codesign
+	security import $(BUILD_DIR)/$(CERT_FILE) -k $(KEYCHAIN_NAME) -P "$(CERT_PASS)" -T /usr/bin/codesign
 	# this is essential to avoid the UI password prompt
-	security set-key-partition-list -S apple-tool:,apple: -s -k '$(KEYCHAIN_PASS)' '$(KEYCHAIN_NAME)'
-	# sign the dmg using certificate that's looked up by unique identifier 'Stanford Univeristy'
-	codesign --timestamp --verbose --sign 'Stanford University' $(MAC_DISK_IMAGE_FILE)
-	# relock the keychain (not sure if this is important?)
-	security lock-keychain '$(KEYCHAIN_NAME)'
+	security set-key-partition-list -S apple-tool:,apple: -s -k $(KEYCHAIN_PASS) $(KEYCHAIN_NAME)
+	# sign the dmg using certificate that's looked up by unique identifier 'Stanford'
+	codesign --timestamp --verbose --sign Stanford $(MAC_DISK_IMAGE_FILE)
 
-signcode:
+codesign_windows:
 	$(GSUTIL) cp gs://stanford_cert/$(CERT_FILE) $(BUILD_DIR)/$(CERT_FILE)
-	$(GSUTIL) cp gs://stanford_cert/$(KEY_FILE) $(BUILD_DIR)/$(KEY_FILE)
-	# On some OS (including our build container), osslsigncode fails with Bus error if we overwrite the binary when signing.
-	osslsigncode -certs $(BUILD_DIR)/$(CERT_FILE) -key $(BUILD_DIR)/$(KEY_FILE) -pass $(CERT_KEY_PASS) -in $(BIN_TO_SIGN) -out "signed.exe"
-	mv "signed.exe" $(BIN_TO_SIGN)
+	"$(SIGNTOOL)" sign -fd SHA256 -f $(BUILD_DIR)/$(CERT_FILE) -p $(CERT_PASS) $(BIN_TO_SIGN)
+	"$(SIGNTOOL)" timestamp -tr http://timestamp.sectigo.com -td SHA256 $(BIN_TO_SIGN)
 	$(RM) $(BUILD_DIR)/$(CERT_FILE)
-	$(RM) $(BUILD_DIR)/$(KEY_FILE)
-	@echo "Installer was signed with osslsigncode"
-
-signcode_windows:
-	$(GSUTIL) cp 'gs://stanford_cert/$(P12_FILE)' '$(BUILD_DIR)/$(P12_FILE)'
-	powershell.exe "& '$(SIGNTOOL)' sign /fd SHA256 /f '$(BUILD_DIR)\$(P12_FILE)' /p '$(CERT_KEY_PASS)' '$(BIN_TO_SIGN)'"
-	powershell.exe "& '$(SIGNTOOL)' timestamp /tr http://timestamp.sectigo.com /td SHA256 '$(BIN_TO_SIGN)'"
-	-$(RM) $(BUILD_DIR)/$(P12_FILE)
 	@echo "Installer was signed with signtool"
 
 deploy:
-	-(cd $(INVEST_BINARIES_DIR) && $(ZIP) -r ../$(INVEST_BINARIES_DIR_ZIP) .)
 	-$(GSUTIL) -m rsync $(DIST_DIR) $(DIST_URL_BASE)
 	-$(GSUTIL) -m rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
 	-$(GSUTIL) -m rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide


### PR DESCRIPTION
First time using `git checkout --patch`!
Also deleted the `KEYCHAIN_PASS` and `STANFORD_CERT_KEY_PASS` secrets which are no longer needed.
Note that the codesigning steps don't run in PR workflows, so check that it's passing on [my branch](https://github.com/emlys/invest/tree/bugfix/gha-codesigning-wrong) instead. That's probably how this accidental revert slipped through (in an unrelated PR, where we didn't expect to look for it).
# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
