### PR TITLE
Add UNA sample data to the download index

### DIFF
--- a/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
+++ b/workbench/src/renderer/components/DataDownloadModal/sampledata_registry.json
@@ -59,6 +59,9 @@
   "Urban Flood Risk Mitigation": {
     "filename": "UrbanFloodMitigation.zip"
   },
+  "Urban Nature Access": {
+    "filename": "UrbanNatureAccess.zip"
+  },
   "Visitation: Recreation and Tourism": {
     "filename": "recreation.zip"
   },


### PR DESCRIPTION
This is a simple PR to add the UNA sample data to the download index.

## Description
Fixes #1210
