### PR TITLE
Task/796 numpy compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -143,6 +143,7 @@ jobs:
                   path: dist
 
             - uses: actions/upload-artifact@v2
+              continue-on-error: true
               with:
                   name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.python-architecture }}
                   path: ./conda-env.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 GDAL>=3.1.2,!=3.3.0  # 3.3.0 had a bug that broke our windows builds: https://github.com/OSGeo/gdal/issues/3898
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
-numpy>=1.11.0,!=1.16.0,<1.22.0
+numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 GDAL>=3.1.2,!=3.3.0  # 3.3.0 had a bug that broke our windows builds: https://github.com/OSGeo/gdal/issues/3898
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
-numpy>=1.11.0,!=1.16.0
+numpy>=1.11.0,!=1.16.0,>=1.21.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 GDAL>=3.1.2,!=3.3.0  # 3.3.0 had a bug that broke our windows builds: https://github.com/OSGeo/gdal/issues/3898
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
-numpy>=1.11.0,!=1.16.0,>=1.21.0
+numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
 scipy>=1.6.0  # pip-only

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -362,7 +362,7 @@ class CarbonValidationTests(unittest.TestCase):
         if parse_version(numpy.__version__) >= parse_version('1.22'):
             expected_value = 492919.769386
         else:
-            expected_value = 492919.73994
+            expected_value = 492919.739940
         # Verify better-than-float32 precision on raster summation.
         # Using a numpy float32 in numpy.sum will pass up to rtol=1e-9.
         numpy.testing.assert_allclose(

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -341,6 +341,7 @@ class CarbonValidationTests(unittest.TestCase):
 
     def test_carbon_totals_precision(self):
         """Carbon: check float64 precision in pixel value summation."""
+        from pkg_resources import parse_version
         from natcap.invest import carbon
 
         big_float32_array = numpy.random.default_rng(seed=1).random(
@@ -358,9 +359,13 @@ class CarbonValidationTests(unittest.TestCase):
             big_float32_array, float(nodata), (2, -2), (2, -2), wkt,
             raster_path)
 
+        if parse_version(numpy.__version__) >= parse_version('1.22'):
+            expected_value = 492919.769386
+        else:
+            expected_value = 492919.73994
         # Verify better-than-float32 precision on raster summation.
         # Using a numpy float32 in numpy.sum will pass up to rtol=1e-9.
         numpy.testing.assert_allclose(
             carbon._accumulate_totals(raster_path),
-            492919.769386,
+            expected_value,
             rtol=1e-12)  # Note better precision

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -338,34 +338,3 @@ class CarbonValidationTests(unittest.TestCase):
              'lulc_cur_year',
              'lulc_fut_year'])
         self.assertEqual(invalid_keys, expected_missing_keys)
-
-    def test_carbon_totals_precision(self):
-        """Carbon: check float64 precision in pixel value summation."""
-        from pkg_resources import parse_version
-        from natcap.invest import carbon
-
-        big_float32_array = numpy.random.default_rng(seed=1).random(
-            (1000, 1000), dtype=numpy.float32)
-
-        # Throw in some nodata values for good measure.
-        nodata = numpy.finfo(numpy.float32).min
-        big_float32_array[1:15] = nodata
-
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(32731)  # WGS84/UTM zone 31s
-        wkt = srs.ExportToWkt()
-        raster_path = os.path.join(self.workspace_dir, 'raster.tif')
-        pygeoprocessing.numpy_array_to_raster(
-            big_float32_array, float(nodata), (2, -2), (2, -2), wkt,
-            raster_path)
-
-        if parse_version(numpy.__version__) >= parse_version('1.22'):
-            expected_value = 492919.769386
-        else:
-            expected_value = 492919.739940
-        # Verify better-than-float32 precision on raster summation.
-        # Using a numpy float32 in numpy.sum will pass up to rtol=1e-9.
-        numpy.testing.assert_allclose(
-            carbon._accumulate_totals(raster_path),
-            expected_value,
-            rtol=1e-12)  # Note better precision

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -362,5 +362,5 @@ class CarbonValidationTests(unittest.TestCase):
         # Using a numpy float32 in numpy.sum will pass up to rtol=1e-9.
         numpy.testing.assert_allclose(
             carbon._accumulate_totals(raster_path),
-            492919.73994,
+            492919.769386,
             rtol=1e-12)  # Note better precision


### PR DESCRIPTION
Removed the restriction on numpy version since there has been a compatible pyinstaller release.
Fixes #796 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
