### PR TITLE
Remove GDAL cache limit in SWY

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,6 +83,9 @@ Unreleased Changes
     * Fixed a bug where monthy quickflow nodata pixels were not being passed
       on to the total quickflow raster, which could result in negative values
       on the edges (`#1105 <https://github.com/natcap/invest/issues/1105>`_)
+    * Removed the GDAL cache size limit on this model, which means that, by
+      default, the model will use up to 5% of installed memory.
+      https://github.com/natcap/invest/issues/1320
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -21,8 +21,6 @@ from ..model_metadata import MODEL_METADATA
 from ..unit_registry import u
 from . import seasonal_water_yield_core
 
-gdal.SetCacheMax(2**26)
-
 LOGGER = logging.getLogger(__name__)
 
 TARGET_NODATA = -1


### PR DESCRIPTION
This PR removes the GDAL cache limit.  The current default is 5% of the system's installed memory.  This was much more performant when testing this on Lingling's computer, running on the whole country of Pakistan for the BELA project.

Fixes #1320 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the affected models' UIs (if relevant)
