### PR TITLE
make custom dmg script derived from create-dmg

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -376,12 +376,6 @@ jobs:
         run: make install
 
       - name: Build binaries
-        # Due to a create-dmg issue, sometimes we wait a very long time
-        # for a disk to unmount, and it fails to do so. Instead of waiting
-        # for an inevitable failure, set timeout-minutes and allow continuation
-        # https://github.com/natcap/invest/issues/984
-        timeout-minutes: 15
-        continue-on-error: true
         run: make ${{ matrix.binary-make-command }}
 
       - name: Install Node.js
@@ -451,7 +445,9 @@ jobs:
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
-        run: make deploy
+        run: |
+          make deploy
+          ls dist
 
       - name: Upload binary artifact
         if: always()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -445,9 +445,7 @@ jobs:
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
-        run: |
-          make deploy
-          ls dist
+        run: make deploy
 
       - name: Upload binary artifact
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -358,20 +358,7 @@ mac_dmg: $(MAC_DISK_IMAGE_FILE)
 $(MAC_DISK_IMAGE_FILE): $(DIST_DIR) $(MAC_APPLICATION_BUNDLE) $(USERGUIDE_TARGET_DIR)
 	# everything in the source directory $(MAC_APPLICATION_BUNDLE_DIR) will be copied into the DMG.
 	# so that directory should only contain the app bundle.
-	create-dmg \
-	    --volname "InVEST $(VERSION)" `# volume name, displayed in the top bar of the DMG window`\
-	    --volicon installer/darwin/invest.icns `# volume icon, displayed in the top bar of the DMG window`\
-	    --background installer/darwin/background.png `# background image of the DMG window`\
-	    --window-pos 100 100 `# DMG window location when first opened, in pixels relative to screen top left corner`\
-	    --window-size 900 660 `# DMG window size in pixels`\
-	    --text-size 12 `# size of text in InVEST and Applications icon labels`\
-	    --icon-size 100 `# size of InVEST and Applications icons, in pixels`\
-	    --icon $(MAC_APPLICATION_BUNDLE_NAME) 220 290 `# InVEST app bundle and location of its icon in pixels relative to window top left corner`\
-	    --app-drop-link 670 290 `# location of Applications icon in pixels relative to window top left corner`\
-	    --eula LICENSE.txt `# license to display before DMG window opens`\
-	    --format UDZO `# disk image format`\
-	    $(MAC_DISK_IMAGE_FILE) `# path to create DMG at`\
-	    $(MAC_APPLICATION_BUNDLE_DIR) # directory containing the app bundle
+	installer/darwin/create_dmg.sh "InVEST $(VERSION)" $(MAC_APPLICATION_BUNDLE_DIR) $(MAC_DISK_IMAGE_FILE)
 
 mac_app: $(MAC_APPLICATION_BUNDLE)
 $(MAC_APPLICATION_BUNDLE): $(BUILD_DIR) $(INVEST_BINARIES_DIR) $(USERGUIDE_TARGET_DIR)

--- a/installer/darwin/create_dmg.sh
+++ b/installer/darwin/create_dmg.sh
@@ -86,7 +86,7 @@ ln -s /Applications "$MOUNT_DIR/Applications"
 cp $VOLUME_ICON_FILE "$MOUNT_DIR/.VolumeIcon.icns"
 SetFile -c icnC "$MOUNT_DIR/.VolumeIcon.icns"
 
-sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues  
+sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues
 # Run AppleScript to do all the Finder cosmetic stuff
 /usr/bin/osascript installer/darwin/customize_dmg.applescript "$VOLUME_NAME"
 sleep 4
@@ -108,10 +108,10 @@ exit_code=1
 until [[ $exit_code -eq 0 || $unmounting_attempts -gt 10 ]]
 do
     echo "Unmounting disk image..."
-    hdiutil detach $DEV_NAME
+    hdiutil detach $DEV_NAME && break
     exit_code=$?
     ((unmounting_attempts=unmounting_attempts+1))
-    sleep $(( 1 * (2 ** unmounting_attempts) ))
+    sleep 2
 done
 unset unmounting_attempts
 
@@ -128,7 +128,10 @@ EULA_RESOURCES_FILE=$(mktemp -t createdmg.tmp.XXXXXXXXXX)
 # Encode the EULA to base64
 EULA_DATA=$(base64 -b 52 $EULA | sed s$'/^\(.*\)$/\t\t\t\\1/')
 # Fill the template with the custom EULA contents
