### PR TITLE
Update for new get_gis_type behavior

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=1.7.1,<1.8.2  # https://github.com/shapely/shapely/issues/1385
 scipy>=1.9.0
-pygeoprocessing>=2.3.2  # pip-only
+pygeoprocessing>=2.3.5  # pip-only
 taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6
 chardet>=3.0.4

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -3093,9 +3093,6 @@ def _validate_habitat_table_paths(habitat_table_path):
             habitat_table_path, habitat_row.path)
         try:
             gis_type = pygeoprocessing.get_gis_type(base_habitat_path)
-            if not gis_type:
-                # Treating an unknown GIS type the same as a bad filepath
-                bad_paths.append(base_habitat_path)
         except ValueError:
             bad_paths.append(base_habitat_path)
 

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -1043,7 +1043,7 @@ def _validate_threat_path(threat_path, lulc_key):
     """
     # Checking threat path exists to control custom error messages
     # for user readability.
-    if os.path.exists(threat_path):
+    try:
         threat_gis_type = pygeoprocessing.get_gis_type(threat_path)
         if threat_gis_type != pygeoprocessing.RASTER_TYPE:
             # Raise a value error with custom message to help users
@@ -1055,7 +1055,7 @@ def _validate_threat_path(threat_path, lulc_key):
                 return None
         else:
             return threat_path
-    else:
+    except ValueError:
         if lulc_key != '_b':
             return "error"
         else:

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1966,17 +1966,10 @@ def _parse_criteria_table(criteria_table_path, target_composite_csv_path):
                             os.path.dirname(criteria_table_path),
                             attribute_value).replace('\\', '/')
 
-                    spatial_file_ok = True
                     try:
-                        if (pygeoprocessing.get_gis_type(attribute_value) ==
-                                pygeoprocessing.UNKNOWN_TYPE):
-                            # File is not a spatial file
-                            spatial_file_ok = False
+                        _ = pygeoprocessing.get_gis_type(attribute_value)
                     except ValueError:
-                        # file not found
-                        spatial_file_ok = False
-
-                    if not spatial_file_ok:
+                        # File is not a spatial file or file not found
                         raise ValueError(
                             "Criterion could not be opened as a spatial "
                             f"file {attribute_value}")


### PR DESCRIPTION
## Description
Pygeoprocessing [issue 244](https://github.com/natcap/pygeoprocessing/issues/244) changed how `get_gis_type` handles non raster and vector types. It will now raise a `ValueError` in PGP 2.3.5. Updating and in some cases simplifying where this function is used in InVEST (CV, HQ, HRA).

Requirements have been bumped to require PGP 2.3.5 so tests will fail until the release of PGP 2.3.5. https://github.com/natcap/pygeoprocessing/issues/290

Did not update HISTORY since the changes are really not user facing.

Fixes #1133 

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
