### PR TITLE
Urban Nature Access: Update greenspace balance rasters

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -33,12 +33,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Setup conda environment
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        channels: conda-forge
-
     # save week number to use in next step
     # save CONDA_PREFIX to GITHUB_ENV so it's accessible outside of shell commands
     - name: Set environment variables
@@ -65,19 +59,15 @@ runs:
         echo "Will update environment using this environment.yml:"
         cat environment.yml
 
-    # NOTE the post step that saves the cache will only run if the job succeeds
-    - name: Restore conda environment cache
-      id: condacache
-      uses: actions/cache@v2
+    - name: Setup conda environment
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        path: ${{ env.CONDA_PREFIX }}
-        key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
-
-    - name: Update environment with dependencies
-      if: steps.condacache.outputs.cache-hit != 'true'
-      shell: bash -l {0} # conda only available in login shell
-      run: conda env update --file environment.yml
+        environment-file: environment.yml
+        environment-name: env
+        channels: conda-forge
+        cache-env: true
+        cache-env-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
 
     - name: List conda environment
-      shell: bash -l {0} # conda only available in login shell
-      run: conda list
+      shell: bash -l {0}
+      run: micromamba list

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Compare conda environments
         continue-on-error: true
         run: |
-          conda list --export > conda-env.txt
+          micromamba list > conda-env.txt
           diff ./conda-env.txt ./conda-env-artifact/conda-env.txt
 
       - name: Build and install wheel
@@ -376,7 +376,7 @@ jobs:
         run: make install
 
       - name: Build binaries
-        run: make ${{ matrix.binary-make-command }}
+        run: make CONDA=micromamba ${{ matrix.binary-make-command }}
 
       - name: Install Node.js
         uses: actions/setup-node@v2

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := bbb8627b456ad756317b3aee06ce439008b0ab96
+GIT_UG_REPO_REV             := 61c1edd9dec21d4d4b825e898848d4f142ac294e
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ $(INVEST_BINARIES_DIR): | $(DIST_DIR) $(BUILD_DIR)
 	-$(RMDIR) $(BUILD_DIR)/pyi-build
 	-$(RMDIR) $(INVEST_BINARIES_DIR)
 	$(PYTHON) -m PyInstaller --workpath $(BUILD_DIR)/pyi-build --clean --distpath $(DIST_DIR) exe/invest.spec
-	$(CONDA) list --export > $(INVEST_BINARIES_DIR)/package_versions.txt
+	$(CONDA) list > $(INVEST_BINARIES_DIR)/package_versions.txt
 	$(INVEST_BINARIES_DIR)/invest list
 
 # Documentation.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 76dac5e3286e545e8e2e2bb7045ef5d17f069768
