### PR TITLE
use oldest-supported-numpy meta package in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,8 @@ invest = "natcap.invest.cli:main"
 # available at runtime.
 requires = [
     'setuptools>=45', 'wheel', 'setuptools_scm>=6.4.0', 'cython', 'babel',
-    # use minimum compatible numpy for each python version
-    # https://github.com/cython/cython/issues/4452
-    'numpy==1.17.3; python_version=="3.8"',
-    'numpy==1.19.3; python_version=="3.9"',
-    'numpy==1.21.3; python_version=="3.10"']
+    'oldest-supported-numpy'
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## Description
Use the [`oldest-supported-numpy`](https://github.com/scipy/oldest-supported-numpy) package to manage the oldest compatible numpy version for each python version. This is a meta-package developed by the scipy org. It saves us the trouble of keeping `pyproject.toml` correct and up to date when we add support for new python versions. 

## Checklist
- [ ] ~Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
