### PR TITLE
BUILDS: pyinstaller-numpy compatibility & NSIS in GHA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -344,7 +344,7 @@ jobs:
                     requirements.txt requirements-dev.txt \
                     requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
-                  make install
+                  python -m pip install .
 
             - name: Run UI tests
               shell: bash -l {0}

--- a/ci/windows-ci-binary-install.ps1
+++ b/ci/windows-ci-binary-install.ps1
@@ -17,14 +17,6 @@ $env:PATH += ";C:\ProgramData\chocolatey\bin"
 # Choco-provided command to reload environment variables
 refreshenv
 
-# Install NSIS.  The choco-provided NSIS puts it somewhere else and
-# the choco CLI option --install-directory isn't available in the OSS
-# version of choco.
-Invoke-WebRequest https://iweb.dl.sourceforge.net/project/nsis/NSIS%203/3.05/nsis-3.05-setup.exe -OutFile nsis.exe
-
-# See http://www.silentinstall.org/nsis for flags used.
-& nsis.exe /SD /D="C:\Program Files (x86)\NSIS"
-
 # Download and install NSIS plugins to their correct places.
 Write-Host "Downloading and extracting NSIS"
 Invoke-WebRequest https://storage.googleapis.com/natcap-build-dependencies/windows/Inetc.zip -OutFile Inetc.zip

--- a/installer/windows/invest_installer.nsi
+++ b/installer/windows/invest_installer.nsi
@@ -101,6 +101,7 @@ OutFile ..\..\dist\InVEST_${FORKNAME}${VERSION}_${ARCHITECTURE}_Setup.exe
 ShowInstDetails show
 BrandingText "2021 ${PRODUCT_PUBLISHER}"
 SetCompressor zlib
+Unicode false
 
 ; Include after SetCompressor
 !include Utils.nsh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # will dynamically import GDAL via python's import system.  This behavior means
 # that we can provide a much easier build experience so long as GDAL is
 # available at runtime.
-requires = ['setuptools>=45', 'wheel', 'setuptools_scm>=6.2', 'numpy', 'cython']
+requires = ['setuptools>=45', 'wheel', 'setuptools_scm>=6.2', 'numpy<1.22.0', 'cython']
 
 [tool.setuptools_scm]
 version_scheme = "post-release"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 GDAL>=3.1.2,!=3.3.0  # 3.3.0 had a bug that broke our windows builds: https://github.com/OSGeo/gdal/issues/3898
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
-numpy>=1.11.0,!=1.16.0
+numpy>=1.11.0,!=1.16.0,<1.22.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only


### PR DESCRIPTION
Temporarily addresses #796 by restricting numpy version. That keeps our builds working until Pyinstaller makes a release with an updated numpy hook.

We also had some NSIS issues to resolve:
1. NSIS is already pre-installed in GHA Windows VMs, so we don't need to install it ourselves
2. Apparently we don't have a unicode-compatible installer, so need to set that flag appropriately in the nsis script

Finally, we have very weird python build issues with python 3.9.9, but only on the UI test step. I replaced `make install` with `python -m pip install .` and that worked, but I can't explain why. 

# Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)

- [ ] Updated the user's guide (if needed)