+GIT_UG_REPO_REV             := 6b5fffaf16b63e01b01fdea11c2774f0f8cbda96
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := e9bd1db0c57c696a60e4075cfe14ce5ea3c13075
+GIT_UG_REPO_REV             := 3945cfb44b272358b45acd3a1f625f45bc609d64
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 401ac875bb6be1ab2f9be2a828f45947948a843f
+GIT_UG_REPO_REV             := 76dac5e3286e545e8e2e2bb7045ef5d17f069768
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 61c1edd9dec21d4d4b825e898848d4f142ac294e
+GIT_UG_REPO_REV             := 2602858b5dc9781f98097c71a068fc8eaa4eacbc
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 2602858b5dc9781f98097c71a068fc8eaa4eacbc
+GIT_UG_REPO_REV             := e9bd1db0c57c696a60e4075cfe14ce5ea3c13075
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 3945cfb44b272358b45acd3a1f625f45bc609d64
+GIT_UG_REPO_REV             := 401ac875bb6be1ab2f9be2a828f45947948a843f
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -294,6 +294,7 @@ ARGS_SPEC = {
 _OUTPUT_BASE_FILES = {
     'greenspace_supply': 'greenspace_supply.tif',
     'admin_boundaries': 'admin_boundaries.gpkg',
+    'greenspace_balance': 'greenspace_balance.tif',
 }
 
 _INTERMEDIATE_BASE_FILES = {
@@ -305,7 +306,6 @@ _INTERMEDIATE_BASE_FILES = {
     'greenspace_area': 'greenspace_area.tif',
     'greenspace_population_ratio': 'greenspace_population_ratio.tif',
     'convolved_population': 'convolved_population.tif',
-    'greenspace_balance': 'greenspace_balance.tif',
     'greenspace_supply_demand_budget': 'greenspace_supply_demand_budget.tif',
     'undersupplied_population': 'undersupplied_population.tif',
     'oversupplied_population': 'oversupplied_population.tif',
@@ -914,7 +914,7 @@ def execute(args):
 
             # Calculate SUP_DEMi_cap for each population group.
             per_cap_greenspace_balance_pop_group_path = os.path.join(
-                intermediate_dir,
+                output_dir,
                 f'greenspace_balance_{pop_group}{suffix}.tif')
             per_cap_greenspace_balance_pop_group_task = graph.add_task(
                 pygeoprocessing.raster_calculator,
@@ -1710,11 +1710,11 @@ def _greenspace_balance_op(greenspace_supply, greenspace_demand):
     return balance
 
 
-def _greenspace_supply_demand_op(greenspace_budget, population):
+def _greenspace_supply_demand_op(greenspace_balance, population):
     """Calculate the supply/demand of greenspace per person.
 
     Args:
-        greenspace_budget (numpy.array): The area of greenspace budgeted to
+        greenspace_balance (numpy.array): The area of greenspace budgeted to
             each person, relative to a minimum required per-person area of
             greenspace.  This matrix must have ``FLOAT32_NODATA`` as its nodata
             value.  This matrix must be the same size and shape as
@@ -1729,12 +1729,12 @@ def _greenspace_supply_demand_op(greenspace_budget, population):
         to each individual in each pixel.
     """
     supply_demand = numpy.full(
-        greenspace_budget.shape, FLOAT32_NODATA, dtype=numpy.float32)
+        greenspace_balance.shape, FLOAT32_NODATA, dtype=numpy.float32)
     valid_pixels = (
-        ~numpy.isclose(greenspace_budget, FLOAT32_NODATA) &
+        ~numpy.isclose(greenspace_balance, FLOAT32_NODATA) &
         ~numpy.isclose(population, FLOAT32_NODATA))
     supply_demand[valid_pixels] = (
-        greenspace_budget[valid_pixels] * population[valid_pixels])
+        greenspace_balance[valid_pixels] * population[valid_pixels])
     return supply_demand
 
 

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -496,7 +496,7 @@ def execute(args):
             'mask_raster_path': file_registry['aligned_mask'],
             'target_raster_path': file_registry['masked_lulc'],
         },
-        task_name='Mask population to the known valid pixels',
+        task_name='Mask lulc to the known valid pixels',
         target_path_list=[file_registry['masked_lulc']],
         dependent_task_list=[
             lulc_alignment_task, valid_pixels_mask_task]
@@ -1646,7 +1646,7 @@ def _supply_demand_vector_for_single_raster_modes(
 
 def _write_supply_demand_vector(source_aoi_vector_path, feature_attrs,
                                 target_aoi_vector_path):
-    """Write data to a copy of en existing AOI vector.
+    """Write data to a copy of an existing AOI vector.
 
     Args:
         source_aoi_vector_path (str): The source AOI vector path.

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -2063,7 +2063,8 @@ def _kernel_exponential(distance, max_distance):
     """
     kernel = numpy.zeros(distance.shape, dtype=numpy.float32)
     pixels_in_radius = (distance <= max_distance)
-    kernel[pixels_in_radius] = numpy.exp(-distance / max_distance)
+    kernel[pixels_in_radius] = numpy.exp(
+        -distance[pixels_in_radius] / max_distance)
     return kernel
 
 

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -33,7 +33,7 @@ KERNEL_LABEL_DICHOTOMY = 'dichotomy'
 KERNEL_LABEL_EXPONENTIAL = 'exponential'
 KERNEL_LABEL_GAUSSIAN = 'gaussian'
 KERNEL_LABEL_DENSITY = 'density'
-KERNEL_LABEL_POWER = 'power'
+# KERNEL_LABEL_POWER = 'power'
 RADIUS_OPT_UNIFORM = 'uniform_radius'
 RADIUS_OPT_GREENSPACE = 'radius_per_greenspace_class'
 RADIUS_OPT_POP_GROUP = 'radius_per_pop_group'
@@ -175,15 +175,15 @@ ARGS_SPEC = {
                         '"weight = 0.75 * (1-(pixel_dist / search_radius)^2)"'
                     ),
                 },
-                KERNEL_LABEL_POWER: {
-                    'display_name': 'Power',
-                    'description': gettext(
-                        'Contributions to a greenspace pixel decrease '
-                        'according to a user-defined negative power function '
-                        'of the form "weight = pixel_dist^beta", where beta '
-                        'is expected to be negative and defined by the user.'
-                    ),
-                },
+                # KERNEL_LABEL_POWER: {
+                #     'display_name': 'Power',
+                #     'description': gettext(
+                #         'Contributions to a greenspace pixel decrease '
+                #         'according to a user-defined negative power function '
+                #         'of the form "weight = pixel_dist^beta", where beta '
+                #         'is expected to be negative and defined by the user.'
+                #     ),
+                # },
             },
             'about': (
                 'Pixels within the search radius of a greenspace pixel '
@@ -276,17 +276,17 @@ ARGS_SPEC = {
                 'the model with search radii defined per population group.'
             ),
         },
-        'decay_function_power_beta': {
-            'name': 'power function beta parameter',
-            'type': 'number',
-            'units': u.none,
-            'expression': 'float(value)',
-            'required': f'decay_function == "{KERNEL_LABEL_POWER}"',
-            'about': gettext(
-                'The beta parameter used for creating a power search '
-                'kernel.  Required when using the Power search kernel.'
-            ),
-        }
+        # 'decay_function_power_beta': {
+        #     'name': 'power function beta parameter',
+        #     'type': 'number',
+        #     'units': u.none,
+        #     'expression': 'float(value)',
+        #     'required': f'decay_function == "{KERNEL_LABEL_POWER}"',
+        #     'about': gettext(
+        #         'The beta parameter used for creating a power search '
+        #         'kernel.  Required when using the Power search kernel.'
+        #     ),
+        # }
     }
 }
 
@@ -365,9 +365,6 @@ def execute(args):
             associating population groups with a search radius for that
             population group.  Population group fieldnames must match
             population group fieldnames in the aoi vector.
-        args['decay_function_power_beta'] (number): The beta parameter used
-            during creation of a power kernel. Required when the selected
-            kernel is KERNEL_LABEL_POWER.
         args['aggregate_by_pop_group'] (bool): Whether to aggregate statistics
             by population groups in the target vector.  This is implied when
             running the model with ``args['search_radius_mode'] ==
@@ -376,6 +373,10 @@ def execute(args):
     Returns:
         ``None``
     """
+    #    args['decay_function_power_beta'] (number): The beta parameter used
+    #        during creation of a power kernel. Required when the selected
+    #        kernel is KERNEL_LABEL_POWER.
+
     LOGGER.info('Starting Urban Nature Access Model')
 
     output_dir = os.path.join(args['workspace_dir'], 'output')
@@ -405,12 +406,12 @@ def execute(args):
         KERNEL_LABEL_DENSITY: _kernel_density,
         # Use the user-provided beta args parameter if the user has provided
         # it.  Helpful to have a consistent kernel creation API.
-        KERNEL_LABEL_POWER: functools.partial(
-            _kernel_power, beta=args.get('decay_function_power_beta', None)),
+        # KERNEL_LABEL_POWER: functools.partial(
+        #     _kernel_power, beta=args.get('decay_function_power_beta', None)),
     }
     # Taskgraph needs a __name__ attribute, so adding one here.
-    kernel_creation_functions[KERNEL_LABEL_POWER].__name__ = (
-        'functools_partial_decay_power')
+    # kernel_creation_functions[KERNEL_LABEL_POWER].__name__ = (
+    #     'functools_partial_decay_power')
 
     # Since we have these keys defined in two places, I want to be super sure
     # that the labels match.

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -266,60 +266,6 @@ class TestRecServer(unittest.TestCase):
             aoi_path,
             os.path.join(out_workspace_dir, 'test_aoi_for_subset.shp'))
 
