### PR TITLE
usage logging: switch from urllib to requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -380,7 +380,7 @@ jobs:
         # for a disk to unmount, and it fails to do so. Instead of waiting
         # for an inevitable failure, set timeout-minutes and allow continuation
         # https://github.com/natcap/invest/issues/984
-        timeout-minutes: 15
+        timeout-minutes: 30
         continue-on-error: true
         run: make ${{ matrix.binary-make-command }}
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -51,6 +51,8 @@ Unreleased Changes
       like path separators, etc, are not allowed.
     * Fixed a bug in validation where a warning about non-overlapping spatial
       layers was missing info about the offending bounding boxes.
+    * Fixed an issue with usage logging that caused SSL errors to appear in the
+      Qt interface logging window.
 * Annual Water Yield
     * Fixed a bug where the model would error when the watersheds/subwatersheds
       input was in geopackage format.


### PR DESCRIPTION
## Description
Fixes #792 
I'm not sure why this fixed the problem, but I'm no longer seeing the SSL error. I guess there's something behind the scenes that `requests` handles for us, but `urllib` doesn't. I'm seeing these debug messages at the end of the model run:
```
2022-05-26 12:56:07,002 (urllib3.connectionpool) connectionpool._new_conn(228) DEBUG Starting new HTTP connection (1): data.naturalcapitalproject.org:80
2022-05-26 12:56:07,029 (urllib3.connectionpool) connectionpool._make_request(456) DEBUG http://data.naturalcapitalproject.org:80 "GET /server_registry/invest_usage_logger_v2/index.html HTTP/1.1" 200 304
2022-05-26 12:56:07,032 (urllib3.connectionpool) connectionpool._new_conn(1001) DEBUG Starting new HTTPS connection (1): us-central1-natcap-servers.cloudfunctions.net:443
2022-05-26 12:56:07,224 (urllib3.connectionpool) connectionpool._make_request(456) DEBUG https://us-central1-natcap-servers.cloudfunctions.net:443 "POST /function-invest-model-finish HTTP/1.1" 200 40
```
so it seems to be working.

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
