### PR TITLE
Bugfix for workbench data-download progress bar

### DIFF
--- a/workbench/src/main/setupDownloadHandlers.js
+++ b/workbench/src/main/setupDownloadHandlers.js
@@ -75,6 +75,10 @@ export default function setupDownloadHandlers(mainWindow) {
         );
       } else {
         logger.info(`download failed: ${state}`);
+        mainWindow.webContents.send(
+          'download-status',
+          ['failed', 'failed'] // ProgressBar expects array length 2
+        );
       }
       if (!downloadQueue.length) {
         logger.info('all downloads complete');

--- a/workbench/src/renderer/components/DataDownloadModal/index.jsx
+++ b/workbench/src/renderer/components/DataDownloadModal/index.jsx
@@ -251,6 +251,21 @@ DataDownloadModal.propTypes = {
 
 export function DownloadProgressBar(props) {
   const [nComplete, nTotal] = props.downloadedNofN;
+  if (nComplete === 'failed') {
+    return (
+      <Expire
+        className="d-inline"
+        delay={props.expireAfter}
+      >
+        <Alert
+          className="d-inline"
+          variant="danger"
+        >
+          {_("Download Failed")}
+        </Alert>
+      </Expire>
+    );
+  }
   if (nComplete === nTotal) {
     return (
       <Expire
@@ -277,6 +292,8 @@ export function DownloadProgressBar(props) {
 }
 
 DownloadProgressBar.propTypes = {
-  downloadedNofN: PropTypes.arrayOf(PropTypes.number).isRequired,
+  downloadedNofN: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ).isRequired,
   expireAfter: PropTypes.number.isRequired,
 };

--- a/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
+++ b/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
@@ -1,6 +1,6 @@
 {
   "Annual Water Yield": {
-    "filename": "Annual_Water_YieldQ.zip"
+    "filename": "Annual_Water_Yield.zip"
   },
   "Carbon Storage and Sequestration": {
     "filename": "Carbon.zip"

--- a/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
+++ b/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
@@ -1,6 +1,6 @@
 {
   "Annual Water Yield": {
-    "filename": "Annual_Water_Yield.zip"
+    "filename": "Annual_Water_YieldQ.zip"
   },
   "Carbon Storage and Sequestration": {
     "filename": "Carbon.zip"

--- a/workbench/tests/renderer/downloadmodal.test.js
+++ b/workbench/tests/renderer/downloadmodal.test.js
@@ -148,6 +148,22 @@ describe('DownloadProgressBar', () => {
       expect(alert).not.toBeInTheDocument();
     });
   });
+
+  test('Displays message on fail, then disappears', async () => {
+    const nComplete = 'failed';
+    const nTotal = 'failed';
+    const { getByText } = render(
+      <DownloadProgressBar
+        downloadedNofN={[nComplete, nTotal]}
+        expireAfter={1000}
+      />
+    );
+    const alert = getByText('Download Failed');
+    expect(alert).toBeInTheDocument();
+    await waitFor(() => {
+      expect(alert).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe('Integration tests with main process', () => {


### PR DESCRIPTION
The progress bar did not accurately reflect the state of a failed download, which would happen on a 404, or presumably a loss of the network .

Fixes #926 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