-eval "cat > \"${EULA_RESOURCES_FILE}\" <<EOF$(<installer/darwin/eula_resources_template.xml)EOF"
+eval "cat > \"${EULA_RESOURCES_FILE}\" <<EOF
+$(<installer/darwin/eula_resources_template.xml)
+EOF
+"
 # Add the license
 hdiutil udifrez -xml $EULA_RESOURCES_FILE '' $DMG_DIR/$DMG_NAME
-rm EULA_RESOURCES_FILE
+rm $EULA_RESOURCES_FILE

--- a/installer/darwin/create_dmg.sh
+++ b/installer/darwin/create_dmg.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+# Create a read-only disk image of the contents of a folder
+# This script is derived from the create-dmg utility
+# https://github.com/create-dmg/create-dmg
+
+# Bail out on any unhandled errors
+set -ex;
+
+VOLUME_NAME=$1
+APP_BUNDLE_PATH=$2
+DMG_PATH=$3
+
+VOLUME_ICON_FILE=installer/darwin/invest.icns
+BACKGROUND_FILE=installer/darwin/background.png
+EULA=LICENSE.txt
+
+SRC_FOLDER=$(cd $APP_BUNDLE_PATH > /dev/null; pwd)
+DMG_DIRNAME=$(dirname $DMG_PATH)
+DMG_DIR=$(cd $DMG_DIRNAME > /dev/null; pwd)
+DMG_NAME=$(basename $DMG_PATH)
+DMG_TEMP_NAME=$DMG_DIR/tmp.$DMG_NAME
+
+# remove .DS_Store from source folder, if there is one
+rm $SRC_FOLDER/.DS_Store || true
+
+# remove intermediate dmg from previous run, if there is one
+rm -f $DMG_TEMP_NAME || true
+
+# Use Megabytes since hdiutil fails with very large byte numbers
+function blocks_to_megabytes() {
+    # Add 1 extra MB, since there's no decimal retention here
+    MB_SIZE=$((($1 * 512 / 1000 / 1000) + 1))
+    echo $MB_SIZE
+}
+
+function get_size() {
+    # Get block size in disk
+    bytes_size=$(du -s "$1" | sed -e 's/    .*//g')
+    echo $(blocks_to_megabytes $bytes_size)
+}
+
+# Create the DMG with the hdiutil estimation
+hdiutil create \
+    -srcfolder $SRC_FOLDER \
+    -volname "$VOLUME_NAME" \
+    -fs HFS+ `# type of file system to write to the image`\
+    -fsargs "-c c=64,a=16,e=16" \
+    -format UDRW `# UDIF read/write image, so we can add the license to it`\
+    $DMG_TEMP_NAME
+
+# Get the created DMG actual size
+DISK_IMAGE_SIZE=$(get_size $DMG_TEMP_NAME)
+
+# Add extra space for additional resources
+DISK_IMAGE_SIZE=$(expr $DISK_IMAGE_SIZE + 20)
+
+# Make sure target image size is within limits
+MIN_DISK_IMAGE_SIZE=$(hdiutil resize -limits $DMG_TEMP_NAME | awk 'NR=1{print int($1/2048+1)}')
+if [ $MIN_DISK_IMAGE_SIZE -gt $DISK_IMAGE_SIZE ]; then
+    DISK_IMAGE_SIZE=$MIN_DISK_IMAGE_SIZE
+fi
+
+# Resize the image for the extra stuff
+hdiutil resize -size ${DISK_IMAGE_SIZE}m $DMG_TEMP_NAME
+
+# Mount the new DMG
+MOUNT_DIR="/Volumes/$VOLUME_NAME"
+
+# Unmount leftover dmg if it was mounted previously (e.g. developer mounted dmg, installed app and forgot to unmount it)
+if [[ -d $MOUNT_DIR ]]; then
+    DEV_NAME=$(hdiutil info | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
+    hdiutil detach $DEV_NAME
+fi
+
+DEV_NAME=$(hdiutil attach -readwrite -noverify -noautoopen $DMG_TEMP_NAME | grep -E --color=never '^/dev/' | sed 1q | awk '{print $1}')
+
+# Copy background image file into volume
+mkdir "$MOUNT_DIR/.background"
+cp $BACKGROUND_FILE "$MOUNT_DIR/.background/$(basename $BACKGROUND_FILE)"
+
+# Link Applications into volume
+ln -s /Applications "$MOUNT_DIR/Applications"
+
+# Copy icon into volume
+cp $VOLUME_ICON_FILE "$MOUNT_DIR/.VolumeIcon.icns"
+SetFile -c icnC "$MOUNT_DIR/.VolumeIcon.icns"
+
+sleep 2 # pause to workaround occasional "Can’t get disk" (-1728) issues  
+# Run AppleScript to do all the Finder cosmetic stuff
+/usr/bin/osascript installer/darwin/customize_dmg.applescript "$VOLUME_NAME"
+sleep 4
+
+# Make sure it's not world writeable
+chmod -Rf go-w "$MOUNT_DIR" &> /dev/null || true
+
+# Tell the volume that it has a special file attribute
+SetFile -a C "$MOUNT_DIR"
+
+# Delete unnecessary file system events log if possible
+rm -rf "$MOUNT_DIR/.fseventsd" || true
+
+# Unmount
+unmounting_attempts=0
+until
+  echo "Unmounting disk image..."
+  (( unmounting_attempts++ ))
+  hdiutil detach $DEV_NAME
+    exit_code=$?
+    (( exit_code ==  0 )) && break            # nothing goes wrong
+    (( exit_code != 16 )) && exit $exit_code  # exit with the original exit code
+    # The above statement returns 1 if test failed (exit_code == 16).
+    #   It can make the code in the {do... done} block to be executed
+do
+  (( unmounting_attempts == 3 )) && exit 16  # patience exhausted, exit with code EBUSY
+    echo "Wait a moment..."
+  sleep $(( 1 * (2 ** unmounting_attempts) ))
+done
+unset unmounting_attempts
+
+# Compress image
+hdiutil convert $DMG_TEMP_NAME \
+    -format UDZO `# UDIF zlib-compressed image`\
+    -imagekey zlib-level=9 `# zlib compression level`\
+    -o $DMG_DIR/$DMG_NAME
+
+rm -f $DMG_TEMP_NAME
+
+# Add EULA resources
+EULA_RESOURCES_FILE=$(mktemp -t createdmg.tmp.XXXXXXXXXX)
+# Encode the EULA to base64
+EULA_DATA=$(base64 -b 52 $EULA | sed s$'/^\(.*\)$/\t\t\t\\1/')
+# Fill the template with the custom EULA contents
+eval "cat > \"${EULA_RESOURCES_FILE}\" <<EOF$(<installer/darwin/eula_resources_template.xml)EOF"
+# Add the license
+hdiutil udifrez -xml $EULA_RESOURCES_FILE '' $DMG_DIR/$DMG_NAME
+rm EULA_RESOURCES_FILE

--- a/installer/darwin/create_dmg.sh
+++ b/installer/darwin/create_dmg.sh
@@ -100,6 +100,8 @@ SetFile -a C "$MOUNT_DIR"
 # Delete unnecessary file system events log if possible
 rm -rf "$MOUNT_DIR/.fseventsd" || true
 
+sleep 60
+
 # Unmount
 unmounting_attempts=0
 until

--- a/installer/darwin/customize_dmg.applescript
+++ b/installer/darwin/customize_dmg.applescript
@@ -1,0 +1,73 @@
+-- This script is derived from the create-dmg utility
+-- https://github.com/create-dmg/create-dmg
+on run (volumeName)
+    tell application "Finder"
+        tell disk (volumeName as string)
+            open
+
+            -- location and size of DMG window when opened
+            set theXOrigin to 100
+            set theYOrigin to 100
+            set theWidth to 900
+            set theHeight to 660
+
+            set theBottomRightX to (theXOrigin + theWidth)
+            set theBottomRightY to (theYOrigin + theHeight)
+            set dsStore to "\"" & "/Volumes/" & volumeName & "/" & ".DS_STORE\""
+
+            tell container window
+                set current view to icon view
+                set toolbar visible to false
+                set statusbar visible to false
+                set the bounds to {theXOrigin, theYOrigin, theBottomRightX, theBottomRightY}
+                set statusbar visible to false
+                set position of every item to {theBottomRightX + 100, 100}
+            end tell
+
+            set opts to the icon view options of container window
+            tell opts
+                set icon size to 100
+                set text size to 12
+                set arrangement to not arranged
+            end tell
+            set background picture of opts to file ".background:background.png"
+
+            -- Positioning
+            set position of item "InVEST.app" to {220, 290}
+
+            -- Applications link
+            set position of item "Applications" to {670, 290}
+            close
+            open
+            -- Force saving of the size
+            delay 1
+
+            tell container window
+                set statusbar visible to false
+                set the bounds to {theXOrigin, theYOrigin, theBottomRightX - 10, theBottomRightY - 10}
+            end tell
+        end tell
+
+        delay 1
+
+        tell disk (volumeName as string)
+            tell container window
+                set statusbar visible to false
+                set the bounds to {theXOrigin, theYOrigin, theBottomRightX, theBottomRightY}
+            end tell
+        end tell
+
+        --give the finder some time to write the .DS_Store file
+        delay 3
+
+        set waitTime to 0
+        set ejectMe to false
+        repeat while ejectMe is false
+            delay 1
+            set waitTime to waitTime + 1
+            
+            if (do shell script "[ -f " & dsStore & " ]; echo $?") = "0" then set ejectMe to true
+        end repeat
+        log "waited " & waitTime & " seconds for .DS_STORE to be created."
+    end tell
+end run

--- a/installer/darwin/eula_resources_template.xml
+++ b/installer/darwin/eula_resources_template.xml
@@ -1,0 +1,110 @@
+<!--
+This template is taken from the create-dmg utility
+https://github.com/create-dmg/create-dmg
+The base64 encoded data strings below are standard parts of the EULA
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LPic</key>
+    <array>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+            AAAAAgAAAAAAAAAAAAQAAA==
+            </data>
+            <key>ID</key>
+            <string>5000</string>
+            <key>Name</key>
+            <string></string>
+        </dict>
+    </array>
+    <key>STR#</key>
+    <array>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+            AAYNRW5nbGlzaCB0ZXN0MQVBZ3JlZQhEaXNhZ3JlZQVQcmludAdT
+            YXZlLi4ueklmIHlvdSBhZ3JlZSB3aXRoIHRoZSB0ZXJtcyBvZiB0
+            aGlzIGxpY2Vuc2UsIGNsaWNrICJBZ3JlZSIgdG8gYWNjZXNzIHRo
+            ZSBzb2Z0d2FyZS4gIElmIHlvdSBkbyBub3QgYWdyZWUsIHByZXNz
+            ICJEaXNhZ3JlZS4i
+            </data>
+            <key>ID</key>
+            <string>5000</string>
+            <key>Name</key>
+            <string>English buttons</string>
+        </dict>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+            AAYHRW5nbGlzaAVBZ3JlZQhEaXNhZ3JlZQVQcmludAdTYXZlLi4u
+            e0lmIHlvdSBhZ3JlZSB3aXRoIHRoZSB0ZXJtcyBvZiB0aGlzIGxp
+            Y2Vuc2UsIHByZXNzICJBZ3JlZSIgdG8gaW5zdGFsbCB0aGUgc29m
+            dHdhcmUuICBJZiB5b3UgZG8gbm90IGFncmVlLCBwcmVzcyAiRGlz
+            YWdyZWUiLg==
+            </data>
+            <key>ID</key>
+            <string>5002</string>
+            <key>Name</key>
+            <string>English</string>
+        </dict>
+    </array>
+    <key>TEXT</key>
+    <array>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+${EULA_DATA}
+            </data>
+            <key>ID</key>
+            <string>5000</string>
+            <key>Name</key>
+            <string>English</string>
+        </dict>
+    </array>
+    <key>TMPL</key>
+    <array>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+            E0RlZmF1bHQgTGFuZ3VhZ2UgSUREV1JEBUNvdW50T0NOVAQqKioq
+            TFNUQwtzeXMgbGFuZyBJRERXUkQebG9jYWwgcmVzIElEIChvZmZz
+            ZXQgZnJvbSA1MDAwRFdSRBAyLWJ5dGUgbGFuZ3VhZ2U/RFdSRAQq
+            KioqTFNURQ==
+            </data>
+            <key>ID</key>
+            <string>128</string>
+            <key>Name</key>
+            <string>LPic</string>
+        </dict>
+    </array>
+    <key>styl</key>
+    <array>
+        <dict>
+            <key>Attributes</key>
+            <string>0x0000</string>
+            <key>Data</key>
+            <data>
+            AAMAAAAAAAwACQAUAAAAAAAAAAAAAAAAACcADAAJABQBAAAAAAAA
+            AAAAAAAAKgAMAAkAFAAAAAAAAAAAAAA=
+            </data>
+            <key>ID</key>
+            <string>5000</string>
+            <key>Name</key>
+            <string>English</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Description
Fixes #984 

This is meant to be a temporary solution assuming that we'll soon switch to the workbench, and then electron-builder will take care of the DMG build for us. The bash script is not great, some things are hard coded, and the base 64 strings in the XML template are weird. But it works!

## Checklist
- [ ] ~Updated HISTORY.rst (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
