### PR TITLE
SWY: don't fill in nodata pixels in quickflow

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,6 +86,8 @@ Unreleased Changes
     * Removed the GDAL cache size limit on this model, which means that, by
       default, the model will use up to 5% of installed memory.
       https://github.com/natcap/invest/issues/1320
+    * Fixed a bug where nodata pixels in quick flow were being set to 0
+      (`#1317 <https://github.com/natcap/invest/issues/1317>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,8 +86,10 @@ Unreleased Changes
     * Removed the GDAL cache size limit on this model, which means that, by
       default, the model will use up to 5% of installed memory.
       https://github.com/natcap/invest/issues/1320
-    * Fixed a bug where nodata pixels in quick flow were being set to 0
-      (`#1317 <https://github.com/natcap/invest/issues/1317>`_)
+    * Monthly quick flow nodata values will now be preserved instead of being
+      set to 0. The old behavior was not well documented and caused some
+      confusion when nodata pixels did not line up. It's safer not to fill in
+      unknown data. (`#1317 <https://github.com/natcap/invest/issues/1317>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1133,12 +1133,6 @@ def _calculate_monthly_quick_flow(
             valid_stream_precip_mask &= ~utils.array_equals_nodata(
                 p_im, p_nodata)
         qf_im[valid_stream_precip_mask] = p_im[valid_stream_precip_mask]
-
-        # this handles some user cases where they don't have data defined on
-        # their landcover raster. It otherwise crashes later with some NaNs.
-        # more intermediate outputs with nodata values guaranteed to be defined
-        qf_im[utils.array_equals_nodata(qf_im, qf_nodata) &
-              ~utils.array_equals_nodata(stream_array, stream_nodata)] = 0.0
         return qf_im
 
     pygeoprocessing.raster_calculator(


### PR DESCRIPTION
## Description
Fixes #1317 
Just removing that line of code. I tested this out on the sample data and the results are basically unchanged (there are like 4 more nodata pixels in the result).

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
