### PR TITLE
CV: Handling unset nodata in bathymetry masking.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -57,6 +57,10 @@ Unreleased Changes
 * Crop Production
     * Fixed a bug in both crop production models where the model would error if
       an observed yield raster had no nodata value.
+* Coastal Vulnerability
+    * Fixed a bug that would cause an error if the user's bathymetry layer did
+      not have a defined nodata value.  The user's bathymetry layer should now
+      be correctly preprocessed with or without a nodata value.
 * DelineateIt
     * Watersheds delineated with this tool will now always have a ``ws_id``
       column containing integer watershed IDs for easier use within the routed

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1,33 +1,32 @@
 """InVEST Coastal Vulnerability."""
-import time
-import os
-import math
 import logging
+import math
+import os
 import pickle
+import time
 
 import numpy
-from osgeo import gdal
-from osgeo import osr
-from osgeo import ogr
 import pandas
+import pygeoprocessing
 import rtree
 import shapely
-import shapely.wkb
+import shapely.errors
 import shapely.ops
 import shapely.speedups
-import shapely.errors
-from shapely.strtree import STRtree
-from shapely.geometry.base import BaseMultipartGeometry
-import pygeoprocessing
+import shapely.wkb
 import taskgraph
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
+from shapely.geometry.base import BaseMultipartGeometry
+from shapely.strtree import STRtree
 
-from . import utils
+from . import gettext
 from . import spec_utils
-from .spec_utils import u
+from . import utils
 from . import validation
 from .model_metadata import MODEL_METADATA
-from . import gettext
-
+from .spec_utils import u
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1777,7 +1776,8 @@ def zero_negative_values(depth_array, nodata):
 def mask_positive_values_op(depth_array, nodata):
     """Convert positive values to nodata for bathymetry."""
     result_array = numpy.empty_like(depth_array)
-    result_array[:] = nodata
+    if nodata is not None:
+        result_array[:] = nodata
     negative_mask = depth_array < 0
     result_array[negative_mask] = depth_array[negative_mask]
     return result_array

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -1776,8 +1776,7 @@ def zero_negative_values(depth_array, nodata):
 def mask_positive_values_op(depth_array, nodata):
     """Convert positive values to nodata for bathymetry."""
     result_array = numpy.empty_like(depth_array)
-    if nodata is not None:
-        result_array[:] = nodata
+    result_array[:] = nodata
     negative_mask = depth_array < 0
     result_array[negative_mask] = depth_array[negative_mask]
     return result_array
