### PR TITLE
Fix rasterization of spatial criteria relative to InVEST 3.9

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,12 @@ Unreleased Changes
       now reprojected to the ``lulc_cur_path`` raster. This fixes a bug where
       rasters with a different SRS would appear to not intersect the
       ``lulc_cur_path`` even if they did. (https://github.com/natcap/invest/issues/1093)
+* HRA
+    * Fixed a regression relative to InVEST 3.9.0 outputs where spatial
+      criteria vectors were being rasterized with the ``ALL_TOUCHED=TRUE``
+      flag, leading to a perceived buffering of spatial criteria in certain
+      cases.  In InVEST 3.9.0, these were rasterized with ``ALL_TOUCHED=FALSE``.
+      https://github.com/natcap/invest/issues/1120
 * Workbench
     * Fixed a bug where the Workbench would become unresponsive during an
       InVEST model run if the model emitted a very high volume of log messages.

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -608,7 +608,8 @@ class HRAUnitTests(unittest.TestCase):
                 self.workspace_dir, 'aligned_criterion_vector.tif'),
         }
 
-        hra._align(raster_path_map, vector_path_map, (30, -30), SRS_WKT)
+        hra._align(raster_path_map, vector_path_map, (30, -30), SRS_WKT,
+                  all_touched_vectors=set([habitat_vector_path]))
 
         # Calculated by hand given the above spatial inputs and
         # (30, -30) pixels.  All rasters should share the same extents and
@@ -654,15 +655,16 @@ class HRAUnitTests(unittest.TestCase):
 
         # The aligned criterion raster should have been rasterized from the
         # rating column.
+        # This is an ALL_TOUCHED=FALSE rasterization.
         ndta = hra._TARGET_NODATA_FLOAT32
         expected_criterion_array = numpy.array([
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta, ndta],
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
-            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
+            [ndta, ndta, 0.12, 0.12, 0.12, ndta, ndta, ndta, ndta, ndta],
             [ndta, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta, ndta],
+            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
+            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta],
+            [0.12, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta, ndta],
+            [ndta, 0.12, 0.12, 0.12, 0.12, 0.12, ndta, ndta, ndta, ndta],
+            [ndta, ndta, 0.12, 0.12, ndta, ndta, ndta, ndta, ndta, ndta],
             [ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta],
             [ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta, ndta]],
             dtype=numpy.float32)


### PR DESCRIPTION
This PR restores a bit of functionality from the InVEST 3.9 HRA implementation that I had missed in the rewrite.  In InVEST 3.9, habitat and stressor vectors are rasterized with `ALL_TOUCHED=TRUE`, while spatial criteria vectors are rasterized with `ALL_TOUCHED=FALSE`.  The HRA rewrite was rasterizing everything as `ALL_TOUCHED=TRUE`, leading to the behavior discussed in https://community.naturalcapitalproject.org/t/habitat-risk-assessment-problems-with-risk-calculation-and-outputs/3122/14.

The HRA 3.9 behavior for spatial criteria seems reasonable to me, so I've restored it here and made sure that it's being tested.

No changes in the user's guide are needed for this since we're just restoring existing functionality.

Fixes #1120 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
