### PR TITLE
Bugfix/hq 1039 unnecessary warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -46,6 +46,9 @@ Unreleased Changes
     * Fixed a bug where using unaligned rasters in the preprocessor would cause
       an error.  The preprocessor will now correctly align input landcover
       rasters and determine transitions from the aligned rasters.
+* Habitat Quality
+    * Removed a warning about an undefined nodata value in threat rasters
+      because it is okay for a threat raster to have an undefined nodata value.
 * HRA
     * Fixed an issue with risk calculations where risk values would be much
       lower than they should be.  Risk values are now correctly calculated.

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -994,14 +994,6 @@ def _raster_values_in_bounds(raster_path_band, lower_bound, upper_bound):
     """
     raster_info = pygeoprocessing.get_raster_info(raster_path_band[0])
     raster_nodata = raster_info['nodata'][0]
-
-    if raster_nodata is None:
-        LOGGER.warning(
-            f"Raster has undefined NODATA value for {raster_path_band[0]}.")
-        # If raster nodata is None then set to _OUT_NODATA to use for masking
-        # where in this case nodata_mask will be all False.
-        raster_nodata = _OUT_NODATA
-
     values_valid = True
 
     for _, raster_block in pygeoprocessing.iterblocks(raster_path_band):


### PR DESCRIPTION
This PR removes a check and warning about `nodata is None` because as of a recent HRA PR, `utils.array_equals_nodata` handles the `None` case for us.

Also, it turns out that it's okay for a threat raster to have undefined nodata. The only requirement for those rasters is that they only have values between 0 and 1.

Fixes #1039

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
