### PR TITLE
Bugfix/1113 patch CVE-2007-4559

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,10 @@
 
 Unreleased Changes
 ------------------
+* General
+    * Fixed a possible path traversal vulnerability when working with datastack
+      archives.  This patches CVE-2007-4559, reported to us by Trellix.
+      https://github.com/natcap/invest/issues/1113
 * Workbench
     * Fixed a bug where the Workbench would become unresponsive during an
       InVEST model run if the model emitted a very high volume of log messages.

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -486,8 +486,7 @@ def extract_datastack_archive(datastack_path, dest_dir_path):
     LOGGER.info('Extracting archive %s to %s', datastack_path, dest_dir_path)
     dest_dir_path = os.path.abspath(dest_dir_path)
     # extract the archive to the workspace
-    with tarfile.open(datastack_path) as tar:
-        tar.extractall(dest_dir_path)
+    _tarfile_safe_extract(datastack_path, dest_dir_path)
 
     # get the arguments dictionary
     arguments_dict = json.load(open(

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -127,9 +127,7 @@ class DatastackArchiveTests(unittest.TestCase):
         datastack.build_datastack_archive(
             params, 'test_datastack_modules.simple_parameters', archive_path)
         out_directory = os.path.join(self.workspace, 'extracted_archive')
-
-        with tarfile.open(archive_path) as tar:
-            tar.extractall(out_directory)
+        datastack._tarfile_safe_extract(archive_path, out_directory)
 
         self.assertEqual(len(os.listdir(out_directory)), 3)
 
@@ -158,9 +156,7 @@ class DatastackArchiveTests(unittest.TestCase):
 
             # extract the archive
             out_directory = os.path.join(self.workspace, 'extracted_archive')
-
-            with tarfile.open(archive_path) as tar:
-                tar.extractall(out_directory)
+            datastack._tarfile_safe_extract(archive_path, out_directory)
 
             archived_params = json.load(
                 open(os.path.join(
@@ -202,8 +198,7 @@ class DatastackArchiveTests(unittest.TestCase):
 
             # extract the archive
             out_directory = os.path.join(dest_dir, 'extracted_archive')
-            with tarfile.open(archive_path) as tar:
-                tar.extractall(out_directory)
+            datastack._tarfile_safe_extract(archive_path, out_directory)
 
             archived_params = json.load(
                 open(os.path.join(
@@ -245,8 +240,7 @@ class DatastackArchiveTests(unittest.TestCase):
 
         # extract the archive
         out_directory = os.path.join(self.workspace, 'extracted_archive')
-        with tarfile.open(archive_path) as tar:
-            tar.extractall(out_directory)
+        datastack._tarfile_safe_extract(archive_path, out_directory)
 
         archived_params = json.load(
             open(os.path.join(out_directory,
@@ -283,8 +277,7 @@ class DatastackArchiveTests(unittest.TestCase):
 
         # extract the archive
         out_directory = os.path.join(self.workspace, 'extracted_archive')
-        with tarfile.open(archive_path) as tar:
-            tar.extractall(out_directory)
+        datastack._tarfile_safe_extract(archive_path, out_directory)
 
         archived_params = json.load(
             open(os.path.join(out_directory,


### PR DESCRIPTION
## Description
After thinking about it some more, datastack archives are a possible point of vulnerability for us because of the intended use of these archives: for folks to share data with us.  So while the code might run in a trusted environment, we can't say the same about data.  So I figured it might be worth going ahead with the patch anyways.

Originally reported in #1099 but declined for some good reasons.

Also, python should _really_ still fix this upstream.

Fixes #1113

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
