### PR TITLE
WB: switch to Setup from Log after Load Parameters

### DIFF
--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -292,6 +292,7 @@ export default class InvestTab extends React.Component {
                   sidebarSetupElementId={sidebarSetupElementId}
                   sidebarFooterElementId={sidebarFooterElementId}
                   executeClicked={executeClicked}
+                  switchTabs={this.switchTabs}
                 />
               </TabPane>
               <TabPane

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -278,6 +278,7 @@ export default class SetupTab extends React.Component {
 
     if (datastack.module_name === this.props.pyModuleName) {
       this.batchUpdateArgs(datastack.args);
+      this.props.switchTabs('setup');
     } else {
       alert( // eslint-disable-line no-alert
         _(`Datastack/Logfile for ${datastack.model_human_name} does not match this model.`)
@@ -568,4 +569,5 @@ SetupTab.propTypes = {
   sidebarSetupElementId: PropTypes.string.isRequired,
   sidebarFooterElementId: PropTypes.string.isRequired,
   executeClicked: PropTypes.bool.isRequired,
+  switchTabs: PropTypes.func.isRequired,
 };

--- a/workbench/tests/invest/flaskapp.test.js
+++ b/workbench/tests/invest/flaskapp.test.js
@@ -227,7 +227,7 @@ describe('Build each model UI from ARGS_SPEC', () => {
         sidebarSetupElementId="foo"
         sidebarFooterElementId="foo"
         executeClicked={false}
-        setSaveAlert={() => {}}
+        switchTabs={() => {}}
       />
     );
     expect(await findByRole('textbox', { name: /workspace/i }))

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -333,10 +333,25 @@ describe('Sidebar Buttons', () => {
       filePaths: ['foo.json']
     };
     ipcRenderer.invoke.mockResolvedValue(mockDialogData);
-    const { findByText, findByLabelText } = renderInvestTab();
 
+    // Render with a completed model run so we can navigate to Log Tab
+    // and assert that Loading new params toggles back to Setup Tab
+    const job = new InvestJob({
+      modelRunName: 'carbon',
+      modelHumanName: 'Carbon Model',
+      status: 'success',
+      argsValues: {},
+      logfile: 'foo.txt',
+      finalTraceback: '',
+    });
+    const { findByText, findByLabelText, findByRole } = renderInvestTab(job);
+
+    userEvent.click(await findByRole('tab', { name: 'Log' }));
     const loadButton = await findByText('Load parameters from file');
     userEvent.click(loadButton);
+
+    const setupTab = await findByRole('tab', { name: 'Setup' });
+    expect(setupTab.classList.contains('active')).toBeTruthy();
 
     const input1 = await findByLabelText(spec.args.workspace.name);
     expect(input1).toHaveValue(mockDatastack.args.workspace);

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -73,6 +73,7 @@ function renderSetupFromSpec(baseSpec, uiSpec) {
       sidebarSetupElementId="foo"
       sidebarFooterElementId="foo"
       executeClicked={false}
+      switchTabs={() => {}}
     />
   );
   return utils;


### PR DESCRIPTION
This PR adds a test and functionality to toggle the UI to the Setup tab after the Load Parameters button is used. Since that button can be used from the Log tab, it's nice to automatically toggle to Setup to make it clear that the parameters did in fact load.

Fixes #948 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
