### PR TITLE
Update LULC and Biophysical Table descriptions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,8 @@ Unreleased Changes
     * Fixed a possible path traversal vulnerability when working with datastack
       archives.  This patches CVE-2007-4559, reported to us by Trellix.
       https://github.com/natcap/invest/issues/1113
+    * Updating descriptions for LULC about text and biophysical table for
+      clarity in model specs. https://github.com/natcap/invest/issues/1077
 * Habitat Quality
     * All spatial inputs including the access vector and threat rasters are
       now reprojected to the ``lulc_cur_path`` raster. This fixes a bug where

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -113,7 +113,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "LULC code corresponding to values in the LULC map.")
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")
                 },
                 "lulc_veg": {
                     "type": "integer",

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -94,9 +94,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "LULC code. Every value in the "
-                        "LULC maps must have a corresponding entry in "
-                        "this column.")
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")
                 },
                 "c_above": {
                     "type": "number",

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -68,9 +68,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "Code for this LULC class from the LULC map. Every "
-                        "value in the LULC raster must have a corresponding "
-                        "entry in this column.")},
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 "is_tropical_forest": {
                     "type": "boolean",
                     "about": gettext(

--- a/src/natcap/invest/globio.py
+++ b/src/natcap/invest/globio.py
@@ -60,7 +60,9 @@ ARGS_SPEC = {
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": gettext("LULC code from the LULC map input.")},
+                    "about": gettext(
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 "globio_lucode": {
                     "type": "integer",
                     "about": gettext("Corresponding GLOBIO LULC code.")}

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -174,8 +174,9 @@ ARGS_SPEC = {
             "columns": {
                 "lulc": {
                     "type": "integer",
-                    "about": gettext("LULC codes corresponding to those in the LULC "
-                               "rasters.")
+                    "about": gettext(
+                        "LULC codes from the LULC rasters. Each code must be "
+                        "a unique integer.")
                 },
                 "habitat": {
                     "type": "ratio",

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -77,8 +77,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "LULC code for this class corresponding to values in "
-                        "the LULC raster.")
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")
                 },
                 "load_[NUTRIENT]": {  # nitrogen or phosphorus nutrient loads
                     "type": "number",

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -92,7 +92,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "LULC code representing this class in the LULC raster."
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")
                     )
                 },
                 "nesting_[SUBSTRATE]_availability_index": {

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -96,7 +96,9 @@ ARGS_SPEC = {
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": gettext("LULC code from the LULC raster.")},
+                    "about": gettext(
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 "usle_c": {
                     "type": "ratio",
                     "about": gettext("Cover-management factor for the USLE")},

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -112,7 +112,9 @@ ARGS_SPEC = {
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": gettext("LULC code matching those in the LULC raster.")},
+                    "about": gettext(
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 "cn_[SOIL_GROUP]": {
                     "type": "number",
                     "units": u.none,

--- a/src/natcap/invest/spec_utils.py
+++ b/src/natcap/invest/spec_utils.py
@@ -71,7 +71,9 @@ AOI = {
 LULC = {
     "type": "raster",
     "bands": {1: {"type": "integer"}},
-    "about": gettext("Map of land use/land cover codes."),
+    "about": gettext(
+        "Map of land use/land cover codes. Each land use/land cover type "
+        "must be assigned a unique integer code."),
     "name": gettext("land use/land cover")
 }
 DEM = {

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -48,7 +48,9 @@ ARGS_SPEC = {
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": gettext("LULC code corresponding to the LULC raster")
+                    "about": gettext(
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")
                 },
                 "emc_[POLLUTANT]": {
                     "type": "number",

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -59,7 +59,8 @@ ARGS_SPEC = {
                 "lucode": {
                     "type": "integer",
                     "about": gettext(
-                        "LULC code corresponding to those in the LULC map.")},
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 "kc": {
                     "type": "number",
                     "units": u.none,

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -60,7 +60,9 @@ ARGS_SPEC = {
             "columns": {
                 "lucode": {
                     "type": "integer",
-                    "about": gettext("LULC codes matching those in the LULC map.")},
+                    "about": gettext(
+                        "LULC codes from the LULC raster. Each code must be "
+                        "a unique integer.")},
                 **{f"cn_{soilgroup.lower()}": {
                     "type": "number", "units": u.none, "about": gettext(
                         "The curve number value for this LULC type in the "


### PR DESCRIPTION
## Description
Updating `LULC.about` text in `spec_utils` to add suggestion of mentioning each LULC class type should be represented as a unique integer. Stopping short of mentioning how this relates to the Biophysical table as most models do this separately and some model specs with `LULC.about` aren't restricted to have a Biophysical table.

Updating consistency of Biophysical table `about` sections in model specs.

Fixes #1077 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
