### PR TITLE
Remove extra space in translation message

### DIFF
--- a/src/natcap/invest/internationalization/locales/es/LC_MESSAGES/messages.po
+++ b/src/natcap/invest/internationalization/locales/es/LC_MESSAGES/messages.po
@@ -2743,7 +2743,7 @@ msgstr ""
 
 #: src/natcap/invest/urban_cooling_model.py:240
 msgid "evapotranspiration weight"
-msgstr "ponderación  de la evapotranspiración"
+msgstr "ponderación de la evapotranspiración"
 
 #: src/natcap/invest/urban_cooling_model.py:243
 msgid ""


### PR DESCRIPTION
## Description
An extra space in a message was causing an issue in the translated UG build.

The issue arose in the `spec_utils.capitalize` function, which I should eventually remove because it's specific to English. But this is the simplest fix for now.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
