### PR TITLE
Auto-pr workflow - handle the case where there are no release branches

### DIFF
--- a/.github/workflows/auto-pr-from-main-into-releases.yml
+++ b/.github/workflows/auto-pr-from-main-into-releases.yml
@@ -50,7 +50,14 @@ jobs:
           fi
 
           # Using grep with pattern ^release filters out any autorelease branches.
-          BRANCHES=$(git ls-remote --heads origin | cut -d '/' -f 3- | grep ^release)
+          # If no release branches are found, exit github actions.
+          BRANCHES=$(git ls-remote --heads origin | cut -d '/' -f 3- | grep ^release || echo '')
+          if [ -z "$BRANCHES" ]
+          then
+              echo "No release branches found; exiting github actions workflow."
+              exit 0
+          fi
+
           echo $BRANCHES  # debugging
           ERRORSPRESENT=0
           for BRANCH in $BRANCHES


### PR DESCRIPTION
This case is now logged and the shell will exit with 0 exit status,
avoiding a failure.  RE:#898

I've tested the requisite bash locally, though not in GHA directly.

## Description
Fixes # 898

## Checklist
- ~~[ ] Updated HISTORY.rst (if these changes are user-facing)~~
- ~~[ ] Updated the user's guide (if needed)~~
- ~~[ ] Tested the affected models' UIs (if relevant)~~
