### PR TITLE
Autorelease/3.10.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,8 +32,12 @@
 
 .. :changelog:
 
-Unreleased Changes
-------------------
+..
+  Unreleased Changes
+  ------------------
+
+3.10.2 (2022-02-07)
+-------------------
 * General
     * The minimum ``setuptools_scm`` version has been increased to 6.4.0 in
       order to bypass calling ``setup.py`` for version information.  The

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,7 @@
   Unreleased Changes
   ------------------
 
-3.10.2 (2022-02-07)
+3.10.2 (2022-02-08)
 -------------------
 * General
     * The minimum ``setuptools_scm`` version has been increased to 6.4.0 in

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := ac7023d684478485fea89c68f8f4154163541e1d
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := e4853ade5280b7aae9074c12d56ac0704edaa7e1
+GIT_UG_REPO_REV             := cc1a43b46cc6ffb1de814553a8306d145e228394
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := ac7023d684478485fea89c68f8f4154163541e1d
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 3694e4b33856354be0ea995f4f611d654f59bc23
+GIT_UG_REPO_REV             := e4853ade5280b7aae9074c12d56ac0704edaa7e1
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
-scipy>=1.6.0  # pip-only
+scipy>=1.6.0,<1.8.0  # pip-only
 pygeoprocessing>=2.3.2  # pip-only
 taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6


### PR DESCRIPTION
3.10.2 release. Also pinning scipy<1.8.0 because that seems to fix the mac binary build issue #880 

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
