### PR TITLE
fix outdated MODEL_METADATA import

### DIFF
--- a/src/natcap/invest/ui/launcher.py
+++ b/src/natcap/invest/ui/launcher.py
@@ -10,6 +10,7 @@ from qtpy import QtGui
 
 
 import natcap.invest
+from natcap.invest.model_metadata import MODEL_METADATA
 
 LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def main():
     scroll_area.setWidget(main_widget)
 
     labels_and_buttons = []
-    for model_name, model_data in sorted(natcap.invest.MODEL_METADATA.items(),
+    for model_name, model_data in sorted(MODEL_METADATA.items(),
             # sort alphabetically by display name
             key=lambda item: item[1].model_title):
         row = layout.rowCount()


### PR DESCRIPTION
## Description
despite my best efforts I missed updating one instance of the `MODEL_METADATA` import in #947. That broke `invest launch`. Apparently `invest launch` isn't under test anywhere, even in `invest-autotest.py`.

## Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
