### PR TITLE
Validation: bugfix in pattern-matching on freestyle strings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,8 @@ Unreleased Changes
       ``universal2`` wheel architecture offered by ``scipy>=1.8.0``.
     * Expose taskgraph logging level for the cli with
       ``--taskgraph-log-level``.
+    * Fixed bug in validation of ``results_suffix`` so that special characters
+      like path separators, etc, are not allowed.
 * RouteDEM
     * Rename the arg ``calculate_downstream_distance`` to
       ``calculate_downslope_distance``. This is meant to clarify that it

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -388,19 +388,14 @@ def check_freestyle_string(value, regexp=None, **kwargs):
 
     Args:
         value: The value to check.  Must be able to be cast to a string.
-        regexp=None (dict): A dict representing validation parameters for a
-            regular expression.  ``regexp['pattern']`` is required, and its
-            value must be a string regular expression.
-            ``regexp['case_sensitive']`` may also be provided and is expected
-            to be a boolean value.  If ``True`` or truthy, the regular
-            expression will ignore case.
+        regexp=None (string): a string interpreted as a regular expression.
 
     Returns:
         A string error message if an error was found.  ``None`` otherwise.
 
     """
     if regexp:
-        matches = re.findall(regexp, str(value), re.IGNORECASE)
+        matches = re.fullmatch(regexp, str(value))
         if not matches:
             return MESSAGES['REGEXP_MISMATCH'].format(regexp=regexp)
     return None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -533,18 +533,21 @@ class FreestyleStringValidation(unittest.TestCase):
     def test_regexp(self):
         """Validation: test that we can check regex patterns on strings."""
         from natcap.invest import validation
+        from natcap.invest.spec_utils import SUFFIX
 
         self.assertEqual(None, validation.check_freestyle_string(
             1.234, regexp='^1.[0-9]+$'))
-
-        self.assertEqual(None, validation.check_freestyle_string(
-            'bar', regexp='BAR'))  # should be case-insensitive
 
         regexp = '^[a-zA-Z]+$'
         error_msg = validation.check_freestyle_string(
             'foobar12', regexp=regexp)
         self.assertEqual(
             error_msg, validation.MESSAGES['REGEXP_MISMATCH'].format(regexp=regexp))
+
+        error_msg = validation.check_freestyle_string(
+            '4/20', regexp=SUFFIX['regexp'])
+        self.assertEqual(
+            error_msg, validation.MESSAGES['REGEXP_MISMATCH'].format(regexp=SUFFIX['regexp']))
 
 
 class OptionStringValidation(unittest.TestCase):


### PR DESCRIPTION
In order for a string to be valid, the whole string needs to fulfill the regex. Otherwise `re.findall('[a-zA-Z0-9_-]*', '4/20')` will find two matches: ['4', '20'] when we want it to find none.

I also removed the default `re.IGNORECASE` because I checked for all the uses of a "regex" in `ARGS_SPEC` and neither of the two uses have a need for ignoring case. It seems better to explicitly include the cases in the regex. And I updated a docstring that seemed out of date.

Fixes #897 

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
