### PR TITLE
Pinning jinja2<3.1

### DIFF
--- a/requirements-docs.yml
+++ b/requirements-docs.yml
@@ -30,6 +30,7 @@ dependencies:
 - virtualenv>=12.0.1
 - wheel>=0.27.0
 - xlrd>=1.2.0
+- jinja2<3.1
 - xlwt
 - pip:
   - pygeoprocessing>=2.3.2 # pip-only


### PR DESCRIPTION
This should get around an import change in jinja2==3.1 that sphinx
doesn't seem to support yet.  See https://github.com/sphinx-doc/sphinx/issues/10291

RE:#933

## Description
Fixes #

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
