### PR TITLE
Expose subwatershed delineation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,8 +42,8 @@ Unreleased Changes
       non-json-serializable objects such as ``pint.Unit``.
       https://github.com/natcap/invest/issues/1280
 * Workbench
-    * Fixed a bug where sampledata downloads failed silently (and progress bar 
-      became innacurate) if the Workbench did not have write permission to 
+    * Fixed a bug where sampledata downloads failed silently (and progress bar
+      became innacurate) if the Workbench did not have write permission to
       the download location. https://github.com/natcap/invest/issues/1070
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and
@@ -51,6 +51,16 @@ Unreleased Changes
       correctly handles this case. https://github.com/natcap/invest/issues/1250
     * Tables in the .xls format are no longer supported. This format was
       deprecated by ``pandas``. (`#1271 <https://github.com/natcap/invest/issues/1271>`_)
+* RouteDEM
+    * RouteDEM now allows the user to calculate Strahler Stream Orders, which
+      will be written to a new vector in the user's workspace. This stream
+      order vector is dependent on the user's Threshold Flow Accumulation value
+      and is only available for the D8 routing model.
+      https://github.com/natcap/invest/issues/884
+    * RouteDEM now allows the user to create a vector of subwatersheds, which
+      are written to a new vector in the user's workspace.  This vector is
+      dependent on the calculation of Strahler Stream Orders and is only
+      available for the D8 routing model. https://github.com/natcap/invest/issues/349
 * Scenic Quality
     * The Scenic Quality model will now raise an error when it encounters a
       geometry that is not a simple Point.  This is in line with the user's

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 5992790e63a5b906aa126cd5d72f019a985925e3
+GIT_SAMPLE_DATA_REPO_REV    := a58b9c7bdd8a31cab469ea919fe0ebf23a6c668e
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := a89253d83d5f70a8ea2d8a951b2d47d603505f14
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := f44ca0cdb8bcdbc98cd10a92caeddd8ac399e6d5
+GIT_UG_REPO_REV             := 51e2fa74e4a1d09c1ab43dcda681027a833232cd
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -150,21 +150,21 @@ MODEL_SPEC = {
                         "The flow accumulation value at the upstream end of "
                         "the stream segment."),
                     "type": "number",
