### PR TITLE
Bugfix for validation spatial overlap message

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -49,6 +49,8 @@ Unreleased Changes
       ``--taskgraph-log-level``.
     * Fixed bug in validation of ``results_suffix`` so that special characters
       like path separators, etc, are not allowed.
+    * Fixed a bug in validation where a warning about non-overlapping spatial
+      layers was missing info about the offending bounding boxes.
 * Crop Production
     * Fixed a bug in both crop production models where the model would error if
       an observed yield raster had no nodata value.

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -55,7 +55,7 @@ MESSAGES = {
     'NOT_AN_INTEGER': gettext('Value "{value}" does not represent an integer'),
     'NOT_BOOLEAN': gettext("Value must be either True or False, not {value}"),
     'NO_PROJECTION': gettext('Spatial file {filepath} has no projection'),
-    'BBOX_NOT_INTERSECT': gettext("Bounding boxes do not intersect:"),
+    'BBOX_NOT_INTERSECT': gettext("Bounding boxes do not intersect: {bboxes}"),
     'NEED_PERMISSION': gettext('You must have {permission} access to this file'),
 }
 
@@ -677,11 +677,16 @@ def check_spatial_overlap(spatial_filepaths_list,
         pygeoprocessing.merge_bounding_box_list(bounding_boxes, 'intersection')
     except ValueError as error:
         LOGGER.debug(error)
-        formatted_lists = ' | '.join(
-            [a + ': ' + str(b) for a, b in zip(
-                checked_file_list, bounding_boxes)])
+        formatted_lists = _format_bbox_list(checked_file_list, bounding_boxes)
         return MESSAGES['BBOX_NOT_INTERSECT'].format(bboxes=formatted_lists)
     return None
+
+
+def _format_bbox_list(file_list, bbox_list):
+    """Format two lists of equal length into one string."""
+    return ' | '.join(
+            [a + ': ' + str(b) for a, b in zip(
+                file_list, bbox_list)])
 
 
 def timeout(func, *args, timeout=5, **kwargs):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -45,6 +45,8 @@ class SpatialOverlapTest(unittest.TestCase):
 
         error_msg = validation.check_spatial_overlap([filepath_1, filepath_2])
         self.assertTrue(validation.MESSAGES['BBOX_NOT_INTERSECT'] in error_msg)
+        self.assertTrue(filepath_1 in error_msg)
+        self.assertTrue(filepath_2 in error_msg)
 
     def test_overlap(self):
         """Validation: verify overlap."""

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -1,4 +1,3 @@
-import os from 'os';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -35,7 +34,7 @@ function filterSpatialOverlapFeedback(message, filepath) {
   const bboxFormatted = bbox.split(' ').map(
     (str) => str.padEnd(22, ' ')
   ).join('').trim();
-  return `${newPrefix}${os.EOL}${bboxFormatted}`;
+  return `${newPrefix}\n${bboxFormatted}`;
 }
 
 function FormLabel(props) {

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -564,6 +564,9 @@ describe('Misc form validation stuff', () => {
     const expectedVal2 = '-79.0198012081401';
     const rasterBox = `[${expectedVal2}, 26.481559513537064, -78.37173806200593, 27.268061760228512]`;
     const message = `Bounding boxes do not intersect: ${vectorValue}: ${vectorBox} | ${rasterValue}: ${rasterBox}`;
+    const newPrefix = 'Bounding box does not intersect at least one other:';
+    const vectorMessage = new RegExp(`${newPrefix}\\s*\\[${expectedVal1}`);
+    const rasterMessage = new RegExp(`${newPrefix}\\s*\\[${expectedVal2}`);
 
     fetchValidation.mockResolvedValue([[Object.keys(spec.args), message]]);
 
@@ -577,17 +580,17 @@ describe('Misc form validation stuff', () => {
     // of that single input.
     const vectorGroup = vectorInput.closest('.input-group');
     await waitFor(() => {
-      expect(within(vectorGroup).getByText(RegExp(expectedVal1)))
+      expect(within(vectorGroup).getByText(vectorMessage))
         .toBeInTheDocument();
-      expect(within(vectorGroup).queryByText(RegExp(expectedVal2)))
+      expect(within(vectorGroup).queryByText(rasterMessage))
         .toBeNull();
     });
 
     const rasterGroup = rasterInput.closest('.input-group');
     await waitFor(() => {
-      expect(within(rasterGroup).getByText(RegExp(expectedVal2)))
+      expect(within(rasterGroup).getByText(rasterMessage))
         .toBeInTheDocument();
-      expect(within(rasterGroup).queryByText(RegExp(expectedVal1)))
+      expect(within(rasterGroup).queryByText(vectorMessage))
         .toBeNull();
     });
   });


### PR DESCRIPTION
Fixes #981 

This PR re-instates the complete feedback message when bounding boxes do not intersect. We were just missing the formatted list of bounding boxes.

Tests needed updating to use the new `kwarg` added to the string template. In one test, I actually fetched the bounding boxes and repeated the formatting step to assert the complete message is present. In other tests, I simply passed in a placeholder empty string, as the tests were focused on other things.

Fixes #980 

I removed the instance of the `os` module; there's no need to use an OS-specific newline character when we're rendering the text in the browser.

I failed to find an easy way to catch this problem during builds or tests: the case where a node module is imported on the renderer side. Maybe a solution will reveal itself as we get more familiar with vite.

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
