### PR TITLE
Resolve scipy dylib issue with pyinstaller in mac binary builds

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -38,6 +38,7 @@ runs:
       with:
         auto-update-conda: true
         channels: conda-forge
+        mamba-version: '*'
 
     # save week number to use in next step
     # save CONDA_PREFIX to GITHUB_ENV so it's accessible outside of shell commands
@@ -76,7 +77,7 @@ runs:
     - name: Update environment with dependencies
       if: steps.condacache.outputs.cache-hit != 'true'
       shell: bash -l {0} # conda only available in login shell
-      run: conda env update --file environment.yml
+      run: mamba env update --file environment.yml
 
     - name: List conda environment
       shell: bash -l {0} # conda only available in login shell

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -38,7 +38,6 @@ runs:
       with:
         auto-update-conda: true
         channels: conda-forge
-        mamba-version: '*'
 
     # save week number to use in next step
     # save CONDA_PREFIX to GITHUB_ENV so it's accessible outside of shell commands
@@ -77,7 +76,7 @@ runs:
     - name: Update environment with dependencies
       if: steps.condacache.outputs.cache-hit != 'true'
       shell: bash -l {0} # conda only available in login shell
-      run: mamba env update --file environment.yml
+      run: conda env update --file environment.yml
 
     - name: List conda environment
       shell: bash -l {0} # conda only available in login shell

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,9 @@
 
 Unreleased Changes
 ------------------
+* General
+    * Updating the ``pyinstaller`` requirement to ``>=4.10`` to support the new
+      ``universal2`` wheel architecture offered by ``scipy>=1.8.0``.
 * RouteDEM
     * Rename the arg ``calculate_downstream_distance`` to
       ``calculate_downslope_distance``. This is meant to clarify that it

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ Sphinx>=1.3.1,!=1.7.1
 sphinx-rtd-theme  # pip-only
 sphinx-intl
 sphinx-reredirects  # pip-only
-PyInstaller>=4.1
+PyInstaller>=4.10
 setuptools_scm>=6.4.0
 requests
 coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
-scipy>=1.6.0  # pip-only
+scipy>=1.6.0
 pygeoprocessing>=2.3.2  # pip-only
 taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 Shapely>=1.7.1,<2.0.0
-scipy>=1.6.0,<1.8.0  # pip-only
+scipy>=1.6.0  # pip-only
 pygeoprocessing>=2.3.2  # pip-only
 taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6


### PR DESCRIPTION
## Description

This PR does 2 things:
* Uses `conda-forge`'s `scipy` instead of the one from PyPI
* Removes the `scipy<1.8.0` constraint

Although pyinstaller 4.10 is supposed to resolve the issue with scipy's `universal2` platform tag, it looked like there was another underlying and related issue with the numpy version we were using when imported through pandas.  Removing the `# pip-only` comment in `requirements.txt` so that we fetch `scipy` from `conda-forge` resolved the issue and the binaries appear to be working fine on my `arm` laptop.

I don't remember why we made `scipy` be `# pip-only`, so if there's something I'm missing or forgetting here, happy to revisit!

@emlys if you get a chance, could you try out the InVEST binaries from this PR?  Here's a recent mac artifact from this branch: https://github.com/phargogh/invest/suites/5777422756/artifacts/192493329

Though there's also a really interesting backburner question of whether to use constraints files, #916 


Fixes #880

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the affected models' UIs (if relevant)
