### PR TITLE
restore accidentally deleted zip command in make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,11 +392,12 @@ codesign_windows:
 	@echo "Installer was signed with signtool"
 
 deploy:
+	-(cd $(INVEST_BINARIES_DIR) && $(ZIP) -r ../$(INVEST_BINARIES_DIR_ZIP) .)
 	-$(GSUTIL) -m rsync $(DIST_DIR) $(DIST_URL_BASE)
 	-$(GSUTIL) -m rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
 	-$(GSUTIL) -m rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
 	@echo "Application binaries (if they were created) can be downloaded from:"
-	@echo "  * $(DOWNLOAD_DIR_URL)/$(subst $(DIST_DIR)/,,$(WINDOWS_INSTALLER_FILE))"
+	@echo "  * $(DOWNLOAD_DIR_URL)"
 
 # Notes on Makefile development
 #


### PR DESCRIPTION
## Description
Looks like I accidentally deleted the line of `make deploy` that creates `windows_invest_binaries.zip` and `mac_invest_binaries.zip` in [this PR](https://github.com/natcap/invest/commit/50c1a2ac9aedc88e5568fb5521ed923b2be2609e#). In the workbench, `fetch-invest` expects those to exist.

## Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
