### PR TITLE
Workbench: use all available vertical space.

### DIFF
--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -5,11 +5,11 @@
 
 /*
 --header-height: fixed height applied to the top navbar.
---content-height: fixed height of the remaining viewport.
+--content-height: height of the remaining viewport.
   Apply this height to any container that should fill the
   available window height and also have a scrollbar appear
   when the content overflows. I could never get a scrollbar
-  to appear with height: 100%, even when parent has this fixed height;
+  to appear with height: 100%, even when parent has a fixed height;
 */
 body {
 	--invest-green: #148F68;
@@ -308,7 +308,6 @@ exceed 100% of window.*/
 	flex:  1 1 0;
 	padding-left: 0;
 	padding-right: 0;
-	height: var(--content-height);
 }
 
 .invest-main-col .tab-content {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -2,8 +2,20 @@
 	font-size: 16px;
 }
 
+
+/*
+--header-height: fixed height applied to the top navbar.
+--content-height: fixed height of the remaining viewport.
+  Apply this height to any container that should fill the
+  available window height and also have a scrollbar appear
+  when the content overflows. I could never get a scrollbar
+  to appear with height: 100%, even when parent has this fixed height;
+*/
 body {
 	--invest-green: #148F68;
+	--header-height: 64px;
+	--content-height: calc(100vh - var(--header-height));
+	min-height: 100vh;
 	background-color: rgba(0,0,0,0);
 	margin: 0;
 	overflow-y: hidden;
@@ -14,6 +26,7 @@ body {
 .navbar {
 	border-bottom: 3px solid var(--invest-green);
 	padding: 0;
+	height: var(--header-height)
 }
 
 .navbar .row {
@@ -162,7 +175,7 @@ exceed 100% of window.*/
 /* Home Tab */
 
 .invest-list-container {
-	height: 87vh;
+	height: var(--content-height);
 	overflow-y: auto;
 }
 
@@ -215,10 +228,7 @@ exceed 100% of window.*/
 }
 
 .recent-job-card-col {
-	display: flex;
-	flex-wrap: nowrap;
-	flex-direction: column;
-	height: 87vh;
+	height: var(--content-height);
 	overflow-y: auto;
 	padding-right: 0.5rem;
 }
@@ -298,7 +308,7 @@ exceed 100% of window.*/
 	flex:  1 1 0;
 	padding-left: 0;
 	padding-right: 0;
-	height: 85vh;
+	height: var(--content-height);
 }
 
 .invest-main-col .tab-content {
@@ -313,6 +323,7 @@ exceed 100% of window.*/
 	display: flex;
 	flex-direction: column;
 	padding-right: 0;
+	padding-bottom: 1rem;
 }
 
 .invest-sidebar-col .nav-link {
@@ -415,7 +426,7 @@ exceed 100% of window.*/
 
 /* InVEST Setup Tab */
 .args-form {
-	height: 85vh;
+	height: var(--content-height);
 	width: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -509,7 +520,7 @@ input[type=text]::placeholder {
 #log-display {
 	overflow: auto;
 	white-space: pre-wrap;
-	height: 85vh;
+	height: var(--content-height);
 }
 
 #log-text {
@@ -517,6 +528,7 @@ input[type=text]::placeholder {
 	font-size:1rem;
 	color: #000;
 	margin-top: 1rem;
+	margin-bottom: 1rem;
 }
 
 #log-text .invest-log-primary {


### PR DESCRIPTION
It seems that containers that should scroll on overflow require a well-defined height -- not a percentage height. So this PR removes some hardcoded values and adds CSS variables to calculate the viewport height available and make sure all of it gets used.

Fixes #972 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