-                    "units": u.count,
+                    "units": u.pixels,
                 },
                 "ds_fa": {
                     "about": (
                         "The flow accumulation value at the downstream end of "
                         "the stream segment."),
                     "type": "number",
-                    "units": u.pixels,  # TODO: does this work?
+                    "units": u.pixels,
                 },
                 "thresh_fa": {
                     "about": (
                         "The final threshold flow accumulation value used to "
                         "determine the river segments."),
                     "type": "number",
-                    "units": u.pixels,  # TODO: does this work?
+                    "units": u.pixels,
                 },
                 "upstream_d8_dir": {
                     "about": (

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -114,7 +114,9 @@ MODEL_SPEC = {
         "slope.tif": spec_utils.SLOPE,
         "stream_mask.tif": spec_utils.STREAM,
         "strahler_stream_order.gpkg": {
-            "about": "",
+            "about": (
+                "A vector of line segments indicating the Strahler stream "
+                "order and other properties of each stream segment."),
             "geometries": spec_utils.LINESTRING,
             "fields": {
                 "order": {

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -135,6 +135,7 @@ _FLOW_ACCUMULATION_FILE_PATTERN = 'flow_accumulation%s.tif'
 _STREAM_MASK_FILE_PATTERN = 'stream_mask%s.tif'
 _DOWNSLOPE_DISTANCE_FILE_PATTERN = 'downslope_distance%s.tif'
 _STRAHLER_STREAM_ORDER_PATTERN = 'strahler_stream_order%s.gpkg'
+_SUBWATERSHEDS_PATTERN = 'subwatersheds%s.gpkg'
 
 _ROUTING_FUNCS = {
     'D8': {
@@ -358,8 +359,26 @@ def execute(args):
                             flow_accum_task,
                         ])
 
-                    #if bool(args.get('calculate_subwatersheds', False)):
-                        #subwatersheds_path =
+                    if bool(args.get('calculate_subwatersheds', False)):
+                        subwatersheds_path = os.path.join(
+                            args['workspace_dir'],
+                            _SUBWATERSHEDS_PATTERN % file_suffix)
+                        graph.add_task(
+                            pygeoprocessing.routing.calculate_subwatershed_boundary,
+                            kwargs={
+                                'd8_flow_dir_raster_path_band':
+                                    (flow_dir_path, 1),
+                                'strahler_stream_vector_path':
+                                    stream_order_path,
+                                'target_watershed_boundary_vector_path':
+                                    subwatersheds_path,
+                                'outlet_at_confluence': False,  # The default
+                            },
+                            target_path_list=[subwatersheds_path],
+                            task_name=(
+                                'Calculate subwatersheds from stream order'),
+                            dependent_task_list=[flow_direction_task,
+                                                 stream_order_task])
 
     graph.close()
     graph.join()

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -2,11 +2,9 @@
 import logging
 import os
 
-import numpy
 import pygeoprocessing
 import pygeoprocessing.routing
 import taskgraph
-from osgeo import gdal
 
 from . import gettext
 from . import spec_utils
@@ -94,15 +92,37 @@ MODEL_SPEC = {
             "required": False,
             "about": gettext("Calculate percent slope from the provided DEM."),
             "name": gettext("calculate slope")
-        }
+        },
+        "calculate_stream_order": {
+            "type": "boolean",
+            "required": False,
+            "about": gettext("Calculate the Strahler Stream order."),
+            "name": gettext("calculate strahler stream orders"),
+        },
+        "calculate_subwatersheds": {
+            "type": "boolean",
+            "required": False,
+            "about": gettext("Determine subwatersheds from the stream order."),
+            "name": gettext("calculate subwatersheds"),
+        },
     },
     "outputs": {
+        "_taskgraph_working_dir": spec_utils.TASKGRAPH_DIR,
         "filled.tif": spec_utils.FILLED_DEM,
         "flow_accumulation.tif": spec_utils.FLOW_ACCUMULATION,
         "flow_direction.tif": spec_utils.FLOW_DIRECTION,
         "slope.tif": spec_utils.SLOPE,
         "stream_mask.tif": spec_utils.STREAM,
-        "_taskgraph_working_dir": spec_utils.TASKGRAPH_DIR
+        "strahler_stream_order.gpkg": {
+            "about": "",
+            "geometries": spec_utils.LINESTRING,
+            "fields": {},
+        },
+        "subwatersheds.gpkg": {
+            "about": "",
+            "geometries": spec_utils.POLYGON,
+            "fields": {},
+        },
     }
 }
 
@@ -171,8 +191,12 @@ def execute(args):
             args['calculate_flow_accumulation'],
             args['calculate_flow_direction'], and
             args['calculate_stream_threshold'] are all True.
-        args['calculate_slope'] (bool):  If True, model will calculate a
+        args['calculate_slope'] (bool): If True, model will calculate a
             slope raster from the DEM.
+        args['calculate_stream_order']: If True, model will create a vector of
+            the Strahler stream order.
+        args['calculate_subwatersheds']: If True, the model will create a
+            vector of subwatersheds.
         args['n_workers'] (int): The ``n_workers`` parameter to pass to
             the task graph.  The default is ``-1`` if not provided.
 

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -135,7 +135,7 @@ MODEL_SPEC = {
                         "upstream to downstream component of this stream "
                         "segment."),
                     "type": "number",
-                    "units": u.elevation,  # TODO: will this work?
+                    "units": u.none,
                 },
                 "outlet": {
                     "about": (
@@ -148,7 +148,7 @@ MODEL_SPEC = {
                         "The flow accumulation value at the upstream end of "
                         "the stream segment."),
                     "type": "number",
-                    "units": u.pixels,  # TODO: does this work?
+                    "units": u.count,
                 },
                 "ds_fa": {
                     "about": (

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -116,7 +116,104 @@ MODEL_SPEC = {
         "strahler_stream_order.gpkg": {
             "about": "",
             "geometries": spec_utils.LINESTRING,
-            "fields": {},
+            "fields": {
+                "order": {
+                    "about": "The Strahler stream order.",
+                    "type": "number",
+                    "units": u.none,
+                },
+                "river_id": {
+                    "about": (
+                        "A unique identifier used by all stream segments that "
+                        "connect to the same outlet."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "drop_distance": {
+                    "about": (
+                        "The drop distance in DEM elevation units from the "
+                        "upstream to downstream component of this stream "
+                        "segment."),
+                    "type": "number",
+                    "units": u.elevation,  # TODO: will this work?
+                },
+                "outlet": {
+                    "about": (
+                        "1 if this segment is an outlet, 0 if it is not."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "river_id": {
+                    "about": (
+                        "A unique identifier among all stream segments which "
+                        "are hydrologically connected."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "us_fa": {
+                    "about": (
+                        "The flow accumulation value at the upstream end of "
+                        "the stream segment."),
+                    "type": "number",
+                    "units": u.pixels,  # TODO: does this work?
+                },
+                "ds_fa": {
+                    "about": (
+                        "The flow accumulation value at the downstream end of "
+                        "the stream segment."),
+                    "type": "number",
+                    "units": u.pixels,  # TODO: does this work?
+                },
+                "thresh_fa": {
+                    "about": (
+                        "The final threshold flow accumulation value used to "
+                        "determine the river segments."),
+                    "type": "number",
+                    "units": u.pixels,  # TODO: does this work?
+                },
+                "upstream_d8_dir": {
+                    "about": (
+                        "The direction of flow immediately upstream."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "ds_x": {
+                    "about": "The raster X coordinate for the outlet.",
+                    "type": "number",
+                    "units": u.none,
+                },
+                "ds_y": {
+                    "about": "The raster Y coordinate for the outlet.",
+                    "type": "number",
+                    "units": u.none,
+                },
+                "ds_x_1": {
+                    "about": (
+                        "The raster X coordinate that is 1 pixel upstream "
+                        "from the outlet."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "ds_y_1": {
+                    "about": (
+                        "The raster Y coordinate that is 1 pixel upstream "
+                        "from the outlet."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "us_x": {
+                    "about": (
+                        "The raster X coordinate for the upstream inlet."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "us_y": {
+                    "about": (
+                        "The raster Y coordinate for the upstream inlet."),
+                    "type": "number",
+                    "units": u.none,
+                },
+            },
         },
         "subwatersheds.gpkg": {
             "about": "",

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -143,13 +143,6 @@ MODEL_SPEC = {
                     "type": "number",
                     "units": u.none,
                 },
-                "river_id": {
-                    "about": (
-                        "A unique identifier among all stream segments which "
-                        "are hydrologically connected."),
-                    "type": "number",
-                    "units": u.none,
-                },
                 "us_fa": {
                     "about": (
                         "The flow accumulation value at the upstream end of "
@@ -216,9 +209,48 @@ MODEL_SPEC = {
             },
         },
         "subwatersheds.gpkg": {
-            "about": "",
+            "about": (
+                "A GeoPackage with polygon features representing "
+                "subwatersheds.  A new subwatershed is created for each "
+                "tributary of a stream and is influenced greatly by "
+                "your choice of Threshold Flow Accumulation value."),
             "geometries": spec_utils.POLYGON,
-            "fields": {},
+            "fields": {
+                "stream_id": {
+                    "about": (
+                        "A unique stream id, matching the one in the Strahler "
+                        "stream order vector."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "terminated_early": {
+                    "about": (
+                        "Indicates whether generation of this subwatershed "
+                        "terminated early (1) or completed as expected (0). "
+                        "If you encounter a (1), please let us know via the "
+                        "forums, community.naturalcapitalproject.org."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "outlet_x": {
+                    "about": (
+                        "The X coordinate in pixels from the origin of the "
+                        "outlet of the watershed. This can be useful when "
+                        "determining other properties of the watershed when "
+                        "indexing with the underlying raster data."),
+                    "type": "number",
+                    "units": u.none,
+                },
+                "outlet_y": {
+                    "about": (
+                        "The X coordinate in pixels from the origin of the "
+                        "outlet of the watershed. This can be useful when "
+                        "determining other properties of the watershed when "
+                        "indexing with the underlying raster data."),
+                    "type": "number",
+                    "units": u.none,
+                },
+            },
         },
     }
 }

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -97,13 +97,13 @@ MODEL_SPEC = {
             "type": "boolean",
             "required": False,
             "about": gettext("Calculate the Strahler Stream order."),
-            "name": gettext("calculate strahler stream orders"),
+            "name": gettext("calculate strahler stream orders (D8 only)"),
         },
         "calculate_subwatersheds": {
             "type": "boolean",
             "required": False,
             "about": gettext("Determine subwatersheds from the stream order."),
-            "name": gettext("calculate subwatersheds"),
+            "name": gettext("calculate subwatersheds (D8 only)"),
         },
     },
     "outputs": {

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -173,40 +173,44 @@ MODEL_SPEC = {
                     "units": u.none,
                 },
                 "ds_x": {
-                    "about": "The raster X coordinate for the outlet.",
+                    "about": (
+                        "The DEM X coordinate for the outlet in pixels from "
+                        "the origin."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
                 "ds_y": {
-                    "about": "The raster Y coordinate for the outlet.",
+                    "about": (
+                        "The DEM Y coordinate for the outlet in pixels from "
+                        "the origin."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
                 "ds_x_1": {
                     "about": (
-                        "The raster X coordinate that is 1 pixel upstream "
+                        "The DEM X coordinate that is 1 pixel upstream "
                         "from the outlet."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
                 "ds_y_1": {
                     "about": (
-                        "The raster Y coordinate that is 1 pixel upstream "
+                        "The DEM Y coordinate that is 1 pixel upstream "
                         "from the outlet."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
                 "us_x": {
                     "about": (
-                        "The raster X coordinate for the upstream inlet."),
+                        "The DEM X coordinate for the upstream inlet."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
                 "us_y": {
                     "about": (
-                        "The raster Y coordinate for the upstream inlet."),
+                        "The DEM Y coordinate for the upstream inlet."),
                     "type": "number",
-                    "units": u.none,
+                    "units": u.pixels,
                 },
             },
         },

--- a/tests/test_routedem.py
+++ b/tests/test_routedem.py
@@ -184,6 +184,7 @@ class RouteDEMTests(unittest.TestCase):
             'calculate_downslope_distance': True,
             'calculate_slope': True,
             'calculate_stream_order': True,
+            'calculate_subwatersheds': True,
             'threshold_flow_accumulation': 4,
         }
 
@@ -196,11 +197,13 @@ class RouteDEMTests(unittest.TestCase):
                 'flow_accumulation_foo.tif',
                 'flow_direction_foo.tif',
                 'slope_foo.tif',
-                'stream_mask_foo.tif'):
+                'stream_mask_foo.tif',
+                'strahler_stream_order_foo.gpkg',
+                'subwatersheds_foo.gpkg'):
             self.assertTrue(
                 os.path.exists(
                     os.path.join(args['workspace_dir'], expected_file)),
-                'Raster not found: %s' % expected_file)
+                'File not found: %s' % expected_file)
 
         expected_stream_mask = numpy.array([
             [0, 0, 0, 0, 1, 1, 0, 0, 0],
@@ -264,9 +267,6 @@ class RouteDEMTests(unittest.TestCase):
                 'downslope_distance_foo.tif')).ReadAsArray(),
             rtol=0, atol=1e-6)
 
-        self.assertTrue(os.path.exists(os.path.join(
-            args['workspace_dir'], 'strahler_stream_order_foo.gpkg')))
-
     def test_routedem_mfd(self):
         """RouteDEM: test mfd routing."""
         from natcap.invest import routedem
@@ -282,6 +282,7 @@ class RouteDEMTests(unittest.TestCase):
             'calculate_downslope_distance': True,
             'calculate_slope': False,
             'calculate_stream_order': True,  # make sure file not created
+            'calculate_subwatersheds': True,  # make sure file not created
             'threshold_flow_accumulation': 4,
         }
 
@@ -325,6 +326,8 @@ class RouteDEMTests(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(
             args['workspace_dir'], 'strahler_stream_order_foo.gpkg')))
+        self.assertFalse(os.path.exists(os.path.join(
+            args['workspace_dir'], 'subwatersheds_foo.gpkg')))
 
     def test_validation_required_args(self):
         """RouteDEM: test required args in validation."""

--- a/tests/test_routedem.py
+++ b/tests/test_routedem.py
@@ -1,8 +1,8 @@
 """Module for Regression Testing the InVEST Carbon model."""
-import unittest
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
+import unittest
 
 import numpy
 from osgeo import gdal
@@ -163,8 +163,8 @@ class RouteDEMTests(unittest.TestCase):
              50.249374, 50.24938, 50.249382, 55.17727, 63.18101],
             dtype=numpy.float32).reshape((15,))
         numpy.testing.assert_allclose(
-            expected_unique_values, 
-            numpy.unique(slope_array), 
+            expected_unique_values,
+            numpy.unique(slope_array),
             rtol=0, atol=1e-6)
         numpy.testing.assert_allclose(
             numpy.sum(slope_array), 4088.7358, rtol=0, atol=1e-4)
@@ -183,6 +183,7 @@ class RouteDEMTests(unittest.TestCase):
             'calculate_stream_threshold': True,
             'calculate_downslope_distance': True,
             'calculate_slope': True,
+            'calculate_stream_order': True,
             'threshold_flow_accumulation': 4,
         }
 
@@ -230,7 +231,7 @@ class RouteDEMTests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_flow_accum,
             gdal.OpenEx(os.path.join(
-                args['workspace_dir'], 
+                args['workspace_dir'],
                 'flow_accumulation_foo.tif')).ReadAsArray(),
             rtol=0, atol=1e-6)
 
@@ -244,7 +245,7 @@ class RouteDEMTests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_flow_direction,
             gdal.OpenEx(os.path.join(
-                args['workspace_dir'], 
+                args['workspace_dir'],
                 'flow_direction_foo.tif')).ReadAsArray(),
             rtol=0, atol=1e-6)
 
@@ -259,9 +260,12 @@ class RouteDEMTests(unittest.TestCase):
         numpy.testing.assert_allclose(
             expected_downslope_distance,
             gdal.OpenEx(os.path.join(
-                args['workspace_dir'], 
+                args['workspace_dir'],
                 'downslope_distance_foo.tif')).ReadAsArray(),
             rtol=0, atol=1e-6)
+
+        self.assertTrue(os.path.exists(os.path.join(
+            args['workspace_dir'], 'strahler_stream_order_foo.gpkg')))
 
     def test_routedem_mfd(self):
         """RouteDEM: test mfd routing."""
@@ -277,6 +281,7 @@ class RouteDEMTests(unittest.TestCase):
             'calculate_stream_threshold': True,
             'calculate_downslope_distance': True,
             'calculate_slope': False,
+            'calculate_stream_order': True,  # make sure file not created
             'threshold_flow_accumulation': 4,
         }
 
@@ -317,6 +322,9 @@ class RouteDEMTests(unittest.TestCase):
             raster_sum = numpy.sum(raster.ReadAsArray(), dtype=numpy.float64)
             numpy.testing.assert_allclose(
                 raster_sum, expected_sum, rtol=0, atol=1e-6)
+
+        self.assertFalse(os.path.exists(os.path.join(
+            args['workspace_dir'], 'strahler_stream_order_foo.gpkg')))
 
     def test_validation_required_args(self):
         """RouteDEM: test required args in validation."""

--- a/workbench/src/renderer/ui_config.js
+++ b/workbench/src/renderer/ui_config.js
@@ -239,13 +239,24 @@ const UI_SPEC = {
       ['algorithm'],
       ['calculate_flow_direction'],
       ['calculate_flow_accumulation'],
-      ['calculate_stream_threshold', 'threshold_flow_accumulation', 'calculate_downslope_distance'],
+      ['calculate_stream_threshold',
+        'threshold_flow_accumulation',
+        'calculate_downslope_distance',
+        'calculate_stream_order',
+        'calculate_subwatersheds',
+      ],
     ],
     enabledFunctions: {
       calculate_flow_accumulation: isSufficient.bind(null, 'calculate_flow_direction'),
       calculate_stream_threshold: isSufficient.bind(null, 'calculate_flow_accumulation'),
       threshold_flow_accumulation: isSufficient.bind(null, 'calculate_stream_threshold'),
       calculate_downslope_distance: isSufficient.bind(null, 'calculate_stream_threshold'),
+      calculate_stream_order: ((state) => (
+        isSufficient('calculate_stream_threshold', state)
+        && state.argsValues.algorithm.value === 'D8')),
+      calculate_subwatersheds: ((state) => (
+        isSufficient('calculate_stream_order', state)
+        && state.argsValues.algorithm.value === 'D8')),
     },
   },
   scenario_generator_proximity: {


### PR DESCRIPTION
This PR exposes subwatershed delineation and Strahler stream order extraction in the RouteDEM UI.  Changes here include:

* `MODEL_SPEC` definitions for outputs (and there are a lot of fields!)
* Interactivity rules in the workbench to emphasize dependence on D8 (not available for MFD)
* One additional fix to reduce duplication in an if/else in `execute`.

The bitbucket PR for updating the sample data is up and should be reviewed first: https://bitbucket.org/natcap/invest-sample-data/pull-requests/30

Fixes #349
Fixes #884

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
