### PR TITLE
Fix Scenario Generator arg name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -95,6 +95,8 @@ Unreleased Changes (3.10)
       ``intermediate_outputs/what_drains_to_stream[suffix].tif``.  This raster
       has pixel values of 1 where DEM pixels flow to an identified stream, and
       0 where they do not.
+* Scenario Generator
+    * Changed an args key from ``replacment_lucode`` to ``replacement_lucode``.
 * Scenic Quality
     * Simplify the ``valuation_function`` arg options. The options are now:
       ``linear``, ``logarithmic``, ``exponential``. The names displayed in the

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 08ac77ba9927eb43d364e89100f228eeda994a3a
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := cadb55cca8406f217a24cf05ada64c96bda002b0
+GIT_UG_REPO_REV             := 3abb0fef58eb026b7d36a75eccdd2eb573c7e0f7
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := e1e8cb5f0d9088a469d7eda8a6feacc3199c8caf
+GIT_SAMPLE_DATA_REPO_REV    := 034ac3c6362b563989ec6b8dcd9d6fc4f582c911
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -42,7 +42,7 @@ ARGS_SPEC = {
             "about": _("Base map from which to generate scenarios."),
             "name": _("base LULC map")
         },
-        "replacment_lucode": {
+        "replacement_lucode": {
             "type": "integer",
             "about": _("The LULC code to which habitat will be converted."),
             "name": _("replacement landcover code")
@@ -133,7 +133,7 @@ def execute(args):
         args['results_suffix'] (string): (optional) string to append to any
             output files
         args['base_lulc_path'] (string): path to the base landcover map
-        args['replacment_lucode'] (string or int): code to replace when
+        args['replacement_lucode'] (string or int): code to replace when
             converting pixels
         args['area_to_convert'] (string or float): max area (Ha) to convert
         args['focal_landcover_codes'] (string): a space separated string of
@@ -192,7 +192,7 @@ def execute(args):
     task_graph = taskgraph.TaskGraph(work_token_dir, n_workers)
 
     area_to_convert = float(args['area_to_convert'])
-    replacement_lucode = int(args['replacment_lucode'])
+    replacement_lucode = int(args['replacement_lucode'])
 
     # convert all the input strings to lists of ints
     convertible_type_list = numpy.array([

--- a/tests/test_scenario_proximity.py
+++ b/tests/test_scenario_proximity.py
@@ -37,7 +37,7 @@ class ScenarioProximityTests(unittest.TestCase):
             'convertible_landcover_codes': '1 2 3 4 5',
             'focal_landcover_codes': '1 2 3 4 5',
             'n_fragmentation_steps': '1',
-            'replacment_lucode': '12',
+            'replacement_lucode': '12',
             'n_workers': '-1',
         }
         return args
@@ -141,7 +141,7 @@ class ScenarioGenValidationTests(unittest.TestCase):
         """Initiate list of required keys."""
         self.base_required_keys = [
             'focal_landcover_codes',
-            'replacment_lucode',
+            'replacement_lucode',
             'workspace_dir',
             'n_fragmentation_steps',
             'convertible_landcover_codes',


### PR DESCRIPTION
There was a consistent typo in an arg key. It was consistent everywhere except the UI file, which had the correct spelling. This PR corrects the spelling to match the UI file.

# Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)

- [x] Updated the user's guide (if needed)
