### PR TITLE
reverting changes to use the Makefile solution. #984.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -376,12 +376,6 @@ jobs:
         run: make install
 
       - name: Build binaries
-        # Due to a create-dmg issue, sometimes we wait a very long time
-        # for a disk to unmount, and it fails to do so. Instead of waiting
-        # for an inevitable failure, set timeout-minutes and allow continuation
-        # https://github.com/natcap/invest/issues/984
-        timeout-minutes: 15
-        continue-on-error: true
         run: make ${{ matrix.binary-make-command }}
 
       - name: Install Node.js

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,8 @@ mac_dmg: $(MAC_DISK_IMAGE_FILE)
 $(MAC_DISK_IMAGE_FILE): $(DIST_DIR) $(MAC_APPLICATION_BUNDLE) $(USERGUIDE_TARGET_DIR)
 	# everything in the source directory $(MAC_APPLICATION_BUNDLE_DIR) will be copied into the DMG.
 	# so that directory should only contain the app bundle.
-	create-dmg \
+	# '-' prefix because https://github.com/natcap/invest/issues/984
+	-create-dmg \
 	    --volname "InVEST $(VERSION)" `# volume name, displayed in the top bar of the DMG window`\
 	    --volicon installer/darwin/invest.icns `# volume icon, displayed in the top bar of the DMG window`\
 	    --background installer/darwin/background.png `# background image of the DMG window`\


### PR DESCRIPTION
Fixes a bug introduced in #985 . We didn't want to wait for the inevitable `create-dmg` timeout, but setting a time limit & allowing `continue-on-error` for `make binaries` meant we sometimes ended up with an incomplete DMG. 

This PR moves the error-toleration to the Makefile. So we may have to wait for the full timeout from `create-dmg`, but we won't accidentally deploy broken DMGs.

Fixes #984 

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
