### PR TITLE
Urban Nature Access: Fixing out-of-range supply values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 29d8da596ff197d3cc6e355e7cd4313945b89b71
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 20bce284cb58ff4508a634cd2becde6ad175f7e1
+GIT_UG_REPO_REV             := 49fcb5b30b0f0336e932e6e32e662284a3e711af
 
 
 ENV = "./env"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := a87f94b8dbad326dd71868963cff50ad92f9a77f
+GIT_SAMPLE_DATA_REPO_REV    := 1efa3d62ac4e02e4d424f3f3719dfa263ad8ae64
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 37f63e65da832e99ecb186531a6540193f0e1ad8
+GIT_SAMPLE_DATA_REPO_REV    := a87f94b8dbad326dd71868963cff50ad92f9a77f
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 1efa3d62ac4e02e4d424f3f3719dfa263ad8ae64
+GIT_SAMPLE_DATA_REPO_REV    := 5992790e63a5b906aa126cd5d72f019a985925e3
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -61,19 +61,29 @@ ARGS_SPEC = {
             'about': (
                 "A map of LULC codes. "
                 "All values in this raster must have corresponding entries "
-                "in the LULC attribute table."),
+                "in the LULC attribute table. For this model in particular, "
+                "the urban nature types are of importance.  Non-nature types "
+                "are not required to be uniquely identified. All outputs "
+                "be produced at the resolution of this raster."
+            ),
         },
         'lulc_attribute_table': {
             'name': 'LULC attribute table',
             'type': 'csv',
+            'about': (
+                "A table identifying which LULC codes represent urban nature. "
+                "All LULC classes in the Land Use Land Cover raster MUST have "
+                "corresponding values in this table.  Each row is a land use "
+                "land cover class."
+            ),
             'columns': {
                 'lucode': spec_utils.LULC_TABLE_COLUMN,
                 'urban_nature': {
                     'type': 'number',
                     'units': u.none,
                     'about': (
-                        "1 if this LULC code represents urban nature, 0 "
-                        "if not."
+                        "Binary code indicating whether the LULC type is "
+                        "(1) or is not (0) an urban nature type."
                     ),
                 },
                 'search_radius_m': {
@@ -83,16 +93,15 @@ ARGS_SPEC = {
                         f'search_radius_mode == "{RADIUS_OPT_URBAN_NATURE}"',
                     'expression': 'value >= 0',
                     'about': (
-                        'The distance in meters to use as the search radius '
-                        'for this type of urban nature. Values must be >= 0. '
-                        'Required when running the model with search radii '
-                        'defined per urban nature class.'
+                        'The distance within which a LULC type is relevant '
+                        'to the population group of interest. This is the '
+                        'search distance that the model will apply for '
+                        'this LULC type. Values must be >= 0 and defined '
+                        'in meters. Required when running the model with '
+                        'search radii defined per urban nature class.'
                     ),
                 }
             },
-            'about': (
-                "A table identifying which LULC codes represent urban nature."
-            ),
         },
         'population_raster_path': {
             'type': 'raster',
@@ -103,8 +112,7 @@ ARGS_SPEC = {
             'projected': True,
             'projection_units': u.meter,
             'about': (
-                "A raster representing the number of people who live in each "
-                "pixel."
+                "A raster representing the number of inhabitants per pixel."
             ),
         },
         'admin_boundaries_vector_path': {
@@ -118,18 +126,19 @@ ARGS_SPEC = {
                         f"(search_radius_mode == '{RADIUS_OPT_POP_GROUP}') "
                         "or aggregate_by_pop_group"),
                     "about": gettext(
-                        "The proportion of the population within this region "
-                        "belonging to the identified population group "
-                        "(POP_GROUP). At least one column with the prefix "
-                        "'pop_' is required when aggregating output by "
-                        "population groups."
+                        "The proportion of the population within each "
+                        "administrative unit belonging to the identified "
+                        "population group (POP_GROUP). At least one column "
+                        "with the prefix 'pop_' is required when aggregating "
+                        "output by population groups."
                     ),
                 }
             },
             'about': gettext(
-                "Non-overlapping regions (typically administrative "
-                "boundaries) within which population supply and demand are "
-                "summarized."
+                "A vector representing administrative units. Polygons "
+                "representing administrative units should not overlap. "
+                "Overlapping administrative geometries may cause unexpected "
+                "results and for this reason should not overlap."
             ),
         },
         'urban_nature_demand': {
@@ -240,7 +249,7 @@ ARGS_SPEC = {
             'about': gettext(
                 'The search radius to use when running the model under a '
                 'uniform search radius. Required when running the model '
-                'with a uniform search radius.'),
+                'with a uniform search radius. Units are in meters.'),
         },
         'population_group_radii_table': {
             'name': 'population group radii table',
@@ -251,10 +260,8 @@ ARGS_SPEC = {
                     "type": "ratio",
                     "required": False,
                     "about": gettext(
-                        "The proportion of the population within this region "
-                        "belonging to the identified population group. "
-                        "Values in this column must match those population "
-                        "group field names in the administrative boundaries "
+                        "The name of the population group. Names must match "
+                        "the names defined in the administrative boundaries "
                         "vector."
                     ),
                 },
@@ -265,7 +272,7 @@ ARGS_SPEC = {
                         f'search_radius_mode == "{RADIUS_OPT_POP_GROUP}"',
                     'expression': 'value >= 0',
                     'about': gettext(
-                        "The distance in meters to use as the search radius "
+                        "The search radius in meters to use "
                         "for this population group.  Values must be >= 0."
                     ),
                 },

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -64,7 +64,7 @@ ARGS_SPEC = {
                 "in the LULC attribute table. For this model in particular, "
                 "the urban nature types are of importance.  Non-nature types "
                 "are not required to be uniquely identified. All outputs "
-                "be produced at the resolution of this raster."
+                "will be produced at the resolution of this raster."
             ),
         },
         'lulc_attribute_table': {

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -198,7 +198,8 @@ ARGS_SPEC = {
             'about': (
                 'Pixels within the search radius of an urban nature pixel '
                 'have a distance-weighted contribution to an urban nature '
-                'pixel according to the selected decay function.'),
+                'pixel according to the selected distance-weighting '
+                'function.'),
         },
         'search_radius_mode': {
             'name': 'search radius mode',
@@ -684,7 +685,7 @@ def execute(args):
 
         decayed_population_path = os.path.join(
             intermediate_dir,
-            f'decayed_population_within_{search_radius_m}{suffix}.tif')
+            f'distance_weighted_population_within_{search_radius_m}{suffix}.tif')
         decayed_population_task = graph.add_task(
             _convolve_and_set_lower_bound,
             kwargs={
@@ -752,7 +753,7 @@ def execute(args):
         for search_radius_m in search_radii:
             decayed_population_paths[search_radius_m] = os.path.join(
                 intermediate_dir,
-                f'decayed_population_within_{search_radius_m}{suffix}.tif')
+                f'distance_weighted_population_within_{search_radius_m}{suffix}.tif')
             decayed_population_tasks[search_radius_m] = graph.add_task(
                 _convolve_and_set_lower_bound,
                 kwargs={
@@ -858,7 +859,7 @@ def execute(args):
             search_radius_m = search_radii_by_pop_group[pop_group]
             decayed_population_in_group_path = os.path.join(
                 intermediate_dir,
-                f'decayed_population_in_{pop_group}{suffix}.tif')
+                f'distance_weighted_population_in_{pop_group}{suffix}.tif')
             decayed_population_in_group_paths.append(
                 decayed_population_in_group_path)
             decayed_population_in_group_tasks.append(graph.add_task(
@@ -880,7 +881,7 @@ def execute(args):
 
         sum_of_decayed_population_path = os.path.join(
             intermediate_dir,
-            f'decayed_population_all_groups{suffix}.tif')
+            f'distance_weighted_population_all_groups{suffix}.tif')
         sum_of_decayed_population_task = graph.add_task(
             ndr._sum_rasters,
             kwargs={

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -929,7 +929,7 @@ def execute(args):
             urban_nature_supply_by_group_paths[
                 pop_group] = urban_nature_supply_to_group_path
             urban_nature_supply_by_group_task = graph.add_task(
-                pygeoprocessing.convolve_2d,
+                _convolve_and_set_lower_bound,
                 kwargs={
                     'signal_path_band': (
                         file_registry['urban_nature_population_ratio'], 1),


### PR DESCRIPTION
This PR fixes the out-of-range supply values that were the result of a failure to have a mutually agreed-upon nodata mask when doing a weighted sum.

This also fixes some filenames (no issue associated with this change).  @lmandle had requested that the "decay_" in the names of some files be renamed to something less macabre, so I went with "distance_weighted_" as an alternate prefix.

Some additional textual changes are also included that are needed for the user's guide and better suited to be stored here in the model source code than in the UG chapter itself.

The sample data are also updated to offer a few more notes on the sample tables and which values we made up.

Fixes #1219 
Fixes #1218 
