### PR TITLE
Adding grep/sed generation of POT file body.

### DIFF
--- a/workbench/src/static/internationalization/README.md
+++ b/workbench/src/static/internationalization/README.md
@@ -20,6 +20,14 @@ If it becomes burdensome to keep up with manually editing the POT file, we can l
    ```
    where `<string>` is replaced with your string.
 
+Alternatively, run this bash command (created using BSD toolchain on mac) from the repo root to format the body of the POT file:
+
+   ```bash
+   grep -rho _\(\[\'\"\].\*\[\'\"\]\) . | sort | uniq | sed "s|_[(][\'\"]\(.*\)[\'\"][)]|msgid \"\1\"\nmsgstr \"\"\n|"
+   ```
+
+Insert the result into the POT file.
+
 ### Modifying or removing a translated string that already exists
 1. Manually edit or remove the entry for the string in `messages.pot`.
 

--- a/workbench/src/static/internationalization/locales/es/LC_MESSAGES/messages.po
+++ b/workbench/src/static/internationalization/locales/es/LC_MESSAGES/messages.po
@@ -11,81 +11,85 @@ msgstr ""
 "PO-Revision-Date: 2021-10-28 13:00-0700\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Bounding box does not intersect at least one other:"
-msgstr "Bounding box does not intersect at least one other:"
-
-msgid "Browse"
-msgstr "Browse"
-
-msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
-msgstr "Browse to a datastack (.json) or InVEST logfile (.txt)"
 
 msgid "Cancel"
 msgstr "Cancel"
 
-msgid "Cancel Run"
-msgstr "Cancel Run"
-
-msgid "Clear"
-msgstr "Clear"
-
-msgid "Clear Recent Jobs Shortcuts"
-msgstr "Clear Recent Jobs Shortcuts"
-
-msgid "csv"
-msgstr "csv"
-
-msgid ""
-"`Datastack/Logfile for ${datastack.model_human_name} does not match this "
-"model.`"
-msgstr ""
-"`Datastack/Logfile for ${datastack.model_human_name} does not match this "
-"model.`"
-
-msgid "DEBUG"
-msgstr "DEBUG"
-
-msgid "directory"
-msgstr "directory"
-
-msgid "Download"
-msgstr "Download"
-
 msgid "Download Complete"
 msgstr "Download Complete"
+
+#, fuzzy
+msgid "Download Failed"
+msgstr "Download"
 
 msgid "Download InVEST sample data"
 msgstr "Download InVEST sample data"
 
-msgid "Download Sample Data"
-msgstr "Download Sample Data"
+msgid "Download"
+msgstr "Download"
 
-msgid "`Downloading ${nComplete + 1} of ${nTotal}`"
-msgstr "`Downloading ${nComplete + 1} of ${nTotal}`"
-
-msgid "ERROR"
-msgstr "ERROR"
-
-msgid "file"
-msgstr "file"
+msgid "Export all input data to a compressed archive"
+msgstr ""
 
 msgid "Frequently Asked Questions"
 msgstr "Frequently Asked Questions"
 
-msgid "INFO"
-msgstr "INFO"
-
-msgid "integer"
-msgstr "integer"
-
 msgid "InVEST"
 msgstr "InVEST"
+
+msgid "Open"
+msgstr "Open"
+
+msgid "Save datastack"
+msgstr ""
+
+msgid "Save model setup to a JSON file"
+msgstr ""
+
+#, fuzzy
+msgid "Save model setup to a Python script"
+msgstr "Save to Python script"
+
+msgid "Save to JSON"
+msgstr ""
+
+msgid "Save to Python script"
+msgstr "Save to Python script"
+
+msgid "User's Guide"
+msgstr "User's Guide"
+
+#, fuzzy
+msgid "User's guide entry"
+msgstr "User's Guide"
+
+msgid "Bounding box does not intersect at least one other:"
+msgstr "Bounding box does not intersect at least one other:"
+
+msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
+msgstr "Browse to a datastack (.json) or InVEST logfile (.txt)"
+
+#, fuzzy
+msgid "Browse to a datastack (.json, .tgz) or InVEST logfile (.txt)"
+msgstr "Browse to a datastack (.json) or InVEST logfile (.txt)"
+
+msgid "Cancel Run"
+msgstr "Cancel Run"
+
+#, fuzzy
+msgid "Clear Recent Jobs"
+msgstr "Clear Recent Jobs Shortcuts"
+
+msgid "Download Sample Data"
+msgstr "Download Sample Data"
+
+msgid "Error: see log for details"
+msgstr ""
 
 msgid "InVEST Settings"
 msgstr "InVEST Settings"
@@ -108,38 +112,21 @@ msgstr "Model Complete"
 msgid "No args to see here"
 msgstr "No args to see here"
 
-msgid "(no InVEST workspaces will be deleted)"
-msgstr "(no InVEST workspaces will be deleted)"
-
-msgid "number"
-msgstr "number"
-
 msgid "Only drop one file at a time."
 msgstr "Only drop one file at a time."
-
-msgid "Open"
-msgstr "Open"
 
 msgid "Open Workspace"
 msgstr "Open Workspace"
 
-msgid "percent: a number from 0 - 100"
-msgstr "percent: a number from 0 - 100"
-
-msgid "raster"
-msgstr "raster"
-
-msgid "ratio: a decimal from 0 - 1"
-msgstr "ratio: a decimal from 0 - 1"
-
 msgid "Recent runs:"
 msgstr "Recent runs:"
 
-msgid "Reset"
-msgstr "Reset"
-
 msgid "Reset to Defaults"
 msgstr "Reset to Defaults"
+
+#, fuzzy
+msgid "Run Canceled"
+msgstr "Cancel"
 
 msgid "Run"
 msgstr "Run"
@@ -147,26 +134,83 @@ msgstr "Run"
 msgid "Running"
 msgstr "Running"
 
-msgid "Save Changes"
-msgstr "Save Changes"
-
-msgid "Save to Python script"
-msgstr "Save to Python script"
-
 msgid "Setup"
 msgstr "Setup"
+
+#, fuzzy
+msgid "Taskgraph logging threshold"
+msgstr "en espanol"
 
 msgid "Taskgraph n_workers parameter"
 msgstr "Taskgraph n_workers parameter"
 
+#, fuzzy
+msgid "no invest workspaces will be deleted"
+msgstr "(no InVEST workspaces will be deleted)"
+
+msgid "percent: a number from 0 - 100"
+msgstr "percent: a number from 0 - 100"
+
+msgid "ratio: a decimal from 0 - 1"
+msgstr "ratio: a decimal from 0 - 1"
+
+msgid "synchronous task execution is most reliable"
+msgstr ""
+
 msgid "text"
 msgstr "text"
 
-msgid "User's Guide"
-msgstr "User's Guide"
+#~ msgid "Browse"
+#~ msgstr "Browse"
 
-msgid "vector"
-msgstr "vector"
+#~ msgid "Clear"
+#~ msgstr "Clear"
 
-msgid "WARNING"
-msgstr "WARNING"
+#~ msgid "csv"
+#~ msgstr "csv"
+
+#~ msgid ""
+#~ "`Datastack/Logfile for ${datastack.model_human_name} does not match this "
+#~ "model.`"
+#~ msgstr ""
+#~ "`Datastack/Logfile for ${datastack.model_human_name} does not match this "
+#~ "model.`"
+
+#~ msgid "DEBUG"
+#~ msgstr "DEBUG"
+
+#~ msgid "directory"
+#~ msgstr "directory"
+
+#~ msgid "`Downloading ${nComplete + 1} of ${nTotal}`"
+#~ msgstr "`Downloading ${nComplete + 1} of ${nTotal}`"
+
+#~ msgid "ERROR"
+#~ msgstr "ERROR"
+
+#~ msgid "file"
+#~ msgstr "file"
+
+#~ msgid "INFO"
+#~ msgstr "INFO"
+
+#~ msgid "integer"
+#~ msgstr "integer"
+
+#~ msgid "number"
+#~ msgstr "number"
+
+#~ msgid "raster"
+#~ msgstr "raster"
+
+#~ msgid "Reset"
+#~ msgstr "Reset"
+
+#~ msgid "Save Changes"
+#~ msgstr "Save Changes"
+
+#~ msgid "vector"
+#~ msgstr "vector"
+
+#~ msgid "WARNING"
+#~ msgstr "WARNING"

--- a/workbench/src/static/internationalization/locales/zh/LC_MESSAGES/messages.po
+++ b/workbench/src/static/internationalization/locales/zh/LC_MESSAGES/messages.po
@@ -1,3 +1,22 @@
+# Translations template for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# Automatically generated, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: esoth@stanford.edu\n"
+"POT-Creation-Date: 2021-10-28 13:00-0700\n"
+"PO-Revision-Date: 2021-10-28 13:00-0700\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 msgid "Cancel"
 msgstr ""
 

--- a/workbench/src/static/internationalization/locales/zh/LC_MESSAGES/messages.po
+++ b/workbench/src/static/internationalization/locales/zh/LC_MESSAGES/messages.po
@@ -1,172 +1,134 @@
-# Translations template for PROJECT.
-# Copyright (C) 2021 ORGANIZATION
-# This file is distributed under the same license as the PROJECT project.
-# Automatically generated, 2021.
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: esoth@stanford.edu\n"
-"POT-Creation-Date: 2021-10-28 13:00-0700\n"
-"PO-Revision-Date: 2021-10-28 13:00-0700\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Language: zh\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-msgid "Bounding box does not intersect at least one other:"
-msgstr "Bounding box does not intersect at least one other:"
-
-msgid "Browse"
-msgstr "Browse"
-
-msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
-msgstr "Browse to a datastack (.json) or InVEST logfile (.txt)"
-
 msgid "Cancel"
-msgstr "Cancel"
-
-msgid "Cancel Run"
-msgstr "Cancel Run"
-
-msgid "Clear"
-msgstr "Clear"
-
-msgid "Clear Recent Jobs Shortcuts"
-msgstr "Clear Recent Jobs Shortcuts"
-
-msgid "csv"
-msgstr "csv"
-
-msgid ""
-"`Datastack/Logfile for ${datastack.model_human_name} does not match this "
-"model.`"
 msgstr ""
-"`Datastack/Logfile for ${datastack.model_human_name} does not match this "
-"model.`"
-
-msgid "DEBUG"
-msgstr "DEBUG"
-
-msgid "directory"
-msgstr "directory"
-
-msgid "Download"
-msgstr "Download"
 
 msgid "Download Complete"
-msgstr "Download Complete"
+msgstr ""
+
+msgid "Download Failed"
+msgstr ""
 
 msgid "Download InVEST sample data"
-msgstr "Download InVEST sample data"
+msgstr ""
 
-msgid "Download Sample Data"
-msgstr "Download Sample Data"
+msgid "Download"
+msgstr ""
 
-msgid "`Downloading ${nComplete + 1} of ${nTotal}`"
-msgstr "`Downloading ${nComplete + 1} of ${nTotal}`"
-
-msgid "ERROR"
-msgstr "ERROR"
-
-msgid "file"
-msgstr "file"
+msgid "Export all input data to a compressed archive"
+msgstr ""
 
 msgid "Frequently Asked Questions"
-msgstr "Frequently Asked Questions"
-
-msgid "INFO"
-msgstr "INFO"
-
-msgid "integer"
-msgstr "integer"
+msgstr ""
 
 msgid "InVEST"
-msgstr "InVEST"
-
-msgid "InVEST Settings"
-msgstr "InVEST Settings"
-
-msgid "Language"
-msgstr "Language"
-
-msgid "Load parameters from file"
-msgstr "Load parameters from file"
-
-msgid "Log"
-msgstr "Log"
-
-msgid "Logging threshold"
-msgstr "Logging threshold"
-
-msgid "Model Complete"
-msgstr "Model Complete"
-
-msgid "No args to see here"
-msgstr "No args to see here"
-
-msgid "(no InVEST workspaces will be deleted)"
-msgstr "(no InVEST workspaces will be deleted)"
-
-msgid "number"
-msgstr "number"
-
-msgid "Only drop one file at a time."
-msgstr "Only drop one file at a time."
+msgstr ""
 
 msgid "Open"
-msgstr "Open"
+msgstr ""
 
-msgid "Open Workspace"
-msgstr "Open Workspace"
+msgid "Save datastack"
+msgstr ""
 
-msgid "percent: a number from 0 - 100"
-msgstr "percent: a number from 0 - 100"
+msgid "Save model setup to a JSON file"
+msgstr ""
 
-msgid "raster"
-msgstr "raster"
+msgid "Save model setup to a Python script"
+msgstr ""
 
-msgid "ratio: a decimal from 0 - 1"
-msgstr "ratio: a decimal from 0 - 1"
-
-msgid "Recent runs:"
-msgstr "Recent runs:"
-
-msgid "Reset"
-msgstr "Reset"
-
-msgid "Reset to Defaults"
-msgstr "Reset to Defaults"
-
-msgid "Run"
-msgstr "Run"
-
-msgid "Running"
-msgstr "Running"
-
-msgid "Save Changes"
-msgstr "Save Changes"
+msgid "Save to JSON"
+msgstr ""
 
 msgid "Save to Python script"
-msgstr "Save to Python script"
-
-msgid "Setup"
-msgstr "Setup"
-
-msgid "Taskgraph n_workers parameter"
-msgstr "Taskgraph n_workers parameter"
-
-msgid "text"
-msgstr "text"
+msgstr ""
 
 msgid "User's Guide"
-msgstr "User's Guide"
+msgstr ""
 
-msgid "vector"
-msgstr "vector"
+msgid "User's guide entry"
+msgstr ""
 
-msgid "WARNING"
-msgstr "WARNING"
+msgid "Bounding box does not intersect at least one other:"
+msgstr ""
+
+msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
+msgstr ""
+
+msgid "Browse to a datastack (.json, .tgz) or InVEST logfile (.txt)"
+msgstr ""
+
+msgid "Cancel Run"
+msgstr ""
+
+msgid "Clear Recent Jobs"
+msgstr ""
+
+msgid "Download Sample Data"
+msgstr ""
+
+msgid "Error: see log for details"
+msgstr ""
+
+msgid "InVEST Settings"
+msgstr ""
+
+msgid "Language"
+msgstr ""
+
+msgid "Load parameters from file"
+msgstr ""
+
+msgid "Log"
+msgstr ""
+
+msgid "Logging threshold"
+msgstr ""
+
+msgid "Model Complete"
+msgstr ""
+
+msgid "No args to see here"
+msgstr ""
+
+msgid "Only drop one file at a time."
+msgstr ""
+
+msgid "Open Workspace"
+msgstr ""
+
+msgid "Recent runs:"
+msgstr ""
+
+msgid "Reset to Defaults"
+msgstr ""
+
+msgid "Run Canceled"
+msgstr ""
+
+msgid "Run"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "Setup"
+msgstr ""
+
+msgid "Taskgraph logging threshold"
+msgstr ""
+
+msgid "Taskgraph n_workers parameter"
+msgstr ""
+
+msgid "no invest workspaces will be deleted"
+msgstr ""
+
+msgid "percent: a number from 0 - 100"
+msgstr ""
+
+msgid "ratio: a decimal from 0 - 1"
+msgstr ""
+
+msgid "synchronous task execution is most reliable"
+msgstr ""
+
+msgid "text"
+msgstr ""

--- a/workbench/src/static/internationalization/messages.pot
+++ b/workbench/src/static/internationalization/messages.pot
@@ -16,70 +16,73 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "Bounding box does not intersect at least one other:"
-msgstr ""
-
-msgid "Browse"
-msgstr ""
-
-msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
-msgstr ""
-
 msgid "Cancel"
-msgstr ""
-
-msgid "Cancel Run"
-msgstr ""
-
-msgid "Clear"
-msgstr ""
-
-msgid "Clear Recent Jobs Shortcuts"
-msgstr ""
-
-msgid "csv"
-msgstr ""
-
-msgid "`Datastack/Logfile for ${datastack.model_human_name} does not match this model.`"
-msgstr ""
-
-msgid "DEBUG"
-msgstr ""
-
-msgid "directory"
-msgstr ""
-
-msgid "Download"
 msgstr ""
 
 msgid "Download Complete"
 msgstr ""
 
+msgid "Download Failed"
+msgstr ""
+
 msgid "Download InVEST sample data"
 msgstr ""
 
-msgid "Download Sample Data"
+msgid "Download"
 msgstr ""
 
-msgid "`Downloading ${nComplete + 1} of ${nTotal}`"
-msgstr ""
-
-msgid "ERROR"
-msgstr ""
-
-msgid "file"
+msgid "Export all input data to a compressed archive"
 msgstr ""
 
 msgid "Frequently Asked Questions"
 msgstr ""
 
-msgid "INFO"
-msgstr ""
-
-msgid "integer"
-msgstr ""
-
 msgid "InVEST"
+msgstr ""
+
+msgid "Open"
+msgstr ""
+
+msgid "Save datastack"
+msgstr ""
+
+msgid "Save model setup to a JSON file"
+msgstr ""
+
+msgid "Save model setup to a Python script"
+msgstr ""
+
+msgid "Save to JSON"
+msgstr ""
+
+msgid "Save to Python script"
+msgstr ""
+
+msgid "User's Guide"
+msgstr ""
+
+msgid "User's guide entry"
+msgstr ""
+
+msgid "Bounding box does not intersect at least one other:"
+msgstr ""
+
+msgid "Browse to a datastack (.json) or InVEST logfile (.txt)"
+msgstr ""
+
+msgid "Browse to a datastack (.json, .tgz) or InVEST logfile (.txt)"
+msgstr ""
+
+msgid "Cancel Run"
+msgstr ""
+
+msgid "Clear Recent Jobs"
+msgstr ""
+
+msgid "Download Sample Data"
+msgstr ""
+
+msgid "Error: see log for details"
 msgstr ""
 
 msgid "InVEST Settings"
@@ -103,37 +106,19 @@ msgstr ""
 msgid "No args to see here"
 msgstr ""
 
-msgid "(no InVEST workspaces will be deleted)"
-msgstr ""
-
-msgid "number"
-msgstr ""
-
 msgid "Only drop one file at a time."
-msgstr ""
-
-msgid "Open"
 msgstr ""
 
 msgid "Open Workspace"
 msgstr ""
 
-msgid "percent: a number from 0 - 100"
-msgstr ""
-
-msgid "raster"
-msgstr ""
-
-msgid "ratio: a decimal from 0 - 1"
-msgstr ""
-
 msgid "Recent runs:"
 msgstr ""
 
-msgid "Reset"
+msgid "Reset to Defaults"
 msgstr ""
 
-msgid "Reset to Defaults"
+msgid "Run Canceled"
 msgstr ""
 
 msgid "Run"
@@ -142,26 +127,26 @@ msgstr ""
 msgid "Running"
 msgstr ""
 
-msgid "Save Changes"
-msgstr ""
-
-msgid "Save to Python script"
-msgstr ""
-
 msgid "Setup"
+msgstr ""
+
+msgid "Taskgraph logging threshold"
 msgstr ""
 
 msgid "Taskgraph n_workers parameter"
 msgstr ""
 
+msgid "no invest workspaces will be deleted"
+msgstr ""
+
+msgid "percent: a number from 0 - 100"
+msgstr ""
+
+msgid "ratio: a decimal from 0 - 1"
+msgstr ""
+
+msgid "synchronous task execution is most reliable"
+msgstr ""
+
 msgid "text"
-msgstr ""
-
-msgid "User's Guide"
-msgstr ""
-
-msgid "vector"
-msgstr ""
-
-msgid "WARNING"
 msgstr ""


### PR DESCRIPTION
This PR doesn't fix anything specifically, but it does add a first stab at a custom PO file generation via grep and sed in a bash script to extract gettext strings from the javascript source.  It's not perfect, but I figure it'll get us most of the way there.  The updated POT and PO files for es and zh are also included as presented from the result of `msgmerge`.

RE:#778
