### PR TITLE
Workbench: simplify handling of invest std error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,9 @@
 
 Unreleased Changes
 ------------------
+* Workbench
+    * Fixed a bug where the workbench could crash if there was too much
+      std error from an invest model.
 * Urban Cooling
     * Updated the text for the ``building_intensity`` column in the biophysical
       table to clarify that the values of this column should be normalized

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -42,7 +42,7 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 process.on('unhandledRejection', (err, promise) => {
-  logger.error(`unhandled rejection at promise: ${promise}`);
+  logger.error(`unhandled rejection at: ${promise}`);
   logger.error(err);
   process.exit(1);
 });

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -37,6 +37,15 @@ import pkg from '../../package.json';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
+process.on('uncaughtException', (err) => {
+  logger.error(err);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason, promise) => {
+  logger.error(`unhandled rejection at promise: ${promise}`);
+  logger.error(reason);
+});
+
 if (!process.env.PORT) {
   process.env.PORT = '56789';
 }

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -41,9 +41,10 @@ process.on('uncaughtException', (err) => {
   logger.error(err);
   process.exit(1);
 });
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', (err, promise) => {
   logger.error(`unhandled rejection at promise: ${promise}`);
-  logger.error(reason);
+  logger.error(err);
+  process.exit(1);
 });
 
 if (!process.env.PORT) {

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -120,7 +120,6 @@ export function setupInvestRunHandlers(investExe) {
 
     const stdErrCallback = (data) => {
       logger.debug(`${data}`);
-      investStdErr += `${data}`;
     };
     investRun.stderr.on('data', stdErrCallback);
 
@@ -132,7 +131,6 @@ export function setupInvestRunHandlers(investExe) {
       delete runningJobs[tabID];
       event.reply(`invest-exit-${tabID}`, {
         code: code,
-        stdErr: investStdErr,
       });
       logger.debug(code);
       fs.unlink(datastackPath, (err) => {

--- a/workbench/src/renderer/InvestJob.js
+++ b/workbench/src/renderer/InvestJob.js
@@ -72,7 +72,6 @@ export default class InvestJob {
    * @param {object} obj.argsValues - an invest "args dict" with initial values
    * @param {string} obj.logfile - path to an existing invest logfile
    * @param {string} obj.status - one of 'running'|'error'|'success'
-   * @param {string} obj.finalTraceback - final & most relevant line of stderr
    */
   constructor(
     {
@@ -81,7 +80,6 @@ export default class InvestJob {
       argsValues,
       logfile,
       status,
-      finalTraceback,
     }
   ) {
     if (!modelRunName || !modelHumanName) {
@@ -93,7 +91,6 @@ export default class InvestJob {
     this.argsValues = argsValues;
     this.logfile = logfile;
     this.status = status;
-    this.finalTraceback = finalTraceback;
     this.hash = null;
   }
 }

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -148,7 +148,7 @@ class RecentInvestJobs extends React.Component {
               <span className="status">
                 {(job.status === 'success'
                   ? <span className="status-success">{_('Model Complete')}</span>
-                  : <span className="status-error">{job.finalTraceback || ''}</span>
+                  : <span className="status-error">{job.status}</span>
                 )}
               </span>
             </Card.Footer>

--- a/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
@@ -60,8 +60,9 @@ export default function ModelStatusAlert(props) {
 }
 
 ModelStatusAlert.propTypes = {
-  status: PropTypes.oneOf(['running', 'error', 'success']).isRequired,
-  errorMessage: PropTypes.string,
+  status: PropTypes.oneOf(
+    ['running', 'error', 'success', 'canceled']
+  ).isRequired,
   terminateInvestProcess: PropTypes.func.isRequired,
   handleOpenWorkspace: PropTypes.func.isRequired,
 };

--- a/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
@@ -6,13 +6,15 @@ import Button from 'react-bootstrap/Button';
 
 /* Render different Alert contents depending on an InVEST run status */
 export default function ModelStatusAlert(props) {
+  const { status } = props;
+
   const WorkspaceButton = (
     <Button
       variant="outline-dark"
       onClick={props.handleOpenWorkspace}
       disabled={props.status === 'running'}
     >
-      {_("Open Workspace")}
+      {_('Open Workspace')}
     </Button>
   );
 
@@ -21,42 +23,45 @@ export default function ModelStatusAlert(props) {
       variant="outline-dark"
       onClick={props.terminateInvestProcess}
     >
-      {_("Cancel Run")}
+      {_('Cancel Run')}
     </Button>
   );
 
-  if (props.status === 'running') {
+  if (status === 'running') {
     return (
       <Alert variant="secondary">
         {CancelButton}
       </Alert>
     );
   }
-  if (props.status === 'error') {
-    return (
-      <Alert
-        className="text-break"
-        variant="danger"
-      >
-        {props.finalTraceback}
-        {WorkspaceButton}
-      </Alert>
-    );
+
+  let alertVariant;
+  let alertMessage;
+  if (status === 'success') {
+    alertVariant = 'success';
+    alertMessage = _('Model Complete');
+  } else if (status === 'error') {
+    alertVariant = 'danger';
+    alertMessage = _('Error: see log for details');
+  } else if (status === 'canceled') {
+    alertVariant = 'danger';
+    alertMessage = _('Run Canceled');
   }
-  if (props.status === 'success') {
-    return (
-      <Alert variant="success">
-        {_("Model Complete")}
-        {WorkspaceButton}
-      </Alert>
-    );
-  }
-  return null;
+
+  return (
+    <Alert
+      className="text-break"
+      variant={alertVariant}
+    >
+      {alertMessage}
+      {WorkspaceButton}
+    </Alert>
+  );
 }
 
 ModelStatusAlert.propTypes = {
   status: PropTypes.oneOf(['running', 'error', 'success']).isRequired,
-  finalTraceback: PropTypes.string,
+  errorMessage: PropTypes.string,
   terminateInvestProcess: PropTypes.func.isRequired,
   handleOpenWorkspace: PropTypes.func.isRequired,
 };

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -113,26 +113,12 @@ export default class InvestTab extends React.Component {
       updateJobProperties,
       saveJob,
     } = this.props;
-    let finalTraceback = '';
+    let status = (data.code === 0) ? 'success' : 'error';
     if (this.state.userTerminated) {
-      finalTraceback = 'Run Canceled';
-    } else if (data.stdErr) {
-      // Get the last meaningful line of stderr for display in an Alert.
-      // The PyInstaller exe will always emit a final 'Failed ...' message
-      // after an uncaught exception.
-      const stdErrLines = data.stdErr.split(/\r\n|\r|\n/);
-      while (
-        !finalTraceback || finalTraceback.includes(
-          "Failed to execute script 'cli' due to unhandled exception!"
-        )
-      ) {
-        finalTraceback = stdErrLines.pop();
-      }
+      status = 'canceled';
     }
-    const status = (data.code === 0) ? 'success' : 'error';
     updateJobProperties(tabID, {
       status: status,
-      finalTraceback: finalTraceback,
     });
     saveJob(tabID);
     this.setState({
@@ -270,7 +256,6 @@ export default class InvestTab extends React.Component {
                   ? (
                     <ModelStatusAlert
                       status={status}
-                      finalTraceback={finalTraceback}
                       handleOpenWorkspace={() => handleOpenWorkspace(logfile)}
                       terminateInvestProcess={this.terminateInvestProcess}
                     />

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -201,7 +201,6 @@ export default class InvestTab extends React.Component {
       modelRunName,
       argsValues,
       logfile,
-      finalTraceback,
     } = this.props.job;
 
     const { tabID, investSettings } = this.props;
@@ -310,7 +309,6 @@ InvestTab.propTypes = {
     argsValues: PropTypes.object,
     logfile: PropTypes.string,
     status: PropTypes.string,
-    finalTraceback: PropTypes.string,
   }).isRequired,
   tabID: PropTypes.string.isRequired,
   investSettings: PropTypes.shape({

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -105,7 +105,7 @@ export default class InvestTab extends React.Component {
 
   /** Receive data about the exit status of the invest process.
    *
-   * @param {object} data - of shape { code: number, stdErr: string }
+   * @param {object} data - of shape { code: number }
    */
   investExitCallback(data) {
     const {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -298,6 +298,7 @@ exceed 100% of window.*/
 .card-footer .status {
 	overflow: hidden;
 	font-style: italic;
+	text-transform: capitalize;
 }
 
 .card-footer .status-error {

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -61,7 +61,7 @@ afterEach(() => {
   uiConfig.UI_SPEC = UI_SPEC;
 });
 
-describe('Run status Alert renders with data from a recent run', () => {
+describe('Run status Alert renders with status from a recent run', () => {
   const spec = {
     pyname: 'natcap.invest.foo',
     model_name: 'Foo Model',
@@ -86,73 +86,31 @@ describe('Run status Alert renders with data from a recent run', () => {
     removeIpcMainListeners();
   });
 
-  test('final Traceback displays', async () => {
+  test.each([
+    ['success', 'Model Complete'],
+    ['error', 'Error: see log for details'],
+    ['canceled', 'Run Canceled'],
+  ])('status message displays on %s', async (status, message) => {
     const job = new InvestJob({
       modelRunName: 'carbon',
       modelHumanName: 'Carbon Model',
-      status: 'error',
-      argsValues: {},
-      logfile: 'foo.txt',
-      finalTraceback: 'ValueError:',
-    });
-
-    const { findByRole } = renderInvestTab(job);
-    expect(await findByRole('alert'))
-      .toHaveTextContent(job.finalTraceback);
-  });
-
-  test('Model Complete displays if status was success', async () => {
-    const job = new InvestJob({
-      modelRunName: 'carbon',
-      modelHumanName: 'Carbon Model',
-      status: 'success',
-      argsValues: {},
-      logfile: 'foo.txt',
-      finalTraceback: '',
-    });
-
-    const { findByRole } = renderInvestTab(job);
-    expect(await findByRole('alert'))
-      .toHaveTextContent('Model Complete');
-  });
-
-  test('Model Complete displays even with non-fatal stderr', async () => {
-    const job = new InvestJob({
-      modelRunName: 'carbon',
-      modelHumanName: 'Carbon Model',
-      status: 'success',
-      argsValues: {},
-      logfile: 'foo.txt',
-      finalTraceback: 'Error that did not actually raise an exception',
-    });
-
-    const { findByRole, queryByText } = renderInvestTab(job);
-    expect(await findByRole('alert'))
-      .toHaveTextContent('Model Complete');
-    expect(queryByText(job.finalTraceback))
-      .toBeNull();
-  });
-
-  test('Open Workspace button is available on success', async () => {
-    const job = new InvestJob({
-      modelRunName: 'carbon',
-      modelHumanName: 'Carbon Model',
-      status: 'success',
+      status: status,
       argsValues: {},
       logfile: 'foo.txt',
     });
 
     const { findByRole } = renderInvestTab(job);
-    const openWorkspace = await findByRole('button', { name: 'Open Workspace' })
-    openWorkspace.click();
-    expect(shell.showItemInFolder).toHaveBeenCalledTimes(1);
+    expect(await findByRole('alert'))
+      .toHaveTextContent(message);
   });
 
-  test('Open Workspace button is available on error', async () => {
+  test.each([
+    'success', 'error', 'canceled',
+  ])('Open Workspace button is available on %s', async (status) => {
     const job = new InvestJob({
       modelRunName: 'carbon',
       modelHumanName: 'Carbon Model',
-      status: 'error',
+      status: status,
       argsValues: {},
       logfile: 'foo.txt',
     });
@@ -342,7 +300,6 @@ describe('Sidebar Buttons', () => {
       status: 'success',
       argsValues: {},
       logfile: 'foo.txt',
-      finalTraceback: '',
     });
     const { findByText, findByLabelText, findByRole } = renderInvestTab(job);
 


### PR DESCRIPTION
This PR simplifies how the Workbench displays stderr data from invest. With this PR, the invest subprocess no longer sends stderr data to the renderer for display. 

But don't worry, the Workbench still displays the stderr in the model's log pane. Because,
invest stderr (i.e. python exception) is already caught and logged by the python logger (see `utils.prepare_workspace   try/except`) and so it comes through the invest stdout stream also. 

So the final traceback of a model is now only displayed at the end of the model's log, where it is bold and red. It no longer appears in the sidebar alert, which now reads "Error: see log for details". And it no longer appears on the Recent Runs cards, which now only indicate "Model Complete", "Error", or "Canceled".

This Fixes #1092 and also removes a lot of messy logic for trying to extract the most meaningful part of the stderr message.

## Checklist
- [x] Updated HISTORY.rst (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
