### PR TITLE
turn on logging again for the invest server. #563.

### DIFF
--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -16,7 +16,6 @@ from natcap.invest import spec_utils
 from natcap.invest import usage
 
 LOGGER = logging.getLogger(__name__)
-logging.getLogger('flask_cors').level = logging.DEBUG
 
 PREFIX = 'api'
 app = Flask(__name__)

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -14,14 +14,9 @@ const HOSTNAME = 'http://localhost';
  * @returns {ChildProcess} - a reference to the subprocess.
  */
 export function createPythonFlaskProcess(investExe) {
-  // TODO: starting `invest serve` without any python logging
-  // because of https://github.com/natcap/invest/issues/563
-  // & https://github.com/natcap/invest-workbench/issues/144
-  // Once those are resolved, we probably want some logging here,
-  // maybe --debug if devMode, -vvv if production?
   const pythonServerProcess = spawn(
     investExe,
-    ['serve', '--port', process.env.PORT],
+    ['--debug', 'serve', '--port', process.env.PORT],
     { shell: true } // necessary in dev mode & relying on a conda env
   );
 


### PR DESCRIPTION
We had turned off logging because of #563 . I've turned it back on and confirmed that the server-not-responding is no longer an issue. Possibly because we now make far fewer calls to validation (and subsequent logging) during typing. I chose `--debug` level because these messages only go to a file during production, so the extra noise is not noticeable to the user. And it's potentially useful to have as much logging as possible in those files.

Also removed debug-level logging from `flask-cors`, that was only meant to be there during development.

Fixes #563

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
