### PR TITLE
Fix debug logging bug

### DIFF
--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -14,7 +14,6 @@ from natcap.invest import MODEL_METADATA
 from natcap.invest import spec_utils
 from natcap.invest import usage
 
-logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
 
 app = Flask(__name__)


### PR DESCRIPTION
# Description
The problem was that `logging.basicConfig(level=logging.DEBUG)` was called in `ui_server.py`. This shouldn't be needed, since logging should already be configured at the entrypoint (`cli.py`). 

I triggered the problem in https://github.com/natcap/invest/commit/fca3a56f9a9e0ea7b3165eef7df78b5e90774b5e when I moved the `import ui_server` statement in `cli.py` up to the module level. That made `ui_server.py` and `basicConfig` get evaluated _before_ `cli.py` configured the root logger. It seems that `basicConfig` logs to stderr unless told otherwise.

# Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
