### PR TITLE
Remove trailing/leading whitespaces from table values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,6 +37,8 @@ Unreleased Changes
 * General
     * Updating the ``pyinstaller`` requirement to ``>=4.10`` to support the new
       ``universal2`` wheel architecture offered by ``scipy>=1.8.0``.
+    * Now removing leading / trailing whitespaces from table input values as
+      well as columns in most InVEST models.
 * RouteDEM
     * Rename the arg ``calculate_downstream_distance`` to
       ``calculate_downslope_distance``. This is meant to clarify that it

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -599,7 +599,8 @@ def read_csv_to_dataframe(
     Wrapper around ``pandas.read_csv`` that standardizes the column names by
     stripping leading/trailing whitespace and optionally making all lowercase.
     This helps avoid common errors caused by user-supplied CSV files with
-    column names that don't exactly match the specification.
+    column names that don't exactly match the specification. Strips
+    leading/trailing whitespace from data entries as well.
 
     Args:
         path (string): path to a CSV file
@@ -638,6 +639,10 @@ def read_csv_to_dataframe(
     dataframe.columns = dataframe.columns.str.strip()
     if to_lower:
         dataframe.columns = dataframe.columns.str.lower()
+
+    # Remove values with leading ('^ +') and trailing (' +$') whitespace.
+    # Regular expressions using 'replace' only substitute on strings.
+    dataframe = dataframe.replace(r"^ +| +$", r"", regex=True)
 
     return dataframe
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -988,6 +988,29 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df.columns[0], '1')
         self.assertEqual(df['1'][0], 'a')
 
+    def test_removal_whitespace(self):
+        """utils: test that leading/trailing whitespace is removed."""
+        from natcap.invest import utils
+
+        csv_file = os.path.join(self.workspace_dir, 'csv.csv')
+
+        with open(csv_file, 'w') as file_obj:
+            file_obj.write(" Col1, Col2 ,Col3 \n")
+            file_obj.write(" val1, val2 ,val3 \n")
+            file_obj.write(" , 2 1 ,  ")
+        df = utils.read_csv_to_dataframe(csv_file)
+        # header should have no leading / trailing whitespace
+        self.assertEqual(df.columns[0], 'Col1')
+        self.assertEqual(df.columns[1], 'Col2')
+        self.assertEqual(df.columns[2], 'Col3')
+        # values should have no leading / trailing whitespace
+        self.assertEqual(df['Col1'][0], 'val1')
+        self.assertEqual(df['Col2'][0], 'val2')
+        self.assertEqual(df['Col3'][0], 'val3')
+        self.assertEqual(df['Col1'][1], '')
+        self.assertEqual(df['Col2'][1], '2 1')
+        self.assertEqual(df['Col3'][1], '')
+
 
 class CreateCoordinateTransformationTests(unittest.TestCase):
     """Tests for natcap.invest.utils.create_coordinate_transformer."""


### PR DESCRIPTION
Updating `utils.read_csv_to_dataframe` function to remove leading/trailing whitespaces from csv table values as well as columns.

Added test in `test_utils` to check columns and values have whitespace removed.

## Description
Fixes #930 

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
