### PR TITLE
Fix natcap/invest#1105: mask qf sum using nodata from all months

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,6 +79,10 @@ Unreleased Changes
     * Fixed an issue with sediment deposition progress logging that was
       causing the "percent complete" indicator to not progress linearly.
       https://github.com/natcap/invest/issues/1262
+* Seasonal Water Yield
+    * Fixed a bug where monthy quickflow nodata pixels were not being passed
+      on to the total quickflow raster, which could result in negative values
+      on the edges (`#1105 <https://github.com/natcap/invest/issues/1105>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1021,13 +1021,16 @@ def _calculate_annual_qfi(qfm_path_list, target_qf_path):
 
     def qfi_sum_op(*qf_values):
         """Sum the monthly qfis."""
-        qf_sum = numpy.zeros(qf_values[0].shape)
-        valid_mask = ~utils.array_equals_nodata(qf_values[0], qf_nodata)
-        valid_qf_sum = qf_sum[valid_mask]
-        for index in range(len(qf_values)):
-            valid_qf_sum += qf_values[index][valid_mask]
-        qf_sum[:] = qf_nodata
-        qf_sum[valid_mask] = valid_qf_sum
+
+        # only calculate the sum where data is available for all 12 months
+        valid_mask = numpy.full(qf_values[0].shape, True)
+        for qf_array in qf_values:
+            valid_mask &= ~utils.array_equals_nodata(qf_array, qf_nodata)
+
+        qf_sum = numpy.full(qf_values[0].shape, qf_nodata, dtype=numpy.float32)
+        qf_sum[valid_mask] = 0
+        for qf_array in qf_values:
+            qf_sum[valid_mask] += qf_array[valid_mask]
         return qf_sum
 
     pygeoprocessing.raster_calculator(

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -1030,6 +1030,42 @@ class SeasonalWaterYieldRegressionTests(unittest.TestCase):
         self.assertTrue(numpy.isclose(
             quickflow_array, expected_quickflow_array).all())
 
+    def test_calculate_annual_qfi_different_nodata_areas(self):
+        """Test with qf rasters with different areas of nodata."""
+        from natcap.invest.seasonal_water_yield import seasonal_water_yield
+        qf_array_1 = numpy.array([
+            [10, 10],
+            [10, -1]], dtype=numpy.float32)
+        qf_array_2 = numpy.array([
+            [10, 10],
+            [-1, 10]], dtype=numpy.float32)
+        qf_array_3 = numpy.array([
+            [-1, 10],
+            [10, 10]], dtype=numpy.float32)
+
+        qf_1_path = os.path.join(self.workspace_dir, 'qf_1.tif')
+        qf_2_path = os.path.join(self.workspace_dir, 'qf_2.tif')
+        qf_3_path = os.path.join(self.workspace_dir, 'qf_3.tif')
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)  # UTM Zone 10N
+        project_wkt = srs.ExportToWkt()
+        output_path = os.path.join(self.workspace_dir, 'qf_sum.tif')
+
+        # write all the test arrays to raster files
+        for array, path in [(qf_array_1, qf_1_path),
+                            (qf_array_2, qf_2_path),
+                            (qf_array_3, qf_3_path)]:
+            pygeoprocessing.numpy_array_to_raster(
+                array, -1, (1, -1), (1180000, 690000), project_wkt, path)
+        seasonal_water_yield._calculate_annual_qfi(
+            [qf_1_path, qf_2_path, qf_3_path], output_path)
+        numpy.testing.assert_allclose(
+            pygeoprocessing.raster_to_numpy_array(output_path),
+            numpy.array([
+                [-1, 30],
+                [-1, -1]], dtype=numpy.float32))
+
     def test_local_recharge_undefined_nodata(self):
         """Test `calculate_local_recharge` with undefined nodata values"""
         from natcap.invest.seasonal_water_yield import \


### PR DESCRIPTION
## Description
Fixes #1105 

Breaking these changes out from the other SWY issues.

The issue was that we were assuming all 12 monthly quickflow rasters had nodata in the same place. We were masking all of them based on the nodata mask for January. This was a wrong assumption - each monthly quickflow raster is derived from a user-provided monthly precipitation raster, which can have different nodata areas.

This bug was the root cause of at least one user complaint that they had negative values on the edges of their quickflow raster. They had a negative nodata value that was being treated as valid data, and summed together with real data, resulting in a negative sum.

This PR masks the quickflow sum based on all 12 monthly quickflow rasters. The quickflow sum will have nodata where any of the 12 monthly rasters has nodata. The quickflow sum will have valid data only where all 12 monthly rasters have valid data.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
