### PR TITLE
I. #852 add TG logging to workbench settings.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,6 +37,8 @@ Unreleased Changes
 * General
     * Updating the ``pyinstaller`` requirement to ``>=4.10`` to support the new
       ``universal2`` wheel architecture offered by ``scipy>=1.8.0``.
+    * Expose taskgraph logging level for the cli with
+      ``--taskgraph-log-level``.
 * RouteDEM
     * Rename the arg ``calculate_downstream_distance`` to
       ``calculate_downslope_distance``. This is meant to clarify that it

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -362,8 +362,7 @@ def main(user_args=None):
     LOGGER.info('Setting handler log level to %s', log_level)
 
     # Set the log level for taskgraph.
-    tg_logging_map = {'DEBUG': 10, 'INFO': 20, 'WARNING': 30, 'ERROR': 40}
-    taskgraph_log_level = tg_logging_map[args.taskgraph_log_level.upper()]
+    taskgraph_log_level = logging.getlevelName(args.taskgraph_log_level.upper())
     logging.getLogger('taskgraph').setLevel(taskgraph_log_level)
     LOGGER.info('Setting taskgraph log level to %s', taskgraph_log_level)
 

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -362,7 +362,7 @@ def main(user_args=None):
     LOGGER.info('Setting handler log level to %s', log_level)
 
     # Set the log level for taskgraph.
-    taskgraph_log_level = logging.getlevelName(args.taskgraph_log_level.upper())
+    taskgraph_log_level = logging.getLevelName(args.taskgraph_log_level.upper())
     logging.getLogger('taskgraph').setLevel(taskgraph_log_level)
     LOGGER.debug('Setting taskgraph log level to %s', taskgraph_log_level)
 

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -246,6 +246,13 @@ def main(user_args=None):
         action='store_const', const=logging.DEBUG,
         help='Enable debug logging. Alias for -vvv')
 
