### PR TITLE
WB: Simplify the rules for adding to the recent runs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,15 +26,20 @@
   - Wave Energy
   - Wind Energy
 
+  Workbench fixes/enhancements:
+  - Workbench
+
   Everything else:
   - General
 
-
 .. :changelog:
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* General
+* Workbench
+    * Fixed a bug where some model runs would not generate a new item
+      in the list of recent runs.
 
 3.11.0 (2022-05-24)
 -------------------

--- a/workbench/src/preload/api.js
+++ b/workbench/src/preload/api.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import path from 'path';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -28,9 +27,6 @@ export default {
   getLogger: getLogger,
   path: {
     resolve: path.resolve,
-  },
-  crypto: {
-    sha1hash: (data) => crypto.createHash('sha1').update(data).digest('hex'),
   },
   electron: {
     ipcRenderer: {

--- a/workbench/src/renderer/InvestJob.js
+++ b/workbench/src/renderer/InvestJob.js
@@ -1,6 +1,5 @@
 import localforage from 'localforage';
 
-const { crypto } = window.Workbench;
 const logger = window.Workbench.getLogger('InvestJob.js');
 
 const HASH_ARRAY_KEY = 'jobHashes';
@@ -44,10 +43,12 @@ export default class InvestJob {
   }
 
   static async saveJob(job) {
+    job.hash = window.crypto.getRandomValues(
+      new Uint32Array(1)
+    ).toString();
     const isoDate = new Date().toISOString().split('T')[0];
     const localTime = new Date().toTimeString().split(' ')[0];
     job.humanTime = `${isoDate} ${localTime}`;
-    job.hash = crypto.sha1hash(job.humanTime);
     let sortedJobHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
     if (!sortedJobHashes) {
       await InvestJob.initDB();

--- a/workbench/src/renderer/InvestJob.js
+++ b/workbench/src/renderer/InvestJob.js
@@ -1,9 +1,9 @@
 import localforage from 'localforage';
 
-const { crypto, path } = window.Workbench;
+const { crypto } = window.Workbench;
 const logger = window.Workbench.getLogger('InvestJob.js');
 
-const HASH_ARRAY_KEY = 'workspaceHashes';
+const HASH_ARRAY_KEY = 'jobHashes';
 const MAX_CACHED_JOBS = 30;
 const investJobStore = localforage.createInstance({
   name: 'InvestJobs'
@@ -20,8 +20,8 @@ export default class InvestJob {
 
   /* If none exists, init an empty array for the sorted workspace hashes */
   static async initDB() {
-    const workspaceHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
-    if (!workspaceHashes) {
+    const jobHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
+    if (!jobHashes) {
       investJobStore.setItem(HASH_ARRAY_KEY, []);
     }
   }
@@ -29,9 +29,9 @@ export default class InvestJob {
   /* Return an array of job metadata objects, ordered by most recently saved */
   static async getJobStore() {
     let jobArray = [];
-    const sortedWorkspaceHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
-    if (sortedWorkspaceHashes) {
-      jobArray = await Promise.all(sortedWorkspaceHashes.map(
+    const sortedJobHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
+    if (sortedJobHashes) {
+      jobArray = await Promise.all(sortedJobHashes.map(
         (key) => investJobStore.getItem(key)
       ));
     }
@@ -43,50 +43,24 @@ export default class InvestJob {
     return InvestJob.getJobStore();
   }
 
-  static getWorkspaceHash(modelRunName, workspaceDir, resultsSuffix) {
-    if (workspaceDir && modelRunName) {
-      const workspaceHash = crypto.sha1hash(
-        `${modelRunName}
-         ${JSON.stringify(path.resolve(workspaceDir))}
-         ${JSON.stringify(resultsSuffix)}`
-      );
-      return workspaceHash;
-    }
-    throw Error(
-      'Cannot hash a job that is missing workspace or modelRunName properties'
-    );
-  }
-
   static async saveJob(job) {
-    if (!job.workspaceHash) {
-      job.workspaceHash = this.getWorkspaceHash(
-        job.modelRunName,
-        job.argsValues.workspace_dir,
-        job.argsValues.resultsSuffix
-      );
-    }
     const isoDate = new Date().toISOString().split('T')[0];
     const localTime = new Date().toTimeString().split(' ')[0];
     job.humanTime = `${isoDate} ${localTime}`;
-    let sortedWorkspaceHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
-    if (!sortedWorkspaceHashes) {
+    job.hash = crypto.sha1hash(job.humanTime);
+    let sortedJobHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
+    if (!sortedJobHashes) {
       await InvestJob.initDB();
-      sortedWorkspaceHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
+      sortedJobHashes = await investJobStore.getItem(HASH_ARRAY_KEY);
     }
-    // If this key already exists, make sure not to duplicate it,
-    // and make sure to move it to the front
-    const idx = sortedWorkspaceHashes.indexOf(job.workspaceHash);
-    if (idx > -1) {
-      sortedWorkspaceHashes.splice(idx, 1);
-    }
-    sortedWorkspaceHashes.unshift(job.workspaceHash);
-    if (sortedWorkspaceHashes.length > MAX_CACHED_JOBS) {
+    sortedJobHashes.unshift(job.hash);
+    if (sortedJobHashes.length > MAX_CACHED_JOBS) {
       // only 1 key is ever added at a time, so only 1 item to remove
-      const lastKey = sortedWorkspaceHashes.pop();
+      const lastKey = sortedJobHashes.pop();
       investJobStore.removeItem(lastKey);
     }
-    await investJobStore.setItem(HASH_ARRAY_KEY, sortedWorkspaceHashes);
-    await investJobStore.setItem(job.workspaceHash, job);
+    await investJobStore.setItem(HASH_ARRAY_KEY, sortedJobHashes);
+    await investJobStore.setItem(job.hash, job);
     return InvestJob.getJobStore();
   }
 
@@ -119,6 +93,6 @@ export default class InvestJob {
     this.logfile = logfile;
     this.status = status;
     this.finalTraceback = finalTraceback;
-    this.workspaceHash = null;
+    this.hash = null;
   }
 }

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -143,7 +143,6 @@ class RecentInvestJobs extends React.Component {
               <span className="text-heading">{'Suffix: '}</span>
               <span className="text-mono">{job.argsValues.results_suffix}</span>
             </Card.Title>
-            <Card.Text>{job.description || <em>no description</em>}</Card.Text>
             <Card.Footer className="text-muted">
               <span className="timestamp">{job.humanTime}</span>
               <span className="status">

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -128,7 +128,7 @@ class RecentInvestJobs extends React.Component {
         <Card
           className="text-left recent-job-card"
           as="button"
-          key={job.workspaceHash}
+          key={job.hash}
           onClick={() => this.handleClick(job)}
         >
           <Card.Body>
@@ -146,10 +146,10 @@ class RecentInvestJobs extends React.Component {
             <Card.Text>{job.description || <em>no description</em>}</Card.Text>
             <Card.Footer className="text-muted">
               <span className="timestamp">{job.humanTime}</span>
-              <span className="status-traceback">
+              <span className="status">
                 {(job.status === 'success'
-                  ? '\u{2705}'
-                  : <em>{job.finalTraceback || ''}</em>
+                  ? <span className="status-success">{_('Model Complete')}</span>
+                  : <span className="status-error">{job.finalTraceback || ''}</span>
                 )}
               </span>
             </Card.Footer>

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -291,10 +291,22 @@ exceed 100% of window.*/
 	white-space: nowrap;
 }
 
-.card-footer .status-traceback {
+.card-footer .status {
+	overflow: hidden;
+	font-style: italic;
+}
+
+.card-footer .status-error {
+	display: inline-block;
 	color: red;
 	overflow: hidden;
-	text-overflow: ellipsis;	
+	text-overflow: ellipsis;
+	width: 100%;
+	white-space: nowrap;
+}
+
+.card-footer .status-success {
+	color: var(--invest-green);
 }
 
 .card-footer .timestamp {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -248,6 +248,7 @@ exceed 100% of window.*/
 	margin-bottom: 1rem;
 	padding: 0;
 	height: fit-content;
+	filter: drop-shadow(2px 2px 2px grey);
 }
 
 .card-body {
@@ -258,6 +259,9 @@ exceed 100% of window.*/
 .card-header {
 	background-color: var(--invest-green);
 	filter: opacity(0.75);
+	margin-bottom: 1rem;
+	margin-left: -0.1rem;
+	margin-right: -0.05rem;
 }
 
 .card-header .header-title {
@@ -268,7 +272,6 @@ exceed 100% of window.*/
 }
 
 .card-title {
-	padding-top: 1rem;
 	padding-left: 1.25rem;
 }
 
@@ -281,14 +284,15 @@ exceed 100% of window.*/
 	font-size: 1.2rem;
 }
 
-.card-text {
-	padding-left: 1.25rem;
-}
-
 .card-footer {
 	display: flex;
 	justify-content: space-between;
 	white-space: nowrap;
+	padding-right: 1rem;
+}
+
+.card-footer span {
+	text-overflow: ellipsis;
 }
 
 .card-footer .status {
@@ -297,12 +301,7 @@ exceed 100% of window.*/
 }
 
 .card-footer .status-error {
-	display: inline-block;
 	color: red;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	width: 100%;
-	white-space: nowrap;
 }
 
 .card-footer .status-success {

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -322,7 +322,7 @@ describe('Display recently executed InVEST jobs on Home tab', () => {
         expect(within(card).getByText(job.argsValues.workspace_dir))
           .toBeInTheDocument();
         if (job.status === 'success') {
-          expect(getByText('\u{2705}'))
+          expect(getByText('Model Complete'))
             .toBeInTheDocument();
         }
         if (job.status === 'error' && job.finalTraceback) {

--- a/workbench/tests/renderer/investjob.test.js
+++ b/workbench/tests/renderer/investjob.test.js
@@ -22,45 +22,6 @@ describe('InvestJob', () => {
       .toThrow(errorMessage);
   });
 
-  test('workspaceHash collisions only when expected', async () => {
-    const modelName = 'foo';
-    const job1 = new InvestJob({
-      modelRunName: modelName,
-      modelHumanName: 'Foo',
-      argsValues: baseArgsValues,
-    });
-    InvestJob.saveJob(job1);
-    const job2 = new InvestJob({
-      modelRunName: modelName,
-      modelHumanName: 'Foo',
-      argsValues: baseArgsValues,
-    });
-    let storedJobs = await InvestJob.saveJob(job2);
-    // Identical workspace, suffix, and modelRunName mean there should
-    // only be one saved job.
-    expect(storedJobs).toHaveLength(1);
-
-    const job3 = new InvestJob({
-      modelRunName: 'carbon',
-      modelHumanName: 'Foo',
-      argsValues: baseArgsValues,
-    });
-    storedJobs = await InvestJob.saveJob(job3);
-    // A different model with the same workspace should not collide
-    expect(storedJobs).toHaveLength(2);
-  });
-
-  test('save method errors if no workspace is set', async () => {
-    const job = new InvestJob({
-      modelRunName: 'foo',
-      modelHumanName: 'Foo',
-      argsValues: { results_suffix: 'foo' },
-    });
-    await expect(InvestJob.saveJob(job)).rejects.toThrow(
-      'Cannot hash a job that is missing workspace or modelRunName properties'
-    );
-  });
-
   test('save method works with no pre-existing database', async () => {
     const job = new InvestJob({
       modelRunName: 'foo',
@@ -91,10 +52,10 @@ describe('InvestJob', () => {
     expect(recentJobs[0]).toBe(job2);
     recentJobs = await InvestJob.saveJob(job1);
     expect(recentJobs[0]).toBe(job1);
-    expect(recentJobs).toHaveLength(2);
+    expect(recentJobs).toHaveLength(3);
   });
 
-  test('save on the same instance overwrites entry', async () => {
+  test('save on the same job adds new entry', async () => {
     const job1 = new InvestJob({
       modelRunName: 'foo',
       modelHumanName: 'Foo',
@@ -103,7 +64,7 @@ describe('InvestJob', () => {
     let recentJobs = await InvestJob.saveJob(job1);
     expect(recentJobs).toHaveLength(1);
     recentJobs = await InvestJob.saveJob(job1);
-    expect(recentJobs).toHaveLength(1);
+    expect(recentJobs).toHaveLength(2);
   });
 
   test('save never accumulates more jobs than max allowed', async () => {


### PR DESCRIPTION
The new rule is, anytime an invest model run exits, a new job is appended to the list of the recent runs. 

Also some minor enhancements to style and layout of the cards. Here's the new look:
![Capture](https://user-images.githubusercontent.com/4071255/170712036-2d099f30-d013-4b70-bf3c-0c22c876fcfb.PNG)


Fixes #1010
Fixes #999

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
