### PR TITLE
Add tooltip to model tabs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,9 +34,11 @@
 
 .. :changelog:
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+* Workbench
+    * Added tooltips to the model tabs so that they can be identified even when
+      several tabs are open (`#1071 <https://github.com/natcap/invest/issues/1088>`_)
 
 3.12.1 (2022-12-16)
 -------------------

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -241,7 +241,7 @@ export default class App extends React.Component {
           key={`${id}-tooltip`}
           placement="bottom"
           overlay={(
-            <Tooltip data-testid="tab-tooltip">
+            <Tooltip>
               {job.modelHumanName}
             </Tooltip>
           )}

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -238,9 +238,10 @@ export default class App extends React.Component {
       }
       investNavItems.push(
         <OverlayTrigger
+          key={`${job.modelHumanName}-tooltip`}
           placement="bottom"
           overlay={(
-            <Tooltip>
+            <Tooltip data-testid="tab-tooltip">
               {job.modelHumanName}
             </Tooltip>
           )}

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -238,7 +238,7 @@ export default class App extends React.Component {
       }
       investNavItems.push(
         <OverlayTrigger
-          key={`${job.modelHumanName}-tooltip`}
+          key={`${id}-tooltip`}
           placement="bottom"
           overlay={(
             <Tooltip data-testid="tab-tooltip">

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -10,6 +10,8 @@ import Button from 'react-bootstrap/Button';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Spinner from 'react-bootstrap/Spinner';
+import Tooltip from 'react-bootstrap/Tooltip';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { MdClose, MdHome } from 'react-icons/md';
 
 import HomeTab from './components/HomeTab';
@@ -235,27 +237,36 @@ export default class App extends React.Component {
           statusSymbol = '';
       }
       investNavItems.push(
-        <Nav.Item
-          key={id}
-          className={id === activeTab ? 'active' : ''}
+        <OverlayTrigger
+          placement="bottom"
+          overlay={(
+            <Tooltip>
+              {job.modelHumanName}
+            </Tooltip>
+          )}
         >
-          <Nav.Link eventKey={id}>
-            {statusSymbol}
-            {` ${job.modelHumanName}`}
-          </Nav.Link>
-          <Button
-            aria-label={`close ${job.modelHumanName} tab`}
-            className="close-tab"
-            variant="outline-dark"
-            onClick={(event) => {
-              event.stopPropagation();
-              this.closeInvestModel(id);
-            }}
-            onDragOver={dragOverHandlerNone}
+          <Nav.Item
+            key={id}
+            className={id === activeTab ? 'active' : ''}
           >
-            <MdClose />
-          </Button>
-        </Nav.Item>
+            <Nav.Link eventKey={id}>
+              {statusSymbol}
+              {` ${job.modelHumanName}`}
+            </Nav.Link>
+            <Button
+              aria-label={`close ${job.modelHumanName} tab`}
+              className="close-tab"
+              variant="outline-dark"
+              onClick={(event) => {
+                event.stopPropagation();
+                this.closeInvestModel(id);
+              }}
+              onDragOver={dragOverHandlerNone}
+            >
+              <MdClose />
+            </Button>
+          </Nav.Item>
+        </OverlayTrigger>
       );
       investTabPanes.push(
         <TabPane

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -97,7 +97,7 @@ describe('Various ways to open and close InVEST models', () => {
   });
 
   test('Clicking an invest model button renders SetupTab', async () => {
-    const { findByText, findByRole } = render(
+    const { findByText, getByTestId, findByRole } = render(
       <App />
     );
 
@@ -110,6 +110,9 @@ describe('Various ways to open and close InVEST models', () => {
     const setupTab = await findByText('Setup');
     expect(setupTab.classList.contains('active')).toBeTruthy();
     expect(getSpec).toHaveBeenCalledTimes(1);
+    const navTab = await findByRole('tab', { name: MOCK_MODEL_TITLE });
+    userEvent.hover(navTab);
+    getByTestId('tab-tooltip');
   });
 
   test('Clicking a recent job renders SetupTab', async () => {

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -98,7 +98,7 @@ describe('Various ways to open and close InVEST models', () => {
   });
 
   test('Clicking an invest model button renders SetupTab', async () => {
-    const { findByText, findByTestId, findByRole } = render(
+    const { findByText, findByRole } = render(
       <App />
     );
 

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -11,6 +11,7 @@ import { ipcRenderer } from 'electron';
 import {
   render, waitFor, within
 } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -97,7 +98,7 @@ describe('Various ways to open and close InVEST models', () => {
   });
 
   test('Clicking an invest model button renders SetupTab', async () => {
-    const { findByText, getByTestId, findByRole } = render(
+    const { findByText, findByTestId, findByRole } = render(
       <App />
     );
 
@@ -111,8 +112,10 @@ describe('Various ways to open and close InVEST models', () => {
     expect(setupTab.classList.contains('active')).toBeTruthy();
     expect(getSpec).toHaveBeenCalledTimes(1);
     const navTab = await findByRole('tab', { name: MOCK_MODEL_TITLE });
-    userEvent.hover(navTab);
-    getByTestId('tab-tooltip');
+    act(() => {
+      userEvent.hover(navTab);
+    });
+    await findByRole('tooltip', { name: MOCK_MODEL_TITLE });
   });
 
   test('Clicking a recent job renders SetupTab', async () => {


### PR DESCRIPTION
## Description
Fixes #1071 
I don't think there's any way around the model tabs being unreadable when there are many tabs open, but having tooltips should help. This is similar to how Firefox handles a lot of tabs.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
