### PR TITLE
Urban Nature Access: Assume a default nodata value if one is not provided

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Set up GCP
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: "= 417.0.1"
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
@@ -189,6 +191,8 @@ jobs:
       - name: Set up GCP
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: "= 417.0.1"
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
@@ -366,6 +370,8 @@ jobs:
       - name: Set up GCP
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: "= 417.0.1"
 
       - name: Sign binaries (macOS)
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' # secrets not available in PR
@@ -457,6 +463,8 @@ jobs:
       - name: Set up GCP
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          version: "= 417.0.1"
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,13 +123,13 @@ jobs:
 
       - name: Authenticate GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
       - name: Set up GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
@@ -182,13 +182,13 @@ jobs:
         # different extensions)
       - name: Authenticate GCP
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
       - name: Set up GCP
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
@@ -359,13 +359,13 @@ jobs:
 
       - name: Authenticate GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
       - name: Set up GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Sign binaries (macOS)
         if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' # secrets not available in PR
@@ -450,13 +450,13 @@ jobs:
 
       - name: Authenticate GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
       - name: Set up GCP
         if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,6 +62,14 @@ Unreleased Changes
     * The Scenic Quality model now supports both uppercase and lowercase
       fieldnames. Leading and trailing spaces are now also stripped for the
       user's convenience. https://github.com/natcap/invest/issues/1276
+* Urban Nature Access
+    * The model will now handle a case where an input raster might not have a
+      nodata value defined.  When this happens, a nodata value is inferred
+      based on the datatype of the source raster and a ``WARNING`` is logged to
+      notify the user.  It is possible, though unlikely, that the assumed value
+      may collide with values in the source raster.  If this happens, the
+      workaround is to define the correct nodata value in the source raster.
+      https://github.com/natcap/invest/issues/1293
 
 3.13.0 (2023-03-17)
 -------------------


### PR DESCRIPTION
Urban Nature Access has a masking step where, given a mask raster, convert pixel values to nodata outside of the mask.  This breaks if the user does not have a nodata value defined.  To get around this, this PR assumes a datatype-specific default nodata value if one has not already been provided.  I don't particularly like assuming values like this, but masking seems like an interesting possible case where it just doesn't make sense without having a nodata value defined or assumed.

Fixes #1293 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
