### PR TITLE
Workbench: better visual cues for clickable navigation

### DIFF
--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -342,7 +342,7 @@ export default class App extends React.Component {
           </Navbar>
 
           <TabContent
-            id="top-tab-content"
+            id="home-tab-content"
             onDragOver={dragOverHandlerNone}
           >
             <TabPane

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -10,7 +10,7 @@ import Button from 'react-bootstrap/Button';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Spinner from 'react-bootstrap/Spinner';
-import { MdClose } from 'react-icons/md';
+import { MdClose, MdHome } from 'react-icons/md';
 
 import HomeTab from './components/HomeTab';
 import InvestTab from './components/InvestTab';
@@ -295,6 +295,7 @@ export default class App extends React.Component {
                     onSelect={this.switchTabs}
                     eventKey="home"
                   >
+                    <MdHome />
                     {_("InVEST")}
                   </Nav.Link>
                 </Navbar.Brand>

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -283,13 +283,12 @@ export default class App extends React.Component {
         />
         <TabContainer activeKey={activeTab}>
           <Navbar
-            className="px-0 py-0"
             onDragOver={dragOverHandlerNone}
           >
             <Row
               className="w-100 flex-nowrap"
             >
-              <Col sm={3} className="px-0">
+              <Col sm={3}>
                 <Navbar.Brand>
                   <Nav.Link
                     onSelect={this.switchTabs}

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -299,7 +299,7 @@ export default class App extends React.Component {
                   </Nav.Link>
                 </Navbar.Brand>
               </Col>
-              <Col className="pl-1 pr-0 navbar-middle">
+              <Col className="navbar-middle">
                 <Nav
                   justify
                   variant="tabs"
@@ -310,7 +310,7 @@ export default class App extends React.Component {
                   {investNavItems}
                 </Nav>
               </Col>
-              <Col className="px-0 text-right navbar-right">
+              <Col className="text-right navbar-right">
                 {
                   (downloadedNofN)
                     ? (

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -287,7 +287,7 @@ export default class App extends React.Component {
             onDragOver={dragOverHandlerNone}
           >
             <Row
-              className="w-100 flex-nowrap mr-0"
+              className="w-100 flex-nowrap"
             >
               <Col sm={3} className="px-0">
                 <Navbar.Brand>

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -170,7 +170,7 @@ class RecentInvestJobs extends React.Component {
                   </h4>
                 )
                 : (
-                  <div>
+                  <div className="default-text">
                     {_(`Setup a model from a sample datastack file (.json)
                         or from an InVEST model's logfile (.txt): `)}
                   </div>

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -159,7 +159,7 @@ class RecentInvestJobs extends React.Component {
     });
 
     return (
-      <Container>
+      <>
         <div className="mb-1">
           {recentButtons.length
             ? (
@@ -182,7 +182,7 @@ class RecentInvestJobs extends React.Component {
         <React.Fragment>
           {recentButtons}
         </React.Fragment>
-      </Container>
+      </>
     );
   }
 }

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -160,25 +160,32 @@ class RecentInvestJobs extends React.Component {
 
     return (
       <>
-        <div className="mb-1">
+        {/*<div className="mb-1">*/}
+        <Container>
+        <Row>
+        <Col className="recent-header-col">
           {recentButtons.length
             ? (
-              <h4 className="d-inline-block">
-                {_("Recent runs:")}
+              <h4>
+                {_('Recent runs:')}
               </h4>
             )
             : (
-              <div className="d-inline-block">
-                {_(`Try the <b>Open</b> button to setup a model from a sample
-                    datastack file (.json) or from an InVEST model's logfile (.txt)`)}
+              <div>
+                {_(`Setup a model from a sample datastack file (.json)
+                    or from an InVEST model's logfile (.txt): `)}
               </div>
             )}
+          </Col>
+          <Col className="open-button-col">
           <OpenButton
-            className="float-right"
+            className="mr-2"
             openInvestModel={this.props.openInvestModel}
-            batchUpdateArgs={this.props.batchUpdateArgs}
           />
-        </div>
+          </Col>
+        </Row>
+        </Container>
+        {/*</div>*/}
         <React.Fragment>
           {recentButtons}
         </React.Fragment>

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -160,32 +160,30 @@ class RecentInvestJobs extends React.Component {
 
     return (
       <>
-        {/*<div className="mb-1">*/}
         <Container>
-        <Row>
-        <Col className="recent-header-col">
-          {recentButtons.length
-            ? (
-              <h4>
-                {_('Recent runs:')}
-              </h4>
-            )
-            : (
-              <div>
-                {_(`Setup a model from a sample datastack file (.json)
-                    or from an InVEST model's logfile (.txt): `)}
-              </div>
-            )}
-          </Col>
-          <Col className="open-button-col">
-          <OpenButton
-            className="mr-2"
-            openInvestModel={this.props.openInvestModel}
-          />
-          </Col>
-        </Row>
+          <Row>
+            <Col className="recent-header-col">
+              {recentButtons.length
+                ? (
+                  <h4>
+                    {_('Recent runs:')}
+                  </h4>
+                )
+                : (
+                  <div>
+                    {_(`Setup a model from a sample datastack file (.json)
+                        or from an InVEST model's logfile (.txt): `)}
+                  </div>
+                )}
+            </Col>
+            <Col className="open-button-col">
+              <OpenButton
+                className="mr-2"
+                openInvestModel={this.props.openInvestModel}
+              />
+            </Col>
+          </Row>
         </Container>
-        {/*</div>*/}
         <React.Fragment>
           {recentButtons}
         </React.Fragment>

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -7,6 +7,10 @@ import TabContainer from 'react-bootstrap/TabContainer';
 import Nav from 'react-bootstrap/Nav';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import {
+  MdKeyboardArrowRight,
+  MdArrowRight
+} from 'react-icons/md';
 
 import ModelStatusAlert from './ModelStatusAlert';
 import SetupTab from '../SetupTab';
@@ -240,14 +244,18 @@ export default class InvestTab extends React.Component {
               onSelect={this.switchTabs}
             >
               <Nav.Link eventKey="setup">
-                {_('Setup')}
+                <span>
+                {_('Setup ')}
+                </span>
+                <MdKeyboardArrowRight />
               </Nav.Link>
               <div
                 className="sidebar-setup"
                 id={sidebarSetupElementId}
               />
               <Nav.Link eventKey="log" disabled={logDisabled}>
-                {_('Log')}
+                {_('Log ')}
+                <MdKeyboardArrowRight />
               </Nav.Link>
             </Nav>
             <div className="sidebar-row">

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -9,7 +9,6 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import {
   MdKeyboardArrowRight,
-  MdArrowRight
 } from 'react-icons/md';
 
 import ModelStatusAlert from './ModelStatusAlert';

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -244,9 +244,7 @@ export default class InvestTab extends React.Component {
               onSelect={this.switchTabs}
             >
               <Nav.Link eventKey="setup">
-                <span>
-                {_('Setup ')}
-                </span>
+                {_('Setup')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
               <div
@@ -254,7 +252,7 @@ export default class InvestTab extends React.Component {
                 id={sidebarSetupElementId}
               />
               <Nav.Link eventKey="log" disabled={logDisabled}>
-                {_('Log ')}
+                {_('Log')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
             </Nav>

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -247,16 +247,16 @@ export default class InvestTab extends React.Component {
                 {_('Setup')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
-              <div
-                className="sidebar-setup"
-                id={sidebarSetupElementId}
-              />
               <Nav.Link eventKey="log" disabled={logDisabled}>
                 {_('Log')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
             </Nav>
-            <div className="sidebar-row">
+            <div
+              className="sidebar-row sidebar-buttons"
+              id={sidebarSetupElementId}
+            />
+            <div className="sidebar-row sidebar-links">
               <ResourcesLinks
                 moduleName={modelRunName}
                 docs={modelSpec.userguide}

--- a/workbench/src/renderer/components/OpenButton/index.jsx
+++ b/workbench/src/renderer/components/OpenButton/index.jsx
@@ -38,8 +38,6 @@ export default class OpenButton extends React.Component {
     const tipText = _('Browse to a datastack (.json) or InVEST logfile (.txt)');
     return (
       <OverlayTrigger
-        // defaultShow={this.props.defaultShow}
-        // flip={this.props.defaultShow}
         placement="left"
         delay={{ show: 250, hide: 400 }}
         overlay={<Tooltip>{tipText}</Tooltip>}

--- a/workbench/src/renderer/components/OpenButton/index.jsx
+++ b/workbench/src/renderer/components/OpenButton/index.jsx
@@ -38,6 +38,8 @@ export default class OpenButton extends React.Component {
     const tipText = _('Browse to a datastack (.json) or InVEST logfile (.txt)');
     return (
       <OverlayTrigger
+        // defaultShow={this.props.defaultShow}
+        // flip={this.props.defaultShow}
         placement="left"
         delay={{ show: 250, hide: 400 }}
         overlay={<Tooltip>{tipText}</Tooltip>}

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -40,12 +40,16 @@ body {
 .navbar-middle {
 	flex-shrink: 1;
 	min-width: 0;
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .navbar-right {
 	/*max-width: fit-content;
 	margin-left: 0.5rem;*/
 	margin-right: -15px;
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .navbar-brand .nav-link {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -6,26 +6,18 @@ body {
 	--invest-green: #148F68;
 	background-color: rgba(0,0,0,0);
 	margin: 0;
-	/*padding: 1rem;*/
 	overflow-y: hidden;
 }
 
 /*Top Navigation*/
 
 .navbar {
-	/*height: 3rem;*/
-	/*align-items: end;*/
-	/*padding-bottom: 0;*/
 	border-bottom: 3px solid var(--invest-green);
-	/*background-color: #fff*/
 	padding: 0;
 }
 
 .navbar .row {
 	align-items: end;
-	/*padding-bottom: 0;
-	border-bottom: 3px solid var(--invest-green);
-	background-color: #fff*/
 }
 
 .navbar-brand {
@@ -172,7 +164,6 @@ exceed 100% of window.*/
 .invest-list-container {
 	height: 87vh;
 	overflow-y: auto;
-	/*padding-left: 0;*/
 }
 
 .invest-list-group {
@@ -224,9 +215,7 @@ exceed 100% of window.*/
 	flex-direction: column;
 	height: 87vh;
 	overflow-y: auto;
-	/*padding-top: 0.5rem;*/
 	padding-right: 0.5rem;
-	/*margin-right: 16px;*/
 }
 
 .recent-job-card-col .container {
@@ -236,8 +225,6 @@ exceed 100% of window.*/
 }
 
 .recent-job-card {
-	/*flex: 1 0 auto!important;*/
-	/*flex-direction: row;*/
 	width: inherit; 
 	margin-bottom: 1rem;
 	padding: 0;
@@ -317,7 +304,6 @@ exceed 100% of window.*/
 	display: flex;
 	flex-direction: column;
 	padding-right: 0;
-	/*padding-left: 1rem;*/
 }
 
 .invest-sidebar-col .nav-link {
@@ -515,7 +501,6 @@ input[type=text]::placeholder {
 	overflow: auto;
 	white-space: pre-wrap;
 	height: 85vh;
-	/*background-color: #191919;*/
 }
 
 #log-text {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -280,7 +280,8 @@ body {
 
 .invest-sidebar-col .nav-link {
 	color: #000;
-	background-color: #fff;
+	border-right: 5px solid transparent;
+	border-radius: 0;
 	font-size: 1.3rem;
 	font-weight: 550;
 	display: flex;
@@ -295,6 +296,8 @@ body {
 
 .invest-sidebar-col .nav-link:hover, .invest-sidebar-col .nav-link:focus {
 	background-color: rgb(240, 240, 240);
+	border-right: 5px solid rgb(240, 240, 240);
+	border-radius: 0;
 }
 
 .invest-sidebar-col .nav-link.disabled {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -209,6 +209,11 @@ exceed 100% of window.*/
 	padding-left: 0;
 }
 
+.recent-header-col .default-text {
+	padding-left: 0;
+	text-align: right;
+}
+
 .recent-job-card-col {
 	display: flex;
 	flex-wrap: nowrap;
@@ -222,6 +227,10 @@ exceed 100% of window.*/
 	padding-top: 0.25rem;
 	padding-bottom: 0.25rem;
 	padding-right: 0.5rem;
+}
+
+.recent-job-card-col .container .row {
+	align-items: center;
 }
 
 .recent-job-card {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -48,6 +48,13 @@ body {
 	font-size: 2.0rem;
 	letter-spacing: 1px;
 	padding-bottom: 0;
+	display: flex;
+	align-items: center;
+}
+
+/*tricky to align icon with text*/
+.navbar-brand .nav-link svg {
+	margin-bottom: -0.2rem;
 }
 
 .navbar-nav.nav-tabs {
@@ -343,7 +350,7 @@ body {
 }
 
 .sidebar-footer {
-    margin-top: auto;
+  margin-top: auto;
 }
 
 /* Model Status Alert */

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -314,8 +314,8 @@ body {
 .sidebar-row {
 	display: flex;
 	flex-direction: column;
-	font-size: 1.0rem;
-	padding-left: 1.0rem;
+	font-size: 1rem;
+	padding-left: 1rem;
 	padding-right: 1rem;
 }
 

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -209,22 +209,39 @@ exceed 100% of window.*/
 	font-weight: 600;
 }
 
+.open-button-col {
+	max-width: fit-content;
+	padding-right: 0;
+}
+
+.recent-header-col {
+	padding-left: 0;
+}
+
 .recent-job-card-col {
 	display: flex;
 	flex-wrap: nowrap;
 	flex-direction: column;
 	height: 87vh;
 	overflow-y: auto;
-	padding-top: 0.5rem;
-	padding-right: 0;
+	/*padding-top: 0.5rem;*/
+	padding-right: 0.5rem;
+	/*margin-right: 16px;*/
+}
+
+.recent-job-card-col .container {
+	padding-top: 0.25rem;
+	padding-bottom: 0.25rem;
+	padding-right: 0.5rem;
 }
 
 .recent-job-card {
-	flex: 1 0 auto!important;
-	flex-direction: row;
+	/*flex: 1 0 auto!important;*/
+	/*flex-direction: row;*/
 	width: inherit; 
-	margin-bottom: 15px!important;
+	margin-bottom: 1rem;
 	padding: 0;
+	height: fit-content;
 }
 
 .card-body {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -13,7 +13,7 @@ body {
 /*Top Navigation*/
 
 .navbar {
-	height: 3rem;
+	/*height: 3rem;*/
 }
 
 .navbar .row {
@@ -151,7 +151,7 @@ body {
 }
 
 .tab-content {
-	padding-top:  10px;
+	/*padding-top:  10px;*/
 }
 
 /* Home Tab */
@@ -490,8 +490,9 @@ input[type=text]::placeholder {
 
 #log-text {
 	font-family: monospace;
-	font-size:1.0rem;
+	font-size:1rem;
 	color: #000;
+	margin-top: 1rem;
 }
 
 #log-text .invest-log-primary {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -18,6 +18,7 @@ body {
 	/*padding-bottom: 0;*/
 	border-bottom: 3px solid var(--invest-green);
 	/*background-color: #fff*/
+	padding: 0;
 }
 
 .navbar .row {
@@ -167,7 +168,7 @@ exceed 100% of window.*/
 .invest-list-container {
 	height: 87vh;
 	overflow-y: auto;
-	padding-left: 0;
+	/*padding-left: 0;*/
 }
 
 .invest-list-group {
@@ -295,7 +296,7 @@ exceed 100% of window.*/
 	display: flex;
 	flex-direction: column;
 	padding-right: 0;
-	padding-left: 0;
+	/*padding-left: 1rem;*/
 }
 
 .invest-sidebar-col .nav-link {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -294,9 +294,7 @@ body {
 }
 
 .invest-sidebar-col .nav-link:hover, .invest-sidebar-col .nav-link:focus {
-	background-color: rgb(230, 230, 230);
-	text-decoration-line: underline;
-	text-decoration-thickness: 3px;
+	background-color: rgb(240, 240, 240);
 }
 
 .invest-sidebar-col .nav-link.disabled {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -298,7 +298,7 @@ body {
 }
 
 .invest-sidebar-col .nav-link.disabled {
-	color: #6c757d;
+	color: #888888;
 }
 
 .invest-sidebar-col .nav-link.active {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -283,10 +283,20 @@ body {
 	background-color: #fff;
 	font-size: 1.3rem;
 	font-weight: 550;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-right: 0;
+}
+
+.invest-sidebar-col .nav-link svg {
+	font-size: 2rem;
 }
 
 .invest-sidebar-col .nav-link:hover, .invest-sidebar-col .nav-link:focus {
-	background-color: ghostwhite;
+	background-color: rgb(230, 230, 230);
+	text-decoration-line: underline;
+	text-decoration-thickness: 3px;
 }
 
 .invest-sidebar-col .nav-link.disabled {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -271,6 +271,7 @@ body {
 	 /* main col can grow & shrink, sidebar cannot. */
 	flex:  1 1 0;
 	padding-left: 0;
+	padding-right: 0;
 	height: 85vh;
 }
 

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -6,7 +6,7 @@ body {
 	--invest-green: #148F68;
 	background-color: rgba(0,0,0,0);
 	margin: 0;
-	padding: 1rem;
+	/*padding: 1rem;*/
 	overflow-y: hidden;
 }
 
@@ -14,13 +14,17 @@ body {
 
 .navbar {
 	/*height: 3rem;*/
+	/*align-items: end;*/
+	/*padding-bottom: 0;*/
+	border-bottom: 3px solid var(--invest-green);
+	/*background-color: #fff*/
 }
 
 .navbar .row {
 	align-items: end;
-	padding-bottom: 0;
+	/*padding-bottom: 0;
 	border-bottom: 3px solid var(--invest-green);
-	background-color: #fff
+	background-color: #fff*/
 }
 
 .navbar-brand {
@@ -38,8 +42,9 @@ body {
 }
 
 .navbar-right {
-	max-width: fit-content;
-	margin-left: 0.5rem;
+	/*max-width: fit-content;
+	margin-left: 0.5rem;*/
+	margin-right: -15px;
 }
 
 .navbar-brand .nav-link {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -310,29 +310,35 @@ body {
 	border-radius: 0;
 }
 
-.sidebar-setup {
-	display: flex;
-	flex-direction: column;
-	flex-wrap: nowrap;
-	align-items: flex-start;
-	padding-left: 1.5rem;
-}
-
-.sidebar-setup .btn {
-	white-space: nowrap;
-}
-
-/* Resources Links */
 .sidebar-row {
 	display: flex;
 	flex-direction: column;
 	font-size: 1.0rem;
-	padding-left: inherit;
+	padding-left: 1.0rem;
 	padding-right: 1rem;
 }
 
-.sidebar-row .alert {
+.sidebar-buttons {
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
+	align-items: flex-start;
+}
+
+.sidebar-buttons .btn {
+	white-space: nowrap;
+	background: none;
+	border: none;
+	color: black;
+	padding-left: 0;
+}
+
+.sidebar-buttons .alert {
 	margin-top: 1rem;
+}
+
+.sidebar-links a {
+	padding-top: 0.5rem;
 }
 
 .sidebar-footer {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -45,8 +45,8 @@ body {
 }
 
 .navbar-right {
-	/*max-width: fit-content;
-	margin-left: 0.5rem;*/
+	max-width: fit-content;
+	margin-left: 0.5rem;
 	margin-right: -15px;
 	padding-left: 0;
 	padding-right: 0;

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -48,6 +48,7 @@ body {
 	font-size: 2.0rem;
 	letter-spacing: 1px;
 	padding-bottom: 0;
+	padding-left: 0.7rem;
 	display: flex;
 	align-items: center;
 }
@@ -158,6 +159,7 @@ body {
 .invest-list-container {
 	height: 87vh;
 	overflow-y: auto;
+	padding-left: 0;
 }
 
 .invest-list-group {
@@ -200,7 +202,8 @@ body {
 	flex-direction: column;
 	height: 87vh;
 	overflow-y: auto;
-	margin-top: 15px;
+	padding-top: 0.5rem;
+	padding-right: 0;
 }
 
 .recent-job-card {
@@ -283,6 +286,7 @@ body {
 	display: flex;
 	flex-direction: column;
 	padding-right: 0;
+	padding-left: 0;
 }
 
 .invest-sidebar-col .nav-link {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -155,8 +155,11 @@ body {
 	margin-right: 0.2rem;
 }
 
-.tab-content {
-	/*padding-top:  10px;*/
+/* add padding to accomodate the width of a scroll bar
+otherwise the bar will make overall width of content
+exceed 100% of window.*/
+#home-tab-content {
+	padding-right:  16px;
 }
 
 /* Home Tab */

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -346,7 +346,7 @@ describe('Display recently executed InVEST jobs on Home tab', () => {
       <App />
     );
 
-    const node = await findByText(/button to setup a model/);
+    const node = await findByText(/Setup a model from a sample datastack file/);
     expect(node).toBeInTheDocument();
   });
 
@@ -371,7 +371,7 @@ describe('Display recently executed InVEST jobs on Home tab', () => {
     });
     userEvent.click(getByRole('button', { name: 'settings' }));
     userEvent.click(getByText('Clear Recent Jobs'));
-    const node = await findByText(/button to setup a model/);
+    const node = await findByText(/Setup a model from a sample datastack file/);
     expect(node).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Trying to make it more obvious that "Setup" and "Log" are clickable, and not just headers. I added `>` icons to attract the mouse, and enhanced the "on-hover" styles. In this image my mouse isn't visible, but it's hovering over "Log".

![tabs](https://user-images.githubusercontent.com/4071255/165815744-94bf3c9b-edea-4618-9b2f-4067c5e78113.PNG)


Log is still disabled and has no hover effects until after a model starts running. In this image, I already ran the model.
Fixes #962 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