+    parser.add_argument(
+        '--taskgraph-log-level', dest='taskgraph_log_level', default='ERROR',
+        type=str, choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+        help=('Set the logging level for Taskgraph. Affects how much logging '
+              'Taskgraph prints to the console and (if running in headless '
+              'mode) how much is written to the logfile.'))
+
     # list the language code and corresponding language name (in that language)
     supported_languages_string = ', '.join([
         f'{locale} ({display_name})'
@@ -353,6 +360,12 @@ def main(user_args=None):
     handler.setLevel(max(log_level, logging.DEBUG))  # don't go below DEBUG
     root_logger.addHandler(handler)
     LOGGER.info('Setting handler log level to %s', log_level)
+
+    # Set the log level for taskgraph.
+    tg_logging_map = {'DEBUG': 10, 'INFO': 20, 'WARNING': 30, 'ERROR': 40}
+    taskgraph_log_level = tg_logging_map[args.taskgraph_log_level.upper()]
+    logging.getLogger('taskgraph').setLevel(taskgraph_log_level)
+    LOGGER.info('Setting taskgraph log level to %s', taskgraph_log_level)
 
     # FYI: Root logger by default has a level of logging.WARNING.
     # To capture ALL logging produced in this system at runtime, use this:

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -364,7 +364,7 @@ def main(user_args=None):
     # Set the log level for taskgraph.
     taskgraph_log_level = logging.getlevelName(args.taskgraph_log_level.upper())
     logging.getLogger('taskgraph').setLevel(taskgraph_log_level)
-    LOGGER.info('Setting taskgraph log level to %s', taskgraph_log_level)
+    LOGGER.debug('Setting taskgraph log level to %s', taskgraph_log_level)
 
     # FYI: Root logger by default has a level of logging.WARNING.
     # To capture ALL logging produced in this system at runtime, use this:

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -21,6 +21,12 @@ const LOGLEVELMAP = {
   WARNING: '-v',
   ERROR: '',
 };
+const TGLOGLEVELMAP = {
+  DEBUG: '--taskgraph-log-level=DEBUG',
+  INFO: '--taskgraph-log-level=INFO',
+  WARNING: '--taskgraph-log-level=WARNING',
+  ERROR: '--taskgraph-log-level=ERROR',
+};
 const TEMP_DIR = path.join(app.getPath('userData'), 'tmp');
 
 export function setupInvestRunHandlers(investExe) {
@@ -39,7 +45,7 @@ export function setupInvestRunHandlers(investExe) {
   });
 
   ipcMain.on(ipcMainChannels.INVEST_RUN, async (
-    event, modelRunName, pyModuleName, args, loggingLevel, language, tabID
+    event, modelRunName, pyModuleName, args, loggingLevel, taskgraphLoggingLevel, language, tabID
   ) => {
     let investRun;
     let investStarted = false;
@@ -64,6 +70,7 @@ export function setupInvestRunHandlers(investExe) {
 
     const cmdArgs = [
       LOGLEVELMAP[loggingLevel],
+      TGLOGLEVELMAP[taskgraphLoggingLevel],
       `--language "${language}"`,
       'run',
       modelRunName,

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -172,6 +172,7 @@ export default class InvestTab extends React.Component {
       this.state.modelSpec.pyname,
       args,
       investSettings.loggingLevel,
+      investSettings.taskgraphLoggingLevel,
       investSettings.language,
       tabID
     );
@@ -323,6 +324,7 @@ InvestTab.propTypes = {
   tabID: PropTypes.string.isRequired,
   investSettings: PropTypes.shape({
     nWorkers: PropTypes.string,
+    taskgraphLoggingLevel: PropTypes.string,
     loggingLevel: PropTypes.string,
     language: PropTypes.string,
   }).isRequired,

--- a/workbench/src/renderer/components/SettingsModal/SettingsStorage.js
+++ b/workbench/src/renderer/components/SettingsModal/SettingsStorage.js
@@ -17,7 +17,7 @@ const investSettingsStore = localforage.createInstance({
 export function getDefaultSettings() {
   const defaultSettings = {
     nWorkers: '-1',
-    taskgraphLoggingLevel: 'ERROR',
+    taskgraphLoggingLevel: 'INFO',
     loggingLevel: 'INFO',
     sampleDataDir: '',
     language: 'en'

--- a/workbench/src/renderer/components/SettingsModal/SettingsStorage.js
+++ b/workbench/src/renderer/components/SettingsModal/SettingsStorage.js
@@ -10,12 +10,14 @@ const investSettingsStore = localforage.createInstance({
  *
  * @returns {object} to destructure into:
  *     {String} nWorkers - TaskGraph number of workers
+ *     {String} taskgraphLoggingLevel - InVEST taskgraph logging level
  *     {String} loggingLevel - InVEST model logging level
  *     {String} sampleDataDir - default location for sample datastack downloads
  */
 export function getDefaultSettings() {
   const defaultSettings = {
     nWorkers: '-1',
+    taskgraphLoggingLevel: 'ERROR',
     loggingLevel: 'INFO',
     sampleDataDir: '',
     language: 'en'

--- a/workbench/src/renderer/components/SettingsModal/index.jsx
+++ b/workbench/src/renderer/components/SettingsModal/index.jsx
@@ -156,6 +156,24 @@ export default class SettingsModal extends React.Component {
                 </Form.Control>
               </Col>
             </Form.Group>
+            <Form.Group as={Row}>
+              <Form.Label column sm="6" htmlFor="taskgraph-logging-select">
+                {_('Taskgraph logging threshold')}
+              </Form.Label>
+              <Col sm="6">
+                <Form.Control
+                  id="taskgraph-logging-select"
+                  as="select"
+                  name="taskgraphLoggingLevel"
+                  value={investSettings.taskgraphLoggingLevel}
+                  onChange={this.handleChange}
+                >
+                  {logLevelOptions.map(
+                    (opt) => <option value={opt} key={opt}>{_(opt)}</option>
+                  )}
+                </Form.Control>
+              </Col>
+            </Form.Group>
             {
               (nWorkersOptions)
                 ? (
@@ -248,6 +266,7 @@ SettingsModal.propTypes = {
   clearJobsStorage: PropTypes.func.isRequired,
   investSettings: PropTypes.shape({
     nWorkers: PropTypes.string,
+    taskgraphLoggingLevel: PropTypes.string,
     loggingLevel: PropTypes.string,
     sampleDataDir: PropTypes.string,
     language: PropTypes.string,

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -407,8 +407,8 @@ describe('InVEST global settings: dialog interactions', () => {
 
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    const loggingInput = getByLabelText(loggingLabelText, { exact: true });
-    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: true });
+    const loggingInput = getByLabelText(loggingLabelText);
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText);
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     userEvent.selectOptions(nWorkersInput, [getByText(nWorkersLabel)]);
@@ -459,8 +459,8 @@ describe('InVEST global settings: dialog interactions', () => {
 
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    const loggingInput = getByLabelText(loggingLabelText, { exact: true });
-    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: true });
+    const loggingInput = getByLabelText(loggingLabelText);
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText);
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     // Test that the invest settings were loaded in from store.

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -407,8 +407,8 @@ describe('InVEST global settings: dialog interactions', () => {
 
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    const loggingInput = getByLabelText(loggingLabelText, { exact: false });
-    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: false });
+    const loggingInput = getByLabelText(loggingLabelText, { exact: true });
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: true });
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     userEvent.selectOptions(nWorkersInput, [getByText(nWorkersLabel)]);
@@ -459,8 +459,8 @@ describe('InVEST global settings: dialog interactions', () => {
 
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
-    const loggingInput = getByLabelText(loggingLabelText, { exact: false });
-    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: false });
+    const loggingInput = getByLabelText(loggingLabelText, { exact: true });
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: true });
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     // Test that the invest settings were loaded in from store.

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -379,6 +379,7 @@ describe('Display recently executed InVEST jobs on Home tab', () => {
 describe('InVEST global settings: dialog interactions', () => {
   const nWorkersLabelText = 'Taskgraph n_workers parameter';
   const loggingLabelText = 'Logging threshold';
+  const tgLoggingLabelText = 'Taskgraph logging threshold';
   const languageLabelText = 'Language';
 
   beforeEach(async () => {
@@ -395,6 +396,7 @@ describe('InVEST global settings: dialog interactions', () => {
     const nWorkersLabel = 'Threaded task management (0)';
     const nWorkersValue = '0';
     const loggingLevel = 'DEBUG';
+    const tgLoggingLevel = 'DEBUG';
     const languageValue = 'es';
 
     const {
@@ -406,12 +408,15 @@ describe('InVEST global settings: dialog interactions', () => {
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
     const loggingInput = getByLabelText(loggingLabelText, { exact: false });
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: false });
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     userEvent.selectOptions(nWorkersInput, [getByText(nWorkersLabel)]);
     await waitFor(() => { expect(nWorkersInput).toHaveValue(nWorkersValue); });
     userEvent.selectOptions(loggingInput, [loggingLevel]);
     await waitFor(() => { expect(loggingInput).toHaveValue(loggingLevel); });
+    userEvent.selectOptions(tgLoggingInput, [tgLoggingLevel]);
+    await waitFor(() => { expect(tgLoggingInput).toHaveValue(tgLoggingLevel); });
     userEvent.selectOptions(languageInput, [languageValue]);
     await waitFor(() => { expect(languageInput).toHaveValue(languageValue); });
     userEvent.click(getByRole('button', { name: 'close settings' }));
@@ -421,10 +426,12 @@ describe('InVEST global settings: dialog interactions', () => {
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(nWorkersValue);
       expect(loggingInput).toHaveValue(loggingLevel);
+      expect(tgLoggingInput).toHaveValue(tgLoggingLevel);
       expect(languageInput).toHaveValue(languageValue);
     });
     expect(await getSettingsValue('nWorkers')).toBe(nWorkersValue);
     expect(await getSettingsValue('loggingLevel')).toBe(loggingLevel);
+    expect(await getSettingsValue('taskgraphLoggingLevel')).toBe(tgLoggingLevel);
     expect(await getSettingsValue('language')).toBe(languageValue);
   });
 
@@ -432,11 +439,13 @@ describe('InVEST global settings: dialog interactions', () => {
     const defaultSettings = {
       nWorkers: '-1',
       loggingLevel: 'INFO',
+      taskgraphLoggingLevel: 'ERROR',
       language: 'en',
     };
     const expectedSettings = {
       nWorkers: '0',
       loggingLevel: 'ERROR',
+      taskgraphLoggingLevel: 'INFO',
       language: 'es',
     };
 
@@ -451,12 +460,14 @@ describe('InVEST global settings: dialog interactions', () => {
     userEvent.click(await findByRole('button', { name: 'settings' }));
     const nWorkersInput = getByLabelText(nWorkersLabelText, { exact: false });
     const loggingInput = getByLabelText(loggingLabelText, { exact: false });
+    const tgLoggingInput = getByLabelText(tgLoggingLabelText, { exact: false });
     const languageInput = getByLabelText(languageLabelText, { exact: false });
 
     // Test that the invest settings were loaded in from store.
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(expectedSettings.nWorkers);
       expect(loggingInput).toHaveValue(expectedSettings.loggingLevel);
+      expect(tgLoggingInput).toHaveValue(expectedSettings.tgLoggingLevel);
       expect(languageInput).toHaveValue(expectedSettings.language);
     });
 
@@ -465,6 +476,7 @@ describe('InVEST global settings: dialog interactions', () => {
     await waitFor(() => {
       expect(nWorkersInput).toHaveValue(defaultSettings.nWorkers);
       expect(loggingInput).toHaveValue(defaultSettings.loggingLevel);
+      expect(tgLoggingInput).toHaveValue(defaultSettings.tgLoggingLevel);
       expect(languageInput).toHaveValue(defaultSettings.language);
     });
   });

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -45,7 +45,7 @@ function renderInvestTab(job = DEFAULT_JOB) {
     <InvestTab
       job={job}
       tabID={tabID}
-      investSettings={{ nWorkers: '-1', loggingLevel: 'INFO' }}
+      investSettings={{ nWorkers: '-1', loggingLevel: 'INFO', taskgraphLoggingLevel: 'ERROR' }}
       saveJob={() => {}}
       updateJobProperties={() => {}}
     />


### PR DESCRIPTION
Adds taskgraph logging threshold to the Workbench settings modal.  Exposes taskgraph logging through the invest CLI via ``--taskgraph-log-level``.

Added tests similar to ``Logging threshold`` setting.

## Description
Fixes #852

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
