### PR TITLE
Defining a 'safe' layer name for Urban Nature Access admin units vector

### DIFF
--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -513,6 +513,11 @@ def execute(args):
             'target_projection_wkt': lulc_raster_info['projection_wkt'],
             'target_path': file_registry['reprojected_admin_boundaries'],
             'driver_name': 'GPKG',
+            # Making the layer name be what we want the final output to be
+            # called.  Preemptively removing dashes - Arc doesn't like it.
+            'target_layer_name': os.path.splitext(
+                os.path.basename(
+                    file_registry['admin_boundaries']))[0].replace('-', '_'),
             'id_fieldname': ID_FIELDNAME,
         },
         task_name='Reproject admin units',
@@ -1240,7 +1245,8 @@ def _geometries_overlap(vector_path):
 
 
 def _reproject_and_identify(base_vector_path, target_projection_wkt,
-                            target_path, driver_name, id_fieldname):
+                            target_path, driver_name, id_fieldname,
+                            target_layer_name):
     """Reproject a vector and add an ID field.
 
     Args:
@@ -1253,12 +1259,14 @@ def _reproject_and_identify(base_vector_path, target_projection_wkt,
             name and an integer type will be created in the target vector.
             Each feature in the target vector will be assigned a unique integer
             ID.
+        target_layer_name (string): The layer name of the target vector.
 
     Returns:
         ``None``
     """
     pygeoprocessing.reproject_vector(
         base_vector_path, target_projection_wkt, target_path,
+        target_layer_name=target_layer_name,
         driver_name=driver_name)
 
     vector = gdal.OpenEx(target_path, gdal.GA_Update)

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -446,11 +446,11 @@ class UNATests(unittest.TestCase):
 
         # Check that we're getting the appropriate summary values in the
         # admin units vector.
+        layer_name = f"admin_boundaries_{args['results_suffix']}"
         admin_vector_path = os.path.join(
-            args['workspace_dir'], 'output',
-            f"admin_boundaries_{args['results_suffix']}.gpkg")
+            args['workspace_dir'], 'output', f"{layer_name}.gpkg")
         admin_vector = gdal.OpenEx(admin_vector_path)
-        admin_layer = admin_vector.GetLayer()
+        admin_layer = admin_vector.GetLayer(layer_name)
         self.assertEqual(admin_layer.GetFeatureCount(), 1)
 
         # expected field values from eyeballing the results; random seed = 1


### PR DESCRIPTION
We're just defining the layer name.  That is all.

Fixes #1164 