### PR TITLE
Use conda-forge for docs packages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,11 @@
 
 Unreleased Changes
 ------------------
+* General
+    * During builds of the InVEST documentation, the packages
+      ``sphinx-rtd-theme`` and ``sphinx-reredirects`` will be pulled from
+      conda-forge instead of PyPI.
+      (`#1151 <https://github.com/natcap/invest/issues/1151>`_)
 * Workbench
     * Added tooltips to the model tabs so that they can be identified even when
       several tabs are open (`#1071 <https://github.com/natcap/invest/issues/1088>`_)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 Sphinx>=1.3.1,!=1.7.1
-sphinx-rtd-theme  # pip-only
+sphinx-rtd-theme
 sphinx-intl
-sphinx-reredirects  # pip-only
+sphinx-reredirects


### PR DESCRIPTION
I believe these packages were at one point not available on conda-forge, which would explain the pip-only flag.  They are both now on conda-forge.

Fixes #1151 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
