### PR TITLE
move install out of conditional workflow step

### DIFF
--- a/.github/workflows/binary-applications.yml
+++ b/.github/workflows/binary-applications.yml
@@ -63,7 +63,6 @@ jobs:
                         requirements-dev.txt \
                         requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
-                  make install
 
               # Not caching chocolatey packages because the cache may not be reliable
               # https://github.com/chocolatey/choco/issues/2134
@@ -77,6 +76,7 @@ jobs:
 
             - name: Build userguide, binaries, installer
               run: |
+                  make install
                   # This builds the users guide, binaries, and installer
                   make windows_installer
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -287,11 +287,12 @@ jobs:
                   conda upgrade -y pip wheel
                   python ./scripts/convert-requirements-to-conda-yml.py requirements.txt > requirements.yml
                   conda env update --file requirements.yml
-                  make install
 
             - name: Validate sample data
               shell: bash -l {0}
-              run: make validate_sampledata
+              run: |
+                make install
+                make validate_sampledata
 
             - name: Validate user guide links
               shell: bash -l {0}
@@ -339,12 +340,13 @@ jobs:
                     requirements.txt requirements-dev.txt \
                     requirements-gui.txt > requirements-all.yml
                   conda env update --file requirements-all.yml
-                  python -m pip install .
 
             - name: Run UI tests
               shell: bash -l {0}
               timeout-minutes: 10  # tests usually take < 2 minutes, so 10 is generous.
-              run: make test_ui
+              run: |
+                python -m pip install .
+                make test_ui
 
     run-workbench-tests:
         name: "Run Workbench Tests"


### PR DESCRIPTION
## Description
Fixes bug where invest was not being reinstalled in some jobs, if a cached version existed.

## Checklist
- ~[ ] Updated HISTORY.rst (if these changes are user-facing)~
- ~[ ] Updated the user's guide (if needed)~
- ~[ ] Tested the affected models' UIs (if relevant)~
