### PR TITLE
Fix version conflict of `build`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,7 +299,9 @@ jobs:
           requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} pandoc
 
       - name: Make install
-        run: make install
+        run: |
+          conda uninstall build
+          make install
 
         # Not caching chocolatey packages because the cache may not be reliable
         # https://github.com/chocolatey/choco/issues/2134

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,9 +299,7 @@ jobs:
           requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} pandoc
 
       - name: Make install
-        run: |
-          conda uninstall build
-          make install
+        run: make install
 
         # Not caching chocolatey packages because the cache may not be reliable
         # https://github.com/chocolatey/choco/issues/2134

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,4 +22,4 @@ setuptools_scm>=6.4.0
 requests
 coverage
 xlwt
-build
+build  # pip-only


### PR DESCRIPTION
## Description
Fixes #1273 

Adding the `# pip-only` flag ensures that we'll install the current `build` package from PyPI, not the outdated `build` package from conda-forge.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
