### PR TITLE
Bugfix/rec 20 server memory

### DIFF
--- a/scripts/recreation_server/execute_recmodel_server.py
+++ b/scripts/recreation_server/execute_recmodel_server.py
@@ -1,0 +1,19 @@
+import logging
+import multiprocessing
+
+import natcap.invest.recreation.recmodel_server
+
+logging.basicConfig(format='%(asctime)s %(name)-20s %(levelname)-8s %(message)s', level=logging.DEBUG, datefmt='%m/%d/%Y %H:%M:%S ')
+
+args = {
+    'hostname': '10.240.0.4',
+    'port': 54322,
+    'raw_csv_point_data_path': 'photos_2005-2017_odlla.csv',
+    'max_year': 2017,
+    'min_year': 2005,
+    'cache_workspace': './recserver_cache_py36'
+}
+
+if __name__ == '__main__':
+    multiprocessing.set_start_method('spawn')
+    natcap.invest.recreation.recmodel_server.execute(args)

--- a/scripts/recreation_server/execute_recmodel_server.py
+++ b/scripts/recreation_server/execute_recmodel_server.py
@@ -3,17 +3,24 @@ import multiprocessing
 
 import natcap.invest.recreation.recmodel_server
 
-logging.basicConfig(format='%(asctime)s %(name)-20s %(levelname)-8s %(message)s', level=logging.DEBUG, datefmt='%m/%d/%Y %H:%M:%S ')
+logging.basicConfig(
+    format='%(asctime)s %(name)-20s %(levelname)-8s %(message)s',
+    level=logging.DEBUG, datefmt='%m/%d/%Y %H:%M:%S ')
 
 args = {
-    'hostname': '10.240.0.4',
+    'hostname': '',  # the local IP for the server
     'port': 54322,
     'raw_csv_point_data_path': 'photos_2005-2017_odlla.csv',
     'max_year': 2017,
     'min_year': 2005,
-    'cache_workspace': './recserver_cache_py36'
+    'cache_workspace': './recmodel_server_cache'  # a local directory
 }
 
 if __name__ == '__main__':
+    # It's crucial to specify `spawn` here as some OS use 'fork' as the default
+    # for new child processes. And a 'fork' will immediately duplicate all
+    # the resources (memory) of the parent. We noticed that causing
+    # Cannot Allocate Memory errors, as the recmodel_server can start child
+    # processes at a point when it's already using a lot of memory.
     multiprocessing.set_start_method('spawn')
     natcap.invest.recreation.recmodel_server.execute(args)

--- a/scripts/recreation_server/launch_recserver.sh
+++ b/scripts/recreation_server/launch_recserver.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source /home/davemfish/miniconda3/etc/profile.d/conda.sh
+conda activate ./invest/env/
+nohup python -u execute_recmodel_server.py > nohup_recmodel_server.txt 2>&1 &

--- a/scripts/recreation_server/readme.txt
+++ b/scripts/recreation_server/readme.txt
@@ -1,0 +1,57 @@
+To start the rec server:  sudo ./launch_recserver.sh
+****************************************************
+If the server is already running, the port won't be available, and sometimes there are some
+zombie processes leftover after a crash. It can be useful to `sudo killall python` before launching.
+See the commands in the shell script for more details, like the name of the logfile.
+
+-----------------
+DF - Sep 21, 2020
+
+installed natcap.invest from github.com/natcap/invest:release/3.9 to get the latest server
+bugfixes related to issue #304.
+
+--------------
+DF - Sep, 2020
+
+For a while we had two servers up, one running python3 and one running python27 for compatibility
+with old invest clients. That's why there are two cache directories. For a few months we have
+only had the python3 server running and no one has complained.
+
+-----------------
+DF - Oct 17, 2019
+
+Updated the invest-davemfish/invest-env-py36 environment to branch feature/INVEST-3923-Migrate-to-Python37
+The recmodel_server code running here is cross-compatible with python36, so I didn't bother creating a
+new 3.7 env.
+
+-----------------
+DF - July 8, 2019
+
+We're doing python 3 updates. 
+./invest-davemfish is a src tree with branch bugfix/PYTHON3-3895-27to36-compatibility
+./invest-davemfish/invest-env-py36/ is a python3 env created with conda with the above branch installed.
+('conda' should be available to all users. 
+e.g. conda activate /usr/local/recreation_server/invest-davemfish/invest-env-py36
+
+We launched a rec server from that environment on port 54322.
+It will be live alongside the python 2 server that's already on port 54321
+They share data including the input CSV table and the recserver_cache_2017/
+
+The invest bugfix/PYTHON3-3895-27to36-compatibility client source defaults to port 54322
+Once this branch has been merged and released, we can kill the python 2 server on 54321.
+
+The new port also required:
+data.naturalcapitalproject.org/server_registry/invest_recreation_model_py36/index.html
+
+----------------
+DF - July 2 2018
+
+I'm building the cache from the 2005-2017 table. I used launch_2017.sh with recserver_cache_2017 as the cache directory, and 55555 as the port.
+The idea is to build the cache/quadtree without disrupting the existing server running on port 54321. 
+Then after the new cache is built: 
+
+* kill the 'dummy' server on 55555 
+* kill the 'real' server on 54321
+* rename the 2017 cache dir back to recserver_cache 
+* relaunch a server with the 2005-2017 table on port 54321.
+        code should recognize that the quadtree already exists and skip that long process.

--- a/src/natcap/invest/recreation/recmodel_server.py
+++ b/src/natcap/invest/recreation/recmodel_server.py
@@ -1,6 +1,5 @@
 """InVEST Recreation Server."""
-import tracemalloc
-import gc
+
 import subprocess
 import os
 import multiprocessing
@@ -199,11 +198,8 @@ class RecModel(object):
                 run on the server
 
         """
-        tracemalloc.start()
         # make a random workspace name so we can work in parallel
         workspace_id = str(uuid.uuid4())
-        current, peak = tracemalloc.get_traced_memory()
-        print(f"Start of new job: Current memory usage for {workspace_id} is {current / 10**6}MB; Peak was {peak / 10**6}MB")
         workspace_path = os.path.join(self.cache_workspace, workspace_id)
         os.makedirs(workspace_path)
 
@@ -224,14 +220,10 @@ class RecModel(object):
         numpy_date_range = (
             numpy.datetime64(date_range[0]),
             numpy.datetime64(date_range[1]))
-        current, peak = tracemalloc.get_traced_memory()
-        print(f"Before PUD Calc: Current memory usage for {workspace_id} is {current / 10**6}MB; Peak was {peak / 10**6}MB")
         base_pud_aoi_path, monthly_table_path = (
             self._calc_aggregated_points_in_aoi(
                 aoi_path, workspace_path, numpy_date_range,
-                out_vector_filename, workspace_id))
-        current, peak = tracemalloc.get_traced_memory()
-        print(f"After all calcs: Current memory usage for {workspace_id} is {current / 10**6}MB; Peak was {peak / 10**6}MB")
+                out_vector_filename))
 
         # ZIP and stream the result back
         LOGGER.info('zipping result')
@@ -248,10 +240,9 @@ class RecModel(object):
             'calc user days complete sending binary back on %s',
             workspace_path)
         return open(aoi_pud_archive_path, 'rb').read(), workspace_id
-        tracemalloc.stop()
 
     def _calc_aggregated_points_in_aoi(
-            self, aoi_path, workspace_path, date_range, out_vector_filename, workspace_id):
+            self, aoi_path, workspace_path, date_range, out_vector_filename):
         """Aggregate the PUD in the AOI.
 
         Args:
@@ -388,9 +379,6 @@ class RecModel(object):
                     local_qt_pickle_filename, aoi_path, date_range,
                     poly_test_queue, pud_poly_feature_queue))
             polytest_process.daemon = True
-            # gc.collect() # no change
-            current, peak = tracemalloc.get_traced_memory()
-            print(f"Before Fork: Current memory usage for {workspace_id} is {current / 10**6}MB; Peak was {peak / 10**6}MB")
             polytest_process.start()
             polytest_process_list.append(polytest_process)
 


### PR DESCRIPTION
This PR adds some utility scripts we use on the recmodel server. In particular the python script to launch the server process, which now has a key `multiprocessing` config to use `spawn` instead of `fork` for child processes. That should help address `CannotAllocateMemory` errors when child processes are started during a very large run.

Fixes #20 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
