### PR TITLE
Error message for SWY when invalid soil group pixel found

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,6 +44,10 @@ Unreleased Changes
 * Workbench
     * Added tooltips to the model tabs so that they can be identified even when
       several tabs are open (`#1071 <https://github.com/natcap/invest/issues/1088>`_)
+* Seasonal Water Yield
+    * If a soil group raster contains any pixels that are not in the set of
+      allowed soil groups (anything other than 1, 2, 3 or 4), a human readable
+      exception will now be raised. https://github.com/natcap/invest/issues/1193
 
 3.12.1 (2022-12-16)
 -------------------

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1070,6 +1070,7 @@ def _calculate_curve_number_raster(
 
     # Use set of table lucodes in cn_op
     lucodes_set = set(lucodes)
+    valid_soil_groups = set([soil_nodata, *map_soil_type_to_header.keys()])
 
     def cn_op(lulc_array, soil_group_array):
         """Map lulc code and soil to a curve number."""
@@ -1090,7 +1091,17 @@ def _calculate_curve_number_raster(
                 f" raster but not the table are: {missing_lulc_values}.")
             raise ValueError(error_message)
 
-        for soil_group_id in numpy.unique(soil_group_array):
+        unique_soil_groups = numpy.unique(soil_group_array)
+        invalid_soil_groups = set(unique_soil_groups) - valid_soil_groups
+        if invalid_soil_groups:
+            invalid_soil_groups = [str(group) for group in invalid_soil_groups]
+            raise ValueError(
+                "The soil group raster must only have groups 1, 2, 3 or 4. "
+                f"Invalid group(s) {', '.join(invalid_soil_groups)} were "
+                f"found in soil group raster {soil_group_path} "
+                f"(nodata value: {soil_nodata})")
+
+        for soil_group_id in unique_soil_groups:
             if soil_group_id == soil_nodata:
                 continue
             current_soil_mask = (soil_group_array == soil_group_id)

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -875,6 +875,7 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         soil_array = band.ReadAsArray()
         soil_array[50, 50] = 6  # invalid value
         soil_array[51, 51] = 7  # invalid value
+        soil_array[52, 52] = band.GetNoDataValue()  # valid, excluded
         band.WriteArray(soil_array)
         band = None
         raster = None

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -854,6 +854,36 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
             ("The missing values found in the LULC raster but not the"
              " table are: [321]") in str(context.exception))
 
+    def test_invalid_soil_group(self):
+        """SWY test exception when user provides invalid soil group."""
+        import pygeoprocessing
+        from natcap.invest.seasonal_water_yield import seasonal_water_yield
+
+        # use predefined directory so test can clean up files during teardown
+        args = SeasonalWaterYieldRegressionTests.generate_base_args(
+            self.workspace_dir)
+        # make args explicit that this is a base run of SWY
+        args['user_defined_climate_zones'] = False
+        args['user_defined_local_recharge'] = False
+        args['monthly_alpha'] = False
+        args['results_suffix'] = ''
+
+        soil_array = pygeoprocessing.raster_to_numpy_array(
+            args['soil_group_path'])
+        raster = gdal.OpenEx(args['soil_group_path'], gdal.GA_Update)
+        band = raster.GetRasterBand(1)
+        soil_array = band.ReadAsArray()
+        soil_array[50, 50] = 6  # invalid value
+        soil_array[51, 51] = 7  # invalid value
+        band.WriteArray(soil_array)
+        band = None
+        raster = None
+
+        with self.assertRaises(ValueError) as cm:
+            seasonal_water_yield.execute(args)
+        self.assertIn("Invalid group(s) 6, 7 were found in soil group raster",
+                      str(cm.exception))
+
     def test_user_recharge(self):
         """SWY user recharge regression test on sample data.
 


### PR DESCRIPTION
This PR adds a human-readable exception raised in Seasonal Water Yield when a user provides a soil group that isn't permitted.  Only values of 1, 2, 3, 4 and nodata are permitted.

Fixes #1193 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
