### PR TITLE
Fix HRA pandas df call

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -48,6 +48,10 @@ Unreleased Changes
       one stream pixel, it will now snap to the stream pixel with a higher
       flow accumulation value. Before, it would snap to the stream pixel
       encountered first in the raster (though this was not guaranteed).
+* HRA
+    * Fixed a bug with how a pandas dataframe was instantiated. This bug did
+      not effect outputs though some might notice less trailing zeros in the
+      ``SUMMARY_STATISTICS.csv`` output.
 * NDR
     * Changed some model inputs and outputs to clarify that subsurface
       phosphorus is not modeled.

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1183,7 +1183,7 @@ def _zonal_stats_to_csv(
         ['E_']*len_crit_cols + ['C_']*len_crit_cols + ['R_']*len_risk_cols,
         crit_stats_cols*2 + risk_stats_cols)
 
-    stats_df = pandas.DataFrame(index=overlap_df.index, columns=columns)
+    stats_df = pandas.DataFrame(index=overlap_df.index, columns=list(columns))
 
     # Add a ``SUBREGION`` column to the dataframe and update it with the
     # corresponding stats in each subregion


### PR DESCRIPTION
With pandas 1.4.0 a ValueError was being raised from the creation of a pandas df. After reviewing the call it seems that the df has been creating improperly. The df has been taking a map object iterable for the columns argument and failing to create the desired columns. I believe this was an uncaught exception in pandas which is now being properly handled in 1.4.0. However, because of how the rest of the function uses that df, the columns are created and added anyway such that no changes need to be made to the tests.

See issue #835 for a detailed run down.

## Description
Fixes #835 

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