-    @_timeout(30.0)
-    def test_empty_server(self):
-        """Recreation test a client call to simple server."""
-        from natcap.invest.recreation import recmodel_server
-        from natcap.invest.recreation import recmodel_client
-
-        empty_point_data_path = os.path.join(
-            self.workspace_dir, 'empty_table.csv')
-        open(empty_point_data_path, 'w').close()  # touch the file
-
-        # attempt to get an open port; could result in race condition but
-        # will be okay for a test. if this test ever fails because of port
-        # in use, that's probably why
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(('', 0))
-        port = sock.getsockname()[1]
-        sock.close()
-        sock = None
-
-        server_args = {
-            'hostname': 'localhost',
-            'port': port,
-            'raw_csv_point_data_path': empty_point_data_path,
-            'cache_workspace': self.workspace_dir,
-            'min_year': 2004,
-            'max_year': 2015,
-        }
-
-        server_thread = threading.Thread(
-            target=recmodel_server.execute, args=(server_args,))
-        server_thread.daemon = True
-        server_thread.start()
-
-        client_args = {
-            'aoi_path': os.path.join(
-                SAMPLE_DATA, 'test_aoi_for_subset.shp'),
-            'cell_size': 7000.0,
-            'hostname': 'localhost',
-            'port': port,
-            'compute_regression': False,
-            'start_year': '2005',
-            'end_year': '2014',
-            'grid_aoi': False,
-            'results_suffix': '',
-            'workspace_dir': self.workspace_dir,
-        }
-        recmodel_client.execute(client_args)
-
-        # testing for file existence seems reasonable since mostly we are
-        # testing that a local server starts and a client connects to it
-        _test_same_files(
-            os.path.join(REGRESSION_DATA, 'file_list_empty_local_server.txt'),
-            self.workspace_dir)
-
     def test_local_aggregate_points(self):
         """Recreation test single threaded local AOI aggregate calculation."""
         from natcap.invest.recreation import recmodel_server

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -309,6 +309,20 @@ class UNATests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_array, kernel)
 
