### PR TITLE
Minor Workbench installer configuration

### DIFF
--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -35,7 +35,7 @@ const config = {
   ],
   extraFiles: [{
     from: '../LICENSE.txt',
-    to: 'LICENSE.txt',
+    to: 'LICENSE.InVEST.txt',
   }],
   appId: APP_ID,
   productName: PRODUCT_NAME,

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -19,9 +19,16 @@ const APP_ID = `NaturalCapitalProject.Invest.Workbench.${investVersion}`;
 const PRODUCT_NAME = `InVEST ${investVersion} Workbench`;
 const ARTIFACT_NAME = `invest_${investVersion}_workbench_${OS}_${ARCH}.${EXT}`;
 
+// this version appears as a footer in the NSIS installer & uninstaller.
+// It includes package.json version by default, but that is meaningless for us.
+// We can override that, but also must maintain semver compliance, so
+// always trim to this format.
+const installerVersion = investVersion.match(/[0-9]+\.[0-9]+\.[0-9]+/)[0];
+
 const config = {
   extraMetadata: {
     main: 'build/main/main.js',
+    version: installerVersion,
   },
   extraResources: [
     {
@@ -54,6 +61,7 @@ const config = {
     createDesktopShortcut: false,
     installerHeader: 'resources/InVEST-header-wcvi-rocks.bmp',
     oneClick: false,
+    uninstallDisplayName: PRODUCT_NAME,
   },
   files: [
     'build/**/*',

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -51,6 +51,7 @@ const config = {
   },
   nsis: {
     oneClick: false,
+    allowToChangeInstallationDirectory: true,
   },
   files: [
     'build/**/*',

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -50,9 +50,10 @@ const config = {
     icon: 'resources/InVEST-2-256x256.ico',
   },
   nsis: {
-    oneClick: false,
     allowToChangeInstallationDirectory: true,
+    createDesktopShortcut: false,
     installerHeader: 'resources/InVEST-header-wcvi-rocks.bmp',
+    oneClick: false,
   },
   files: [
     'build/**/*',

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -52,6 +52,7 @@ const config = {
   nsis: {
     oneClick: false,
     allowToChangeInstallationDirectory: true,
+    installerHeader: 'resources/InVEST-header-wcvi-rocks.bmp',
   },
   files: [
     'build/**/*',

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "invest-workbench",
-  "version": "0.1.0-beta",
+  "version": "0.1.0",
   "description": "Models that map and value the goods and services from nature that sustain and fulfill human life",
   "main": "build/main/main.js",
   "homepage": "./",


### PR DESCRIPTION
* Adds a header icon to the NSIS window
* NSIS wizard asks user for the install location
* invest license file renamed to distinguish from electron & chromium license files
* NSIS installer no longer creates a desktop icon
* hide the package.json version string from the user by overriding some electron-builder defaults

I tested the Mac and Windows installers with all these changes: https://github.com/davemfish/invest/actions/runs/4407476799

Fixes #996 
Fixes #1069 
Fixes #1078 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
