### PR TITLE
Fix versioning for uploaded sample data

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -250,6 +250,10 @@ jobs:
               with:
                   python-version: 3.8
 
+            - name: Install dependencies
+              # dependencies of setup.py, needed to get the version string
+              run: pip install babel cython numpy setuptools setuptools_scm wheel
+
             - run: make sampledata sampledata_single
 
             - name: Authenticate GCP


### PR DESCRIPTION
## Description
Fixes #833 
The zip file name now contains the version in the "Deploy artifacts to GCS" step on my fork: https://github.com/emlys/invest/runs/4945648840?check_suite_focus=true

I did not go back to the previous approach reading from the toml file: `pip install $(python -c "import toml;print(' '.join(toml.load('pyproject.toml')['build-system']['requires']))")` because it's very finicky getting it to work with the environment markers. And we'll be removing `setup.py --version` soon anyway.

I wish there was a way to document the makefile's python dependencies better. Or at least exit if one is missing. I guess the error from the shell command in `VERSION := $(shell $(PYTHON) setup.py --version)` doesn't raise an error in the shell `make` is running in. I wasn't able to find any info about errors in variable assignment like this.

## Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
