### PR TITLE
Removing the ws_id field requirement in SDR.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -48,6 +48,9 @@ Unreleased Changes
     * Any points over nodata (and therefore excluded from the viewshed
       analysis) will now correctly have their FID reported in the logging.
       https://github.com/natcap/invest/issues/1188
+* SDR
+    * The ``ws_id`` field is no longer a required field in the watershed vector.
+      https://github.com/natcap/invest/issues/1201
 * Seasonal Water Yield
     * If a soil group raster contains any pixels that are not in the set of
       allowed soil groups (anything other than 1, 2, 3 or 4), a human readable

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f5e651c9ba0a012dc033b9c1d12d51e42f6f87b0
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 90b0e96e717894a0fe9e9ef701e1585e5cb8649f
+GIT_UG_REPO_REV             := a270a6662068b6ed576814e7060d424a83a21bb9
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -27,8 +27,6 @@ from . import sdr_core
 
 LOGGER = logging.getLogger(__name__)
 
-INVALID_ID_MSG = gettext('{number} features have a non-integer ws_id field')
-
 ARGS_SPEC = {
     "model_name": MODEL_METADATA["sdr"].model_title,
     "pyname": MODEL_METADATA["sdr"].pyname,
@@ -78,11 +76,6 @@ ARGS_SPEC = {
         },
         "watersheds_path": {
             "type": "vector",
-            "fields": {
-                "ws_id": {
-                    "type": "integer",
-                    "about": gettext("Unique identifier for the watershed.")}
-            },
             "geometries": spec_utils.POLYGONS,
             "projected": True,
             "about": gettext(
@@ -1434,28 +1427,5 @@ def validate(args, limit_to=None):
             be an empty list if validation succeeds.
 
     """
-    validation_warnings = validation.validate(
+    return validation.validate(
         args, ARGS_SPEC['args'], ARGS_SPEC['args_with_spatial_overlap'])
-
-    invalid_keys = validation.get_invalid_keys(validation_warnings)
-    sufficient_keys = validation.get_sufficient_keys(args)
-
-    if ('watersheds_path' not in invalid_keys and
-            'watersheds_path' in sufficient_keys):
-        # The watersheds vector must have an integer column called WS_ID.
-        vector = gdal.OpenEx(args['watersheds_path'], gdal.OF_VECTOR)
-        layer = vector.GetLayer()
-        n_invalid_features = 0
-        for feature in layer:
-            try:
-                int(feature.GetFieldAsString('ws_id'))
-            except ValueError:
-                n_invalid_features += 1
-
-        if n_invalid_features:
-            validation_warnings.append((
-                ['watersheds_path'],
-                INVALID_ID_MSG.format(number=n_invalid_features)))
-            invalid_keys.add('watersheds_path')
-
-    return validation_warnings

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -78,6 +78,7 @@ ARGS_SPEC = {
             "type": "vector",
             "geometries": spec_utils.POLYGONS,
             "projected": True,
+            "fields": {},
             "about": gettext(
                 "Map of the boundaries of the watershed(s) over which to "
                 "aggregate results. Each watershed should contribute to a "

--- a/tests/test_args_specs.py
+++ b/tests/test_args_specs.py
@@ -195,17 +195,17 @@ class ValidateArgsSpecs(unittest.TestCase):
                     # - a fields property that maps each field header to a nested
                     #   type dictionary describing the data in that field
                     # - a geometries property: the set of valid geometry types
-                    self.assertTrue('fields' in arg)
-                    self.assertTrue(isinstance(arg['fields'], dict))
+                    self.assertIn('fields', arg.keys())
+                    self.assertIsInstance(arg['fields'], dict)
                     for field in arg['fields']:
-                        self.assertTrue(isinstance(field, str))
+                        self.assertIsInstance(field, str)
                         self.validate(
                             arg['fields'][field],
                             f'{name}.fields.{field}',
                             parent_type=t)
 
-                    self.assertTrue('geometries' in arg)
-                    self.assertTrue(isinstance(arg['geometries'], set))
+                    self.assertIn('geometries', arg)
+                    self.assertIsInstance(arg['geometries'], set)
 
                     attrs.remove('fields')
                     attrs.remove('geometries')
@@ -213,7 +213,7 @@ class ValidateArgsSpecs(unittest.TestCase):
                     # may optionally have a 'projected' attribute that says
                     # whether the vector must be linearly projected
                     if 'projected' in arg:
-                        self.assertTrue(isinstance(arg['projected'], bool))
+                        self.assertIsInstance(arg['projected'], bool)
                         attrs.remove('projected')
                     # if 'projected' is True, may also have a 'projection_units'
                     # attribute saying the expected linear projection unit
@@ -221,8 +221,8 @@ class ValidateArgsSpecs(unittest.TestCase):
                         # doesn't make sense to have projection units unless
                         # projected is True
                         self.assertTrue(arg['projected'])
-                        self.assertTrue(
-                            isinstance(arg['projection_units'], pint.Unit))
+                        self.assertIsInstance(arg['projection_units'],
+                                              pint.Unit)
                         attrs.remove('projection_units')
 
                 elif t == 'csv':


### PR DESCRIPTION
This field is a relic from earlier versions of the model where we provided an optional valuation step that associated valuation parameters with the watersheds via the WS_ID field.  We removed the valuation component, but forgot to remove the required WS_ID field.

Fixes #1201 

@newtpatrol I've added you as an assignee here as an FYI ... you're of course welcome to review the changes here if you like, up to you!

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