+    def test_exponential_kernel(self):
+        """UNA: Test the exponential decay kernel."""
+        from natcap.invest import urban_nature_access
+
+        max_distance = 3
+        distance = numpy.array([0, 1, 2, 3, 4])
+        kernel = urban_nature_access._kernel_exponential(
+            distance, max_distance)
+        # Regression values are calculated by hand
+        expected_array = numpy.array(
+            [1, 0.71653134, 0.5134171, 0.36787945, 0])
+        numpy.testing.assert_allclose(
+            expected_array, kernel)
+
     def test_greenspace_budgets(self):
         """UNA: Test the per-capita greenspace budgets functions."""
         from natcap.invest import urban_nature_access

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -744,6 +744,20 @@ class UNATests(unittest.TestCase):
                                         f'{basename}_{suffix}{ext}')
                 self.assertTrue(os.path.exists(filepath))
 
+            # check the greenspace demand raster
+            population = pygeoprocessing.raster_to_numpy_array(
+                os.path.join(args['workspace_dir'], 'intermediate',
+                             f'masked_population_{suffix}.tif'))
+            demand = pygeoprocessing.raster_to_numpy_array(
+                os.path.join(args['workspace_dir'], 'output',
+                             f'greenspace_demand_{suffix}.tif'))
+            nodata = urban_nature_access.FLOAT32_NODATA
+            valid_pixels = ~utils.array_equals_nodata(population, nodata)
+            numpy.testing.assert_allclose(
+                (population[valid_pixels].sum() *
+                    float(args['greenspace_demand'])),
+                demand[valid_pixels].sum())
+
         uniform_radius_supply = pygeoprocessing.raster_to_numpy_array(
             os.path.join(uniform_args['workspace_dir'], 'output',
                          'greenspace_supply_uniform.tif'))

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -323,6 +323,20 @@ class UNATests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_array, kernel)
 
+    def test_gaussian_kernel(self):
+        """UNA: Test the gaussian decay kernel."""
+        from natcap.invest import urban_nature_access
+
+        max_distance = 3
+        distance = numpy.array([0, 1, 2, 3, 4])
+        kernel = urban_nature_access._kernel_gaussian(
+            distance, max_distance)
+        # Regression values are calculated by hand
+        expected_array = numpy.array(
+            [1, 0.8626563, 0.4935753, 0, 0])
+        numpy.testing.assert_allclose(
+            expected_array, kernel)
+
     def test_greenspace_budgets(self):
         """UNA: Test the per-capita greenspace budgets functions."""
         from natcap.invest import urban_nature_access

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -11,7 +11,6 @@ import unittest
 
 import numpy
 import pandas
-import pandas.testing
 import pygeoprocessing
 import shapely.geometry
 from natcap.invest import utils
