### PR TITLE
Workbench sampledata link-checks bugfix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -512,13 +512,6 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Check sampledata registry links
-        if: github.event_name != 'pull_request' # no artifacts were deployed in a PR
-        working-directory: workbench
-        run: |
-          yarn add jest
-          yarn run test-sampledata-registry
-
       - name: Upload sample data artifact
         uses: actions/upload-artifact@v2
         with:
@@ -538,3 +531,10 @@ jobs:
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
         run: make deploy
+
+      - name: Check sampledata registry links after deploy
+        if: github.event_name != 'pull_request' # no artifacts were deployed in a PR
+        working-directory: workbench
+        run: |
+          yarn add jest
+          yarn run test-sampledata-registry

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -461,7 +461,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Workbench-${{ runner.os }}-binary
-          path: workbench/dist/*.{{ matrix.binary-extension }}
+          path: workbench/dist/*.${{ matrix.binary-extension }}
 
       - name: Upload user's guide artifact (Windows)
         if: matrix.os == 'windows-latest'

--- a/workbench/scripts/build_sampledata_registry.py
+++ b/workbench/scripts/build_sampledata_registry.py
@@ -2,15 +2,19 @@ import json
 import os
 import sys
 
-REGISTRY_PATH = os.path.join(
+DEFAULT_REGISTRY_PATH = os.path.join(
     os.path.dirname(__file__),
     '../src/renderer/sampledata_registry.json')
+
+TARGET_REGISTRY_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '../src/renderer/sampledata_registry_production.json')
 
 if __name__ == '__main__':
     storage_url = sys.argv[1]
     zip_dir = sys.argv[2]
 
-    with open(REGISTRY_PATH, 'r') as json_file:
+    with open(DEFAULT_REGISTRY_PATH, 'r') as json_file:
         registry = json.load(json_file)
         for model, data in registry.items():
             zipname = data['filename']
@@ -18,5 +22,5 @@ if __name__ == '__main__':
                 os.path.join(zip_dir, zipname)).st_size
             registry[model]['url'] = f'{storage_url}/{zipname}'
 
-    with open(REGISTRY_PATH, 'w') as json_file:
+    with open(TARGET_REGISTRY_PATH, 'w') as json_file:
         json_file.write(json.dumps(registry, indent=2))

--- a/workbench/src/renderer/components/DataDownloadModal/index.jsx
+++ b/workbench/src/renderer/components/DataDownloadModal/index.jsx
@@ -23,7 +23,7 @@ export class DataDownloadModal extends React.Component {
       allLinksArray: [],
       selectedLinksArray: [],
       dataListCheckBoxes: {},
-      sampledataRegistry: {},
+      sampledataRegistry: null,
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -39,7 +39,6 @@ export class DataDownloadModal extends React.Component {
       sampledataRegistry = await import('../../sampledata_registry.json');
     }
     delete sampledataRegistry.default; // the default property was added by import
-    console.log(sampledataRegistry)
     const linksArray = [];
     const dataListCheckBoxes = {};
     Object.entries(sampledataRegistry)
@@ -124,6 +123,9 @@ export class DataDownloadModal extends React.Component {
       selectedLinksArray,
       sampledataRegistry,
     } = this.state;
+    // Don't render until registry is loaded, since it loads async
+    if (!sampledataRegistry) { return <div />; }
+
     const downloadEnabled = Boolean(selectedLinksArray.length);
     const DatasetCheckboxRows = [];
     Object.keys(dataListCheckBoxes)

--- a/workbench/src/renderer/components/DataDownloadModal/index.jsx
+++ b/workbench/src/renderer/components/DataDownloadModal/index.jsx
@@ -10,7 +10,6 @@ import ProgressBar from 'react-bootstrap/ProgressBar';
 import Table from 'react-bootstrap/Table';
 
 import Expire from '../Expire';
-import sampledataRegistry from '../../sampledata_registry.json';
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 const logger = window.Workbench.getLogger(__filename.split('/').slice(-1)[0]);
@@ -24,6 +23,7 @@ export class DataDownloadModal extends React.Component {
       allLinksArray: [],
       selectedLinksArray: [],
       dataListCheckBoxes: {},
+      sampledataRegistry: {},
     };
 
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -31,7 +31,15 @@ export class DataDownloadModal extends React.Component {
     this.handleCheckList = this.handleCheckList.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
+    let sampledataRegistry;
+    try {
+      sampledataRegistry = await import('../../sampledata_registry_production.json');
+    } catch {
+      sampledataRegistry = await import('../../sampledata_registry.json');
+    }
+    delete sampledataRegistry.default; // the default property was added by import
+    console.log(sampledataRegistry)
     const linksArray = [];
     const dataListCheckBoxes = {};
     Object.entries(sampledataRegistry)
@@ -43,6 +51,7 @@ export class DataDownloadModal extends React.Component {
       allLinksArray: linksArray,
       selectedLinksArray: linksArray,
       dataListCheckBoxes: dataListCheckBoxes,
+      sampledataRegistry: sampledataRegistry,
     });
   }
 
@@ -89,7 +98,11 @@ export class DataDownloadModal extends React.Component {
   }
 
   handleCheckList(event, modelName) {
-    let { selectedLinksArray, dataListCheckBoxes } = this.state;
+    let {
+      selectedLinksArray,
+      dataListCheckBoxes,
+      sampledataRegistry,
+    } = this.state;
     const { url } = sampledataRegistry[modelName];
     if (event.currentTarget.checked) {
       selectedLinksArray.push(url);
@@ -106,7 +119,11 @@ export class DataDownloadModal extends React.Component {
   }
 
   render() {
-    const { dataListCheckBoxes, selectedLinksArray } = this.state;
+    const {
+      dataListCheckBoxes,
+      selectedLinksArray,
+      sampledataRegistry,
+    } = this.state;
     const downloadEnabled = Boolean(selectedLinksArray.length);
     const DatasetCheckboxRows = [];
     Object.keys(dataListCheckBoxes)

--- a/workbench/src/renderer/sampledata_registry.json
+++ b/workbench/src/renderer/sampledata_registry.json
@@ -1,128 +1,128 @@
 {
   "Annual Water Yield": {
     "filename": "Annual_Water_Yield.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/Annual_Water_Yield.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/Annual_Water_Yield.zip",
     "filesize": 246603
   },
   "Carbon Storage and Sequestration": {
     "filename": "Carbon.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/Carbon.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/Carbon.zip",
     "filesize": 1901795
   },
   "Coastal Blue Carbon": {
     "filename": "CoastalBlueCarbon.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/CoastalBlueCarbon.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/CoastalBlueCarbon.zip",
     "filesize": 81118
   },
   "Coastal Vulnerability": {
     "filename": "CoastalVulnerability.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/CoastalVulnerability.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/CoastalVulnerability.zip",
     "filesize": 39816081,
     "labelSuffix": "(recommended to run model)"
   },
   "Crop Pollination": {
     "filename": "pollination.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/pollination.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/pollination.zip",
     "filesize": 635299
   },
   "Crop Production": {
     "filename": "CropProduction.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/CropProduction.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/CropProduction.zip",
     "filesize": 58726224,
     "labelSuffix": "(required to run model)"
   },
   "DelineateIt": {
     "filename": "DelineateIt.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/DelineateIt.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/DelineateIt.zip",
     "filesize": 530664
   },
   "Forest Carbon Edge Effect": {
     "filename": "forest_carbon_edge_effect.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/forest_carbon_edge_effect.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/forest_carbon_edge_effect.zip",
     "filesize": 1037563,
     "labelSuffix": "(required to run model)"
   },
   "GLOBIO": {
     "filename": "globio.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/globio.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/globio.zip",
     "filesize": 2084162
   },
   "Habitat Quality": {
     "filename": "HabitatQuality.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/HabitatQuality.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/HabitatQuality.zip",
     "filesize": 1742466
   },
   "Habitat Risk Assessment": {
     "filename": "HabitatRiskAssess.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/HabitatRiskAssess.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/HabitatRiskAssess.zip",
     "filesize": 3273797
   },
   "Nutrient Delivery Ratio": {
     "filename": "NDR.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/NDR.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/NDR.zip",
     "filesize": 704278
   },
   "RouteDEM": {
     "filename": "RouteDEM.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/RouteDEM.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/RouteDEM.zip",
     "filesize": 526890
   },
   "Scenario Generator: Proximity Based": {
     "filename": "scenario_proximity.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/scenario_proximity.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/scenario_proximity.zip",
     "filesize": 928442
   },
   "Scenic Quality": {
     "filename": "ScenicQuality.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/ScenicQuality.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/ScenicQuality.zip",
     "filesize": 25074939
   },
   "Seasonal Water Yield": {
     "filename": "Seasonal_Water_Yield.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/Seasonal_Water_Yield.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/Seasonal_Water_Yield.zip",
     "filesize": 708749
   },
   "Sediment Delivery Ratio": {
     "filename": "SDR.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/SDR.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/SDR.zip",
     "filesize": 728799
   },
   "Urban Stormwater Retention": {
     "filename": "UrbanStormwater.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/UrbanStormwater.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/UrbanStormwater.zip",
     "filesize": 463644
   },
   "Urban Cooling": {
     "filename": "UrbanCoolingModel.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/UrbanCoolingModel.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/UrbanCoolingModel.zip",
     "filesize": 1133854
   },
   "Urban Flood Risk Mitigation": {
     "filename": "UrbanFloodMitigation.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/UrbanFloodMitigation.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/UrbanFloodMitigation.zip",
     "filesize": 187385
   },
   "Visitation: Recreation and Tourism": {
     "filename": "recreation.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/recreation.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/recreation.zip",
     "filesize": 3700742
   },
   "Wave Energy Production": {
     "filename": "WaveEnergy.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/WaveEnergy.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/WaveEnergy.zip",
     "filesize": 77726331,
     "labelSuffix": "(required to run model)"
   },
   "Wind Energy Production": {
     "filename": "WindEnergy.zip",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/WindEnergy.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/WindEnergy.zip",
     "filesize": 5444933,
     "labelSuffix": "(required to run model)"
   },
   "Global DEM & Landmass Polygon": {
     "filename": "Base_Data.zip",
     "labelSuffix": "(required for Wind & Wave Energy)",
-    "url": "https://storage.googleapis.com/natcap-dev-build-artifacts/invest/davemfish/3.9.2.post999+g9f6f8fbba.d20220202/data/Base_Data.zip",
+    "url": "https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/3.10.2/data/Base_Data.zip",
     "filesize": 151372877
   }
 }

--- a/workbench/tests/renderer/downloadmodal.test.js
+++ b/workbench/tests/renderer/downloadmodal.test.js
@@ -50,11 +50,11 @@ describe('Sample Data Download Form', () => {
     expect(modalTitle).toBeNull();
   });
 
-  test('Checkbox initial state & interactions', () => {
+  test('Checkbox initial state & interactions', async () => {
     const {
       getByLabelText,
       getByRole,
-      getAllByRole,
+      findAllByRole,
     } = render(
       <DataDownloadModal
         show={true}
@@ -64,7 +64,7 @@ describe('Sample Data Download Form', () => {
     );
 
     // All checked initially
-    const allCheckBoxes = getAllByRole('checkbox');
+    const allCheckBoxes = await findAllByRole('checkbox');
     expect(allCheckBoxes).toHaveLength(nModels + 1); // +1 for Select All
     allCheckBoxes.forEach((box) => {
       expect(box).toBeChecked();
@@ -95,12 +95,12 @@ describe('Sample Data Download Form', () => {
     expect(modelCheckbox).toBeChecked();
   });
 
-  test('Checkbox list matches the sampledata registry', () => {
+  test('Checkbox list matches the sampledata registry', async () => {
     // The registry itself is validated during the build process
     // by the script called by `npm run fetch-invest`.
     const {
       getByLabelText,
-      getAllByRole,
+      findAllByRole,
     } = render(
       <DataDownloadModal
         show={true}
@@ -109,7 +109,7 @@ describe('Sample Data Download Form', () => {
       />
     );
 
-    const allCheckBoxes = getAllByRole('checkbox');
+    const allCheckBoxes = await findAllByRole('checkbox');
     expect(allCheckBoxes).toHaveLength(nModels + 1); // +1 for Select All
 
     // Each checkbox is labeled by the model's name

--- a/workbench/tests/sampledata_linkcheck/sampledata_registry.test.js
+++ b/workbench/tests/sampledata_linkcheck/sampledata_registry.test.js
@@ -10,8 +10,16 @@
 
 import http from 'http';
 import url from 'url';
+import fs from 'fs';
 
-import sampledataRegistry from '../../src/renderer/sampledata_registry.json';
+import defaultRegistry from '../../src/renderer/sampledata_registry.json';
+
+let productionRegistry;
+try {
+  productionRegistry = JSON.parse(
+    fs.readFileSync('../../src/renderer/sampledata_registry_production.json')
+  );
+} catch {}
 
 function getUrlStatus(options) {
   return new Promise((resolve) => {
@@ -23,7 +31,7 @@ function getUrlStatus(options) {
 }
 
 test.each(
-  Object.values(sampledataRegistry).map((item) => item.url)
+  Object.values(defaultRegistry).map((item) => item.url)
 )('check url: %s', async (address) => {
   const options = {
     method: 'HEAD',
@@ -33,3 +41,17 @@ test.each(
   const status = await getUrlStatus(options);
   expect(status).toBe(200);
 });
+
+if (productionRegistry) {
+  test.each(
+    Object.values(productionRegistry).map((item) => item.url)
+  )('check url: %s', async (address) => {
+    const options = {
+      method: 'HEAD',
+      host: url.parse(address).host,
+      path: url.parse(address).pathname,
+    };
+    const status = await getUrlStatus(options);
+    expect(status).toBe(200);
+  });
+}

--- a/workbench/tests/sampledata_linkcheck/sampledata_registry.test.js
+++ b/workbench/tests/sampledata_linkcheck/sampledata_registry.test.js
@@ -23,12 +23,12 @@ function getUrlStatus(options) {
 }
 
 test.each(
-  Object.entries(sampledataRegistry)
-)('check url: %s', async (model, data) => {
+  Object.values(sampledataRegistry).map((item) => item.url)
+)('check url: %s', async (address) => {
   const options = {
     method: 'HEAD',
-    host: url.parse(data.url).host,
-    path: url.parse(data.url).pathname,
+    host: url.parse(address).host,
+    path: url.parse(address).pathname,
   };
   const status = await getUrlStatus(options);
   expect(status).toBe(200);


### PR DESCRIPTION
There were a few issues going on here:
1. The link-check test needed to be moved after the deploy step in GHA, so that the files exist at the urls being checked.
2. The reason that test seemed to fail intermittently might just be because it wasn't running at all in PRs - since we don't "deploy" from PRs.
3. The prior build process was overwriting `sampledata_registry.json` in place. Since that's a git-tracked file, modifying it alters the `$VERSION` variable derived by `setuptools_scm` in the `Makefile`, which in turn alters the upload path to our bucket. So in the end the URLs in `sampledata_registry.json` did not match where the data actually lives after deploy.

Solutions:
1. easy fix, re-ordered the workflow steps
2. Not a problem, this should still not run in PRs
3. I updated the process so that a git-tracked file is never overwritten during the build process. So now `sampledata_registry.json` serves as a default registry - it's git-tracked, and the application uses it unless another non-tracked file (`sampledata_registry_production.json`) exists. The production file is created -- using the other as a template -- during the build process (`make sampledata`). 

Basically, the `production` file is used in production, and the original registry is used in devMode. I don't think it matters much if the original is kept current for every release/dev-build. It just needs to be functional and it should be updated whenever a sampledata filename changes, or a new model is added.

Fixes #902 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
