### PR TITLE
Use micromamba for building and cacheing python env in GHA

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -70,4 +70,4 @@ runs:
 
     - name: List conda environment
       shell: bash -l {0} # conda only available in login shell
-      run: mamba list
+      run: micromamba list

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -33,12 +33,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Setup conda environment
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        channels: conda-forge
-
     # save week number to use in next step
     # save CONDA_PREFIX to GITHUB_ENV so it's accessible outside of shell commands
     - name: Set environment variables
@@ -65,19 +59,15 @@ runs:
         echo "Will update environment using this environment.yml:"
         cat environment.yml
 
-    # NOTE the post step that saves the cache will only run if the job succeeds
-    - name: Restore conda environment cache
-      id: condacache
-      uses: actions/cache@v2
+    - name: Setup conda environment
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        path: ${{ env.CONDA_PREFIX }}
-        key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
-
-    - name: Update environment with dependencies
-      if: steps.condacache.outputs.cache-hit != 'true'
-      shell: bash -l {0} # conda only available in login shell
-      run: conda env update --file environment.yml
+        environment-file: environment.yml
+        environment-name: env
+        channels: conda-forge
+        cache-env: true
+        cache-env-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
 
     - name: List conda environment
       shell: bash -l {0} # conda only available in login shell
-      run: conda list
+      run: mamba list

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -69,5 +69,5 @@ runs:
         cache-env-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
 
     - name: List conda environment
-      shell: bash -l {0} # conda only available in login shell
+      shell: bash -l {0}
       run: micromamba list

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Compare conda environments
         continue-on-error: true
         run: |
-          conda list --export > conda-env.txt
+          micromamba list --export > conda-env.txt
           diff ./conda-env.txt ./conda-env-artifact/conda-env.txt
 
       - name: Build and install wheel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Compare conda environments
         continue-on-error: true
         run: |
-          micromamba list --export > conda-env.txt
+          micromamba list > conda-env.txt
           diff ./conda-env.txt ./conda-env-artifact/conda-env.txt
 
       - name: Build and install wheel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -376,7 +376,7 @@ jobs:
         run: make install
 
       - name: Build binaries
-        run: make ${{ matrix.binary-make-command }}
+        run: make CONDA=micromamba ${{ matrix.binary-make-command }}
 
       - name: Install Node.js
         uses: actions/setup-node@v2

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ $(INVEST_BINARIES_DIR): | $(DIST_DIR) $(BUILD_DIR)
 	-$(RMDIR) $(BUILD_DIR)/pyi-build
 	-$(RMDIR) $(INVEST_BINARIES_DIR)
 	$(PYTHON) -m PyInstaller --workpath $(BUILD_DIR)/pyi-build --clean --distpath $(DIST_DIR) exe/invest.spec
-	$(CONDA) list --export > $(INVEST_BINARIES_DIR)/package_versions.txt
+	$(CONDA) list > $(INVEST_BINARIES_DIR)/package_versions.txt
 	$(INVEST_BINARIES_DIR)/invest list
 
 # Documentation.


### PR DESCRIPTION
This PR switches from using `setup-miniconda` to using `provision-with-micromamba` to create python environments for all tests & builds. https://github.com/marketplace/actions/provision-with-micromamba

Hopefully we stop seeing the intermittent failure during conda installs noted in #1169. And I think we should also benefit from faster installs. 

Install times without using a cached env:
`conda` (5 samples): `[10, 11, 8, 13, 6]` minutes
`mamba` (7 samples): `[4.5, 2, 6, 3.5, 3, 3, 4]` minutes

In a couple places I had to modify a `conda list --export` command to `micromamba list`, since it's cli does not have the `--export` option. `export` does some text formatting to aid machine-reading. But for our purposes it's all the same to use the more human-readable format. It should not change the results of a `diff`.

Fixes #1169 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
