### PR TITLE
CLI: use our custom json serializer instead of `json.dumps`.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,6 +37,10 @@
 
 Unreleased Changes
 ------------------
+* General
+    * Fixed a bug in the CLI where ``invest getspec --json`` failed on
+      non-json-serializable objects such as ``pint.Unit``.
+      https://github.com/natcap/invest/issues/1280
 * Workbench
     * Fixed a bug where sampledata downloads failed silently (and progress bar 
       became innacurate) if the Workbench did not have write permission to 

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -16,6 +16,7 @@ import natcap.invest
 from natcap.invest import datastack
 from natcap.invest import model_metadata
 from natcap.invest import set_locale
+from natcap.invest import spec_utils
 from natcap.invest import ui_server
 from natcap.invest import utils
 
@@ -417,7 +418,7 @@ def main(user_args=None):
         spec = model_module.MODEL_SPEC
 
         if args.json:
-            message = json.dumps(spec)
+            message = spec_utils.serialize_args_spec(spec)
         else:
             message = pprint.pformat(spec)
         sys.stdout.write(message)


### PR DESCRIPTION
Fixes #1280 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
