### PR TITLE
Correct sediment deposition progress logging

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,6 +62,10 @@ Unreleased Changes
     * The Scenic Quality model now supports both uppercase and lowercase
       fieldnames. Leading and trailing spaces are now also stripped for the
       user's convenience. https://github.com/natcap/invest/issues/1276
+* SDR
+    * Fixed an issue with sediment deposition progress logging that was
+      causing the "percent complete" indicator to not progress linearly.
+      https://github.com/natcap/invest/issues/1262
 
 3.13.0 (2023-03-17)
 -------------------


### PR DESCRIPTION
This PR fixes an issue with the sediment deposition progress logging where logging would progress non-linearly.

I don't have a test for this because it requires a reasonably large DEM to reproduce, which would really slow down our test suite.

Fixes #1262 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