@@ -295,6 +294,20 @@ class UNATests(unittest.TestCase):
         numpy.testing.assert_allclose(1, kernel_array.sum())
         self.assertAlmostEqual(1.5915502e-05, kernel_array.max())
         self.assertEqual(0, kernel_array.min())
+
+    def test_power_kernel(self):
+        """UNA: Test the power kernel."""
+        from natcap.invest import urban_nature_access
+
+        beta = -5
+        max_distance = 3
+        distance = numpy.array([0, 1, 2, 3, 4])
+        kernel = urban_nature_access._kernel_power(
+            distance, max_distance, beta)
+        # These regression values are calculated by hand
+        expected_array = numpy.array([1, 1, (1/32), (1/243), 0])
+        numpy.testing.assert_allclose(
+            expected_array, kernel)
 
     def test_greenspace_budgets(self):
         """UNA: Test the per-capita greenspace budgets functions."""

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -360,7 +360,7 @@ class UNATests(unittest.TestCase):
         numpy.testing.assert_allclose(
             greenspace_budget, expected_greenspace_budget)
 
-        supply_demand = urban_nature_access._greenspace_supply_demand_op(
+        supply_demand = urban_nature_access._greenspace_balance_totalpop_op(
             greenspace_budget, population)
         expected_supply_demand = numpy.array([
             [nodata, 100 * 50.5],
@@ -757,6 +757,18 @@ class UNATests(unittest.TestCase):
                 (population[valid_pixels].sum() *
                     float(args['greenspace_demand'])),
                 demand[valid_pixels].sum())
+
+            # check the total-population greenspace balance
+            per_capita_balance = pygeoprocessing.raster_to_numpy_array(
+                os.path.join(args['workspace_dir'], 'output',
+                             f'greenspace_balance_percapita_{suffix}.tif'))
+            totalpop_balance = pygeoprocessing.raster_to_numpy_array(
+                os.path.join(args['workspace_dir'], 'output',
+                             f'greenspace_balance_totalpop_{suffix}.tif'))
+            numpy.testing.assert_allclose(
+                per_capita_balance[valid_pixels] * population[valid_pixels],
+                totalpop_balance[valid_pixels],
+                rtol=1e-5)  # accommodate accumulation of numerical error
 
         uniform_radius_supply = pygeoprocessing.raster_to_numpy_array(
             os.path.join(uniform_args['workspace_dir'], 'output',

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -337,8 +337,8 @@ class UNATests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_array, kernel)
 
-    def test_greenspace_budgets(self):
-        """UNA: Test the per-capita greenspace budgets functions."""
+    def test_greenspace_balance(self):
+        """UNA: Test the per-capita greenspace balance functions."""
         from natcap.invest import urban_nature_access
 
         nodata = urban_nature_access.FLOAT32_NODATA
@@ -351,7 +351,7 @@ class UNATests(unittest.TestCase):
             [50, 100],
             [40.75, nodata]], dtype=numpy.float32)
 
-        greenspace_budget = urban_nature_access._greenspace_budget_op(
+        greenspace_budget = urban_nature_access._greenspace_balance_op(
                 greenspace_supply, greenspace_demand)
         expected_greenspace_budget = numpy.array([
             [nodata, 50.5],

--- a/workbench/src/renderer/ui_config.js
+++ b/workbench/src/renderer/ui_config.js
@@ -366,7 +366,7 @@ const UI_SPEC = {
       [
         'search_radius_mode',
         'decay_function',
-        'decay_function_power_beta',
+        //'decay_function_power_beta',
         'search_radius',
       ],
     ],
@@ -374,9 +374,9 @@ const UI_SPEC = {
       search_radius: ((state) => (
         isSufficient('search_radius_mode', state)
         && state.argsValues.search_radius_mode.value === 'radius_uniform')),
-      decay_function_power_beta: ((state) => (
-        isSufficient('decay_function', state)
-        && state.argsValues.decay_function.value === 'power')),
+      // decay_function_power_beta: ((state) => (
+      //   isSufficient('decay_function', state)
+      //   && state.argsValues.decay_function.value === 'power')),
       population_group_radii_table: ((state) => (
         isSufficient('search_radius_mode', state)
         && state.argsValues.search_radius_mode.value === 'radius_per_pop_group')),


### PR DESCRIPTION
This PR implements the new/renamed rasters described in #1177.

Two of them ended up being renames.  Only 1 raster needed to be added as an output.

This PR depends on #1150 

Fixes #1177 
