### PR TITLE
Ensure kernels are tiled in HRA and GLOBIO

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,9 @@ Unreleased Changes
       one stream pixel, it will now snap to the stream pixel with a higher
       flow accumulation value. Before, it would snap to the stream pixel
       encountered first in the raster (though this was not guaranteed).
+* Habitat Quality:
+    * Linear decay kernels are now always tiled, which should result in a minor
+      improvement in model runtime, particularly with large decay distances.
 * HRA
     * Fixed a bug with how a pandas dataframe was instantiated. This bug did
       not effect outputs though some might notice less trailing zeros in the

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,9 @@ Unreleased Changes
       one stream pixel, it will now snap to the stream pixel with a higher
       flow accumulation value. Before, it would snap to the stream pixel
       encountered first in the raster (though this was not guaranteed).
+* GLOBIO
+    * Gaussian decay kernels are now always tiled, which should result in a
+      minor improvement in model runtime when large decay distances are used.
 * Habitat Quality:
     * Linear decay kernels are now always tiled, which should result in a minor
       improvement in model runtime, particularly with large decay distances.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest
 pytest-subtests
 wheel>=0.27.0
 pypiwin32; sys_platform == 'win32'  # pip-only
-setuptools>=8.0,<60.7.0  # https://github.com/pyinstaller/pyinstaller/issues/6564
+setuptools>=8.0
 Sphinx>=1.3.1,!=1.7.1
 sphinx-rtd-theme
 sphinx-intl

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest
 pytest-subtests
 wheel>=0.27.0
 pypiwin32; sys_platform == 'win32'  # pip-only
-setuptools>=8.0
+setuptools>=8.0,<60.7.0  # https://github.com/pyinstaller/pyinstaller/issues/6564
 Sphinx>=1.3.1,!=1.7.1
 sphinx-rtd-theme
 sphinx-intl

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -1,22 +1,21 @@
 """GLOBIO InVEST Model."""
-import os
-import logging
 import collections
+import logging
+import os
 import tempfile
 
-from osgeo import gdal
-from osgeo import ogr
-from osgeo import osr
 import numpy
 import pygeoprocessing
 import taskgraph
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
 
-from . import utils
-from . import spec_utils
-from .spec_utils import u
-from . import validation
 from . import MODEL_METADATA
-
+from . import spec_utils
+from . import utils
+from . import validation
+from .spec_utils import u
 
 LOGGER = logging.getLogger(__name__)
 
@@ -718,7 +717,9 @@ def make_gaussian_kernel_path(sigma, kernel_path):
     driver = gdal.GetDriverByName('GTiff')
     kernel_dataset = driver.Create(
         kernel_path.encode('utf-8'), kernel_size, kernel_size, 1,
-        gdal.GDT_Float32, options=['BIGTIFF=IF_SAFER'])
+        gdal.GDT_Float32, options=[
+            'BIGTIFF=IF_SAFER', 'TILED=YES', 'BLOCKXSIZE=256',
+            'BLOCKYSIZE=256'])
 
     # Make some kind of geotransform, it doesn't matter what but
     # will make GIS libraries behave better if it's all defined

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -1,20 +1,20 @@
 # coding=UTF-8
 """InVEST Habitat Quality model."""
 import collections
-import os
 import logging
+import os
 
 import numpy
-from osgeo import gdal
-from osgeo import osr
 import pygeoprocessing
 import taskgraph
+from osgeo import gdal
+from osgeo import osr
 
-from . import utils
-from . import spec_utils
-from .spec_utils import u
-from . import validation
 from . import MODEL_METADATA
+from . import spec_utils
+from . import utils
+from . import validation
+from .spec_utils import u
 
 LOGGER = logging.getLogger(__name__)
 
@@ -939,7 +939,9 @@ def _make_linear_decay_kernel_path(max_distance, kernel_path):
     driver = gdal.GetDriverByName('GTiff')
     kernel_dataset = driver.Create(
         kernel_path.encode('utf-8'), kernel_size, kernel_size, 1,
-        gdal.GDT_Float32, options=['BIGTIFF=IF_SAFER'])
+        gdal.GDT_Float32, options=[
+            'BIGTIFF=IF_SAFER', 'TILED=YES', 'BLOCKXSIZE=256',
+            'BLOCKYSIZE=256'])
 
     # Make some kind of geotransform, it doesn't matter what but
     # will make GIS libraries behave better if it's all defined


### PR DESCRIPTION
This PR tiles convolution kernels in Habitat Quality and GLOBIO that were not yet tiled.  This is done through setting some GDAL options and should produce no functional change on the sample data.  The only consequence of this improvement should be improved runtimes in convolutions (particularly with large kernels) and should also help avoid a case where a large-enough kernel would cause an underlying error in pygeoprocessing to be raised.

I left off automated tests for this because ensuring something is tiled feels like a GDAL-level issue and not something that InVEST should manage, but let me know if you disagree!

This PR is a stop-gap to mitigate this bug in response to a forums post (https://community.naturalcapitalproject.org/t/habitatquality-error-encountered-in-threats-table-threats-distribution-map/2476).  I think the real solution here is in #731  and will involve a redesign of how we work with convolution kernels.

Fixes #843 

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