@@ -1809,6 +1808,15 @@ def warp_and_mask_bathymetry(
     bathy_info = pygeoprocessing.get_raster_info(
         bathymetry_raster_path)
     bathy_nodata = bathy_info['nodata'][0]
+    if bathy_nodata is None:
+        # If a nodata value is not provided, assume the largest positive value
+        # that the datatype can support.  Once we finish masking bathymetry,
+        # all positive values are masked out anyways so this should be safe.
+        try:
+            bathy_nodata = numpy.finfo(bathy_info['numpy_type']).max
+        except ValueError:
+            # When the numpy dtype is not a float, must be an int.
+            bathy_nodata = numpy.iinfo(bathy_info['numpy_type']).max
     bathy_target_dtype = bathy_info['datatype']
 
     clip_and_project_raster(

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -1,21 +1,25 @@
 """Module for Regression Testing the InVEST Coastal Vulnerability module."""
-import unittest
-import tempfile
-import shutil
+import json
 import os
 import pickle
-import json
+import shutil
+import tempfile
+import unittest
 
-from osgeo import gdal, osr, ogr
 import numpy.testing
 import pandas.testing
 import pygeoprocessing
-from shapely.geometry import Point, Polygon, MultiPolygon
-from shapely.geometry import LineString, MultiLineString
 import shapely.wkb
 import taskgraph
-
 from natcap.invest import coastal_vulnerability
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
+from shapely.geometry import LineString
+from shapely.geometry import MultiLineString
+from shapely.geometry import MultiPolygon
+from shapely.geometry import Point
+from shapely.geometry import Polygon
 
 REGRESSION_DATA = os.path.join(
     os.path.dirname(__file__), '..', 'data', 'invest-test-data',
@@ -157,6 +161,21 @@ class CoastalVulnerabilityTests(unittest.TestCase):
             REGRESSION_DATA, 'expected_wave.json')
         assert_pickled_arrays_almost_equal(
             target_wave_exposure_pickle_path, expected_raw_values_path)
+
+    def test_warp_and_mask_op_function(self):
+        """CV: warp_and_mask raster_calculator op handles unset nodata."""
+        # Check a few dtypes for good measure.
+        for dtype in (numpy.int32, numpy.float32):
+            array = numpy.full((5, 5), -1, dtype=dtype)
+            expected_array = array.copy()
+
+            # check that we can handle arbitrary nodata
+            coastal_vulnerability.mask_positive_values_op(array, 255)
+            numpy.testing.assert_allclose(array, expected_array)
+
+            # Check that we can handle unset nodata.
+            coastal_vulnerability.mask_positive_values_op(array, None)
+            numpy.testing.assert_allclose(array, expected_array)
 
     def test_extract_bathymetry(self):
         """CV: regression test for extracting bathymetry along ray."""

--- a/tests/test_coastal_vulnerability.py
+++ b/tests/test_coastal_vulnerability.py
@@ -162,20 +162,56 @@ class CoastalVulnerabilityTests(unittest.TestCase):
         assert_pickled_arrays_almost_equal(
             target_wave_exposure_pickle_path, expected_raw_values_path)
 
-    def test_warp_and_mask_op_function(self):
-        """CV: warp_and_mask raster_calculator op handles unset nodata."""
-        # Check a few dtypes for good measure.
-        for dtype in (numpy.int32, numpy.float32):
-            array = numpy.full((5, 5), -1, dtype=dtype)
-            expected_array = array.copy()
+    def test_warp_and_mask_bathymetry_with_no_nodata(self):
+        """CV: warp_and_mask_bathymetry when bathy has no nodata."""
+        base_shore_point_vector_path = os.path.join(
+            INPUT_DATA, "wwiii_shore_points_5000m.gpkg")
+        workspace_dir = self.workspace_dir
+        base_bathy_raster_path = os.path.join(INPUT_DATA, 'dem_wgs84.tif')
 
-            # check that we can handle arbitrary nodata
-            coastal_vulnerability.mask_positive_values_op(array, 255)
-            numpy.testing.assert_allclose(array, expected_array)
+        # Copy the raster over to the workspace and unset the nodata value
+        # there.
+        no_nodata_bathy_raster_path = os.path.join(
+            workspace_dir, 'no_nodata_dem_wgs84.tif')
+        shutil.copyfile(base_bathy_raster_path, no_nodata_bathy_raster_path)
+        try:
+            raster = gdal.OpenEx(no_nodata_bathy_raster_path, gdal.GA_Update)
+            band = raster.GetRasterBand(1)
+            band.DeleteNoDataValue()
+        finally:
+            band = None
+            raster = None
+        self.assertEqual(  # Make sure we correctly deleted the nodata value.
+            pygeoprocessing.get_raster_info(
+                no_nodata_bathy_raster_path)['nodata'][0],
+            None)
+        target_bathy_raster_path = os.path.join(
+            workspace_dir, 'negative_bathymetry.tif')
+        proxy_vector_info = pygeoprocessing.get_vector_info(
+            base_shore_point_vector_path)
+        proxy_srs_wkt = proxy_vector_info['projection_wkt']
+        proxy_bounding_box = proxy_vector_info['bounding_box']
+        # add the max_fetch_distance to the bounding box so we can use
+        # the clipped raster in the fetch-ray-depth routine.
+        model_resolution = 5000
+        # add the model resolution, to be safe
+        max_fetch_distance = 12000
+        fetch_buffer = max_fetch_distance + model_resolution
+        proxy_bounding_box[0] -= fetch_buffer
+        proxy_bounding_box[1] -= fetch_buffer
+        proxy_bounding_box[2] += fetch_buffer
+        proxy_bounding_box[3] += fetch_buffer
 
-            # Check that we can handle unset nodata.
-            coastal_vulnerability.mask_positive_values_op(array, None)
-            numpy.testing.assert_allclose(array, expected_array)
+        coastal_vulnerability.warp_and_mask_bathymetry(
+            no_nodata_bathy_raster_path, proxy_srs_wkt, proxy_bounding_box,
+            model_resolution, workspace_dir, '',
+            target_bathy_raster_path)
+
+        # Check that the new raster has a nodata value set.
+        self.assertNotEquals(
+            pygeoprocessing.get_raster_info(
+                target_bathy_raster_path)['nodata'][0],
+            None)
 
     def test_extract_bathymetry(self):
         """CV: regression test for extracting bathymetry along ray."""


### PR DESCRIPTION
This PR handles the case where the bathymetry raster could have an unset nodata.

## Description
Fixes #992

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
