### PR TITLE
Address Github Actions warnings

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -29,7 +29,7 @@ runs:
     # after the environment is updated, 'python' will point to the
     # conda-managed python and this python won't be used again
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/auto-pr-from-main-into-releases.yml
+++ b/.github/workflows/auto-pr-from-main-into-releases.yml
@@ -18,7 +18,7 @@ jobs:
     name: PR main into release/**
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: git fetch origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,10 +91,11 @@ jobs:
           path: ./conda-env-artifact
 
       - name: Compare conda environments
-        continue-on-error: true
         run: |
           micromamba list > conda-env.txt
-          diff ./conda-env.txt ./conda-env-artifact/conda-env.txt
+          # make sure that the exit code is always 0
+          # otherwise, an error appears in the action annotations
+          diff ./conda-env.txt ./conda-env-artifact/conda-env.txt || true
 
       - name: Build and install wheel
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
@@ -66,7 +66,7 @@ jobs:
       # Test data is way, way faster by contrast (on the order of a few
       # seconds to archive).
       - name: Restore git-LFS test data cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/invest-test-data
           key: git-lfs-testdata-${{ hashfiles('Makefile') }}
@@ -198,7 +198,7 @@ jobs:
     runs-on: windows-latest
     needs: check-syntax-errors
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
@@ -227,12 +227,12 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
       - name: Restore git-LFS test data cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/invest-test-data
           key: git-lfs-testdata-${{ hashfiles('Makefile') }}
@@ -262,7 +262,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
@@ -283,7 +283,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: nodemodules-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: workbench/node_modules
           key: ${{ runner.os }}-${{ hashFiles('workbench/yarn.lock') }}
@@ -321,7 +321,7 @@ jobs:
             workspace-path: ${{ github.workspace }}
             binary-extension: exe
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
@@ -343,7 +343,7 @@ jobs:
       - name: Restore cached NSIS plugins (Windows)
         id: restore-nsis-cache
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: | # update this list of paths if windows-ci-binary-install.ps1 changes
             C:\Program Files (x86)\NSIS\Plugins\x86-ansi\nsProcess.dll
@@ -385,7 +385,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: nodemodules-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: workbench/node_modules
           key: ${{ runner.os }}-${{ hashFiles('workbench/yarn.lock') }}
@@ -491,11 +491,11 @@ jobs:
     needs: check-syntax-errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,13 +108,13 @@ jobs:
         run: make test
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Wheel for ${{ matrix.os }} ${{ matrix.python-version }}
           path: dist
 
       - name: Upload conda env artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         continue-on-error: true
         with:
           name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
@@ -170,7 +170,7 @@ jobs:
           # natcap.invest from source and that it imports.
           python -c "from natcap.invest import *"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Source distribution
           path: dist
@@ -277,7 +277,7 @@ jobs:
         run: make install
 
       - name: Set up node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -379,7 +379,7 @@ jobs:
         run: make CONDA=micromamba ${{ matrix.binary-make-command }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14.x
 
@@ -449,27 +449,27 @@ jobs:
 
       - name: Upload binary artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: InVEST-${{ runner.os }}-binary
           path: dist/*.${{ matrix.binary-extension }}
 
       - name: Upload workbench binary artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Workbench-${{ runner.os }}-binary
           path: workbench/dist/*.${{ matrix.binary-extension }}
 
       - name: Upload user's guide artifact (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: InVEST-user-guide
           path: dist/InVEST_*_userguide.zip
 
       - name: Upload workbench logging from puppeteer
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ${{ runner.os }}_puppeteer_log.zip'
@@ -481,7 +481,7 @@ jobs:
 
       - name: Upload workspace on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: InVEST-failed-${{ runner.os }}-workspace
           path: ${{ matrix.workspace-path}}
@@ -506,7 +506,7 @@ jobs:
       - run: make sampledata sampledata_single
 
       - name: Upload sample data artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: InVEST-sample-data
           path: dist/*.zip


### PR DESCRIPTION
## Description
Fixes #1183
Causes of the error and warning annotations were:
- We were using old versions of some actions. I bumped these up.
- The diff command was causing an error annotation when differences were found because then the exit code is 1. I changed the command so the exit code is always 0.
- The Qt UI tests raise a test exception, which causes an error annotation, probably because it isn't handled in the best way. Since we're deprecating Qt really soon I did not bother to fix it.

You can see that the annotations are gone, and that the 3 Qt-related errors remain, on the "Summary" page of the checks tab: https://github.com/natcap/invest/actions/runs/4189242762

## Checklist
- [ ] ~Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~
- [ ] ~Updated the user's guide (if needed)~
- [ ] ~Tested the affected models' UIs (if relevant)~
