### PR TITLE
Adding missing f path to the sediment deposition target path list.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,9 @@ Unreleased Changes
     * Rename the arg ``calculate_downstream_distance`` to
       ``calculate_downslope_distance``. This is meant to clarify that it
       applies to pixels that are not part of a stream.
+* SDR
+    * Fixed an issue with SDR where ``f.tif`` might not be recalculated if the
+      file is modified or deleted after execution.
 
 3.10.2 (2022-02-08)
 -------------------

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -560,7 +560,7 @@ def execute(args):
             f_reg['f_path'], f_reg['sdr_path'],
             f_reg['sed_deposition_path']),
         dependent_task_list=[e_prime_task, sdr_task, flow_dir_task],
-        target_path_list=[f_reg['sed_deposition_path']],
+        target_path_list=[f_reg['sed_deposition_path'], f_reg['f_path']],
         task_name='sediment deposition')
 
     _ = task_graph.add_task(


### PR DESCRIPTION
## Description

This corrects a minor issue in the SDR task graph where `f.tif` was not in the target path list for the sediment deposition task, though it should have been.

Such a minor bug and there's no issue in the tracker for it, so none are linked.


## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
