### PR TITLE
fixed request to usage logging endpoint from Workbench

### DIFF
--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -8,44 +8,43 @@ import pkg from '../../package.json';
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 const WORKBENCH_VERSION = pkg.version;
 const HOSTNAME = 'http://localhost';
+const PREFIX = 'api';
 
 export default function investUsageLogger() {
   const sessionId = crypto.randomUUID();
 
   function start(modelPyName, args) {
-    try {
-      logger.debug('logging model start');
-      fetch(`${HOSTNAME}:${process.env.PORT}/log_model_start`, {
-        method: 'post',
-        body: JSON.stringify({
-          model_pyname: modelPyName,
-          model_args: JSON.stringify(args),
-          invest_interface: `Workbench ${WORKBENCH_VERSION}`,
-          session_id: sessionId,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      });
-    } catch (error) {
-      logger.warn('Failed to log model start');
-      logger.warn(error.stack);
-    }
+    logger.debug('logging model start');
+    fetch(`${HOSTNAME}:${process.env.PORT}/${PREFIX}/log_model_start`, {
+      method: 'post',
+      body: JSON.stringify({
+        model_pyname: modelPyName,
+        model_args: JSON.stringify(args),
+        invest_interface: `Workbench ${WORKBENCH_VERSION}`,
+        session_id: sessionId,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+      .then(async (response) => {
+        if (!response.ok) { logger.error(await response.text()); }
+      })
+      .catch((error) => logger.error(error));
   }
 
   function exit(status) {
-    try {
-      logger.debug('logging model exit');
-      fetch(`${HOSTNAME}:${process.env.PORT}/log_model_exit`, {
-        method: 'post',
-        body: JSON.stringify({
-          session_id: sessionId,
-          status: status,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      });
-    } catch (error) {
-      logger.warn('Failed to log model exit');
-      logger.warn(error.stack);
-    }
+    logger.debug('logging model exit');
+    fetch(`${HOSTNAME}:${process.env.PORT}/${PREFIX}/log_model_exit`, {
+      method: 'post',
+      body: JSON.stringify({
+        session_id: sessionId,
+        status: status,
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+      .then(async (response) => {
+        if (!response.ok) { logger.error(await response.text()); }
+      })
+      .catch((error) => logger.error(error));
   }
 
   return {

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -207,6 +207,15 @@ describe('createWindow', () => {
 });
 
 describe('investUsageLogger', () => {
+  beforeEach(() => {
+    // the expected response
+    const response = {
+      ok: true,
+      text: async () => 'foo',
+    };
+    fetch.mockResolvedValue(response);
+  });
+
   test('sends requests with correct payload', () => {
     const modelPyname = 'natcap.invest.carbon';
     const args = {

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -207,6 +207,7 @@ describe('createWindow', () => {
 });
 
 describe('investUsageLogger', () => {
+  const expectedURL = `http://localhost:${process.env.PORT}/api/log_model_start`;
   beforeEach(() => {
     // the expected response
     const response = {
@@ -227,6 +228,7 @@ describe('investUsageLogger', () => {
 
     usageLogger.start(modelPyname, args);
     expect(fetch.mock.calls).toHaveLength(1);
+    expect(fetch.mock.calls[0][0]).toBe(expectedURL);
     const startPayload = JSON.parse(fetch.mock.calls[0][1].body);
 
     usageLogger.exit(investStdErr);

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -4,6 +4,7 @@ import events from 'events';
 import { spawn, exec } from 'child_process';
 import Stream from 'stream';
 
+import fetch from 'node-fetch';
 import GettextJS from 'gettext.js';
 import React from 'react';
 import { ipcRenderer } from 'electron';
@@ -555,6 +556,12 @@ describe('InVEST subprocess testing', () => {
   beforeAll(() => {
     setupInvestRunHandlers(investExe);
     setupInvestLogReaderHandler();
+    // mock request/response for invest usage-logging
+    const response = {
+      ok: true,
+      text: async () => 'foo',
+    };
+    fetch.mockResolvedValue(response);
   });
 
   afterAll(() => {


### PR DESCRIPTION
This PR fixes a fetch request from the workbench to the usage logging endpoint in `ui_server.py`. I added a test to assert the correct endpoint. It kind of feels bad to test an implementation detail like this, but we don't have any other way to catch this right away if we change the endpoint path again. I also added more logging so workbench logs will make it clear when the request failed. The logs will now look like this:

```
[1] [11:28:44.063] [C:\Users\dmf\projects\invest\workbench\build\main\main.js] logging model start
[1] [11:28:44.070] [C:\Users\dmf\projects\invest\workbench\build\main\main.js] 06/28/2022 11:28:44  werkzeug           INFO     127.0.0.1 - - [28/Jun/2022 11:28:44] "POST /log_model_start HTTP/1.1" 404 -
[1]
[1] [11:28:44.073] [C:\Users\dmf\projects\invest\workbench\build\main\main.js] <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
[1] <title>404 Not Found</title>
[1] <h1>Not Found</h1>
[1] <p>The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.</p>
```

Fixes #1014

## Checklist
- [ ] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
