### PR TITLE
Make SQ more tolerant of leading/trailing whitespace and case

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -48,6 +48,9 @@ Unreleased Changes
     * The Scenic Quality model will now raise an error when it encounters a
       geometry that is not a simple Point.  This is in line with the user's
       guide chapter.  https://github.com/natcap/invest/issues/1245
+    * The Scenic Quality model now supports both uppercase and lowercase
+      fieldnames. Leading and trailing spaces are now also stripped for the
+      user's convenience. https://github.com/natcap/invest/issues/1276
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -513,22 +513,27 @@ def _determine_valid_viewpoints(dem_path, structures_path):
                     structures_layer.GetFeatureCount())
 
         radius_fieldname = None
-        fieldnames = set(
-            column.GetName() for column in structures_layer.schema)
+        fieldnames = {}
+        for column in structures_layer.schema:
+            actual_fieldname = column.GetName()
+            cleaned_fieldname = actual_fieldname.upper().strip()
+            fieldnames[cleaned_fieldname] = actual_fieldname
         possible_radius_fieldnames = set(
-            ['RADIUS', 'RADIUS2']).intersection(fieldnames)
+            ['RADIUS', 'RADIUS2']).intersection(set(fieldnames.keys()))
         if possible_radius_fieldnames:
-            radius_fieldname = possible_radius_fieldnames.pop()
+            radius_fieldname = fieldnames[possible_radius_fieldnames.pop()]
 
-        height_present = False
-        height_fieldname = 'HEIGHT'
-        if height_fieldname in fieldnames:
+        try:
+            height_fieldname = fieldnames['HEIGHT']
             height_present = True
+        except KeyError:
+            height_present = False
 
-        weight_present = False
-        weight_fieldname = 'WEIGHT'
-        if weight_fieldname in fieldnames:
+        try:
+            weight_fieldname = fieldnames['WEIGHT']
             weight_present = True
+        except KeyError:
+            weight_present = False
 
         last_log_time = time.time()
         n_features_touched = -1
@@ -560,11 +565,11 @@ def _determine_valid_viewpoints(dem_path, structures_path):
 
             max_radius = None
             if radius_fieldname:
-                max_radius = math.fabs(point.GetField(radius_fieldname))
+                max_radius = math.fabs(float(point.GetField(radius_fieldname)))
 
             height = 0.0
             if height_present:
-                height = math.fabs(point.GetField(height_fieldname))
+                height = math.fabs(float(point.GetField(height_fieldname)))
 
             weight = 1.0
             if weight_present:

--- a/tests/test_scenic_quality.py
+++ b/tests/test_scenic_quality.py
@@ -1,9 +1,6 @@
 """Module for Regression Testing the InVEST Scenic Quality module."""
-import contextlib
 import glob
-import logging
 import os
-import queue
 import shutil
 import tempfile
 import unittest
@@ -409,14 +406,14 @@ class ScenicQualityTests(unittest.TestCase):
                                        'viewpoints.geojson')
         ScenicQualityTests.create_viewpoints(
             viewpoints_path,
-            fields={'RADIUS': ogr.OFTReal,
-                    'HEIGHT': ogr.OFTReal,
+            fields={' RADIUS ': ogr.OFTReal,  # spaces in fieldname
+                    'HeighT': ogr.OFTReal,  # mixed case
                     'WEIGHT': ogr.OFTReal},
             attributes=[
-                {'RADIUS': 6.0, 'HEIGHT': 1.0, 'WEIGHT': 1.0},
-                {'RADIUS': 6.0, 'HEIGHT': 1.0, 'WEIGHT': 1.0},
-                {'RADIUS': 6.0, 'HEIGHT': 1.0, 'WEIGHT': 2.5},
-                {'RADIUS': 6.0, 'HEIGHT': 1.0, 'WEIGHT': 2.5}])
+                {' RADIUS ': 6.0, 'HeighT': 1.0, 'WEIGHT': 1.0},
+                {' RADIUS ': 6.0, 'HeighT': 1.0, 'WEIGHT': 1.0},
+                {' RADIUS ': 6.0, 'HeighT': 1.0, 'WEIGHT': 2.5},
+                {' RADIUS ': 6.0, 'HeighT': 1.0, 'WEIGHT': 2.5}])
 
         aoi_path = os.path.join(self.workspace_dir, 'aoi.geojson')
         ScenicQualityTests.create_aoi(aoi_path)


### PR DESCRIPTION
SQ fieldnames are now more tolerant of leading/trailing whitespace and case.  It seemed easier on us in the long run to fix this rather than to just update the documentation to specify precise fieldnames.

Fixes: #1276

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
