### PR TITLE
Remove `build_lookup_from_csv` and consolidate into `read_csv_to_dataframe`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,12 +44,16 @@ Unreleased Changes
     * Updated the package installation instructions in the API docs for clarity
       and also to highlight the ease of installation through ``conda-forge``.
       https://github.com/natcap/invest/issues/1256
-    * ``utils.build_lookup_from_csv`` now accepts kwargs for ``pandas.read_csv``
-      (`#1319 <https://github.com/natcap/invest/issues/1319>`_)
+    * ``utils.build_lookup_from_csv`` has been deprecated and its functionality
+      has been merged into ``utils.read_csv_to_dataframe``
+      (`#1319 <https://github.com/natcap/invest/issues/1319>`_),
+      (`#1327 <https://github.com/natcap/invest/issues/1327>`_)
 * Workbench
     * Fixed a bug where sampledata downloads failed silently (and progress bar
       became innacurate) if the Workbench did not have write permission to
       the download location. https://github.com/natcap/invest/issues/1070
+* Forest Carbon
+    * The biophysical table is now case-insensitive.
 * HRA
     * Fixed a bug in HRA where the model would error when all exposure and
       consequence criteria were skipped for a single habitat. The model now

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -517,8 +517,8 @@ def execute(args):
             'Checking that watersheds have entries for every `ws_id` in the '
             'valuation table.')
         # Open/read in valuation parameters from CSV file
-        valuation_params = utils.build_lookup_from_csv(
-            args['valuation_table_path'], 'ws_id')
+        valuation_params = utils.read_csv_to_dataframe(
+            args['valuation_table_path'], 'ws_id').to_dict(orient='index')
         watershed_vector = gdal.OpenEx(
             args['watersheds_path'], gdal.OF_VECTOR)
         watershed_layer = watershed_vector.GetLayer()
@@ -636,15 +636,15 @@ def execute(args):
         'lulc': pygeoprocessing.get_raster_info(clipped_lulc_path)['nodata'][0]}
 
     # Open/read in the csv file into a dictionary and add to arguments
-    bio_dict = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode', to_lower=True)
+    bio_dict = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
     bio_lucodes = set(bio_dict.keys())
     bio_lucodes.add(nodata_dict['lulc'])
     LOGGER.debug(f'bio_lucodes: {bio_lucodes}')
 
     if 'demand_table_path' in args and args['demand_table_path'] != '':
-        demand_dict = utils.build_lookup_from_csv(
-            args['demand_table_path'], 'lucode')
+        demand_dict = utils.read_csv_to_dataframe(
+            args['demand_table_path'], 'lucode').to_dict(orient='index')
         demand_reclassify_dict = dict(
             [(lucode, demand_dict[lucode]['demand'])
              for lucode in demand_dict])

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -366,8 +366,8 @@ def execute(args):
          (_INTERMEDIATE_BASE_FILES, intermediate_output_dir),
          (_TMP_BASE_FILES, output_dir)], file_suffix)
 
-    carbon_pool_table = utils.build_lookup_from_csv(
-        args['carbon_pools_path'], 'lucode')
+    carbon_pool_table = utils.read_csv_to_dataframe(
+        args['carbon_pools_path'], 'lucode').to_dict(orient='index')
 
     work_token_dir = os.path.join(
         intermediate_output_dir, '_taskgraph_working_dir')

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1985,7 +1985,7 @@ def _read_transition_matrix(transition_csv_path, biophysical_dict):
         landcover transition, and the second contains accumulation rates for
         the pool for the landcover transition.
     """
-    table = utils.read_csv_to_dataframe(transition_csv_path, index_col=False)
+    table = utils.read_csv_to_dataframe(transition_csv_path)
 
     lulc_class_to_lucode = {}
     max_lucode = 0
@@ -2239,8 +2239,7 @@ def _extract_snapshots_from_table(csv_path):
 
     """
     table = utils.read_csv_to_dataframe(
-        csv_path, to_lower=True, index_col=False,
-        expand_path_cols=['raster_path'])
+        csv_path, cols_to_lower=True, expand_path_cols=['raster_path'])
 
     output_dict = {}
     table.set_index("snapshot_year", drop=False, inplace=True)

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -1987,7 +1987,7 @@ def _read_transition_matrix(transition_csv_path, biophysical_dict):
         the pool for the landcover transition.
     """
     table = utils.read_csv_to_dataframe(
-        transition_csv_path, cols_to_lower=False, vals_to_lower=False)
+        transition_csv_path, convert_cols_to_lower=False, convert_vals_to_lower=False)
 
     lulc_class_to_lucode = {}
     max_lucode = 0
@@ -2031,6 +2031,10 @@ def _read_transition_matrix(transition_csv_path, biophysical_dict):
 
         # Strip any whitespace to eliminate leading/trailing whitespace
         row = row.str.strip()
+
+        # skip rows starting with a blank cell, these are part of the legend
+        if not row['lulc-class']:
+            continue
 
         try:
             from_colname = str(row['lulc-class']).lower()
@@ -2241,7 +2245,7 @@ def _extract_snapshots_from_table(csv_path):
 
     """
     table = utils.read_csv_to_dataframe(
-        csv_path, vals_to_lower=False, expand_path_cols=['raster_path'])
+        csv_path, convert_vals_to_lower=False, expand_path_cols=['raster_path'])
 
     output_dict = {}
     table.set_index("snapshot_year", drop=False, inplace=True)

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -584,8 +584,8 @@ def execute(args):
 
     # We're assuming that the LULC initial variables and the carbon pool
     # transient table are combined into a single lookup table.
-    biophysical_parameters = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'code')
+    biophysical_parameters = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'code').to_dict(orient='index')
 
     # LULC Classnames are critical to the transition mapping, so they must be
     # unique.  This check is here in ``execute`` because it's possible that
@@ -964,8 +964,9 @@ def execute(args):
         if args.get('use_price_table', False):
             prices = {
                 year: values['price'] for (year, values) in
-                utils.build_lookup_from_csv(
-                    args['price_table_path'], 'year').items()}
+                utils.read_csv_to_dataframe(
+                    args['price_table_path'], 'year'
+                ).to_dict(orient='index').items()}
         else:
             inflation_rate = float(args['inflation_rate']) * 0.01
             annual_price = float(args['price'])
@@ -1985,7 +1986,8 @@ def _read_transition_matrix(transition_csv_path, biophysical_dict):
         landcover transition, and the second contains accumulation rates for
         the pool for the landcover transition.
     """
-    table = utils.read_csv_to_dataframe(transition_csv_path)
+    table = utils.read_csv_to_dataframe(
+        transition_csv_path, cols_to_lower=False, vals_to_lower=False)
 
     lulc_class_to_lucode = {}
     max_lucode = 0
@@ -2239,7 +2241,7 @@ def _extract_snapshots_from_table(csv_path):
 
     """
     table = utils.read_csv_to_dataframe(
-        csv_path, cols_to_lower=True, expand_path_cols=['raster_path'])
+        csv_path, vals_to_lower=False, expand_path_cols=['raster_path'])
 
     output_dict = {}
     table.set_index("snapshot_year", drop=False, inplace=True)

--- a/src/natcap/invest/coastal_blue_carbon/preprocessor.py
+++ b/src/natcap/invest/coastal_blue_carbon/preprocessor.py
@@ -209,8 +209,8 @@ def execute(args):
         target_path_list=aligned_snapshot_paths,
         task_name='Align input landcover rasters')
 
-    landcover_table = utils.build_lookup_from_csv(
-        args['lulc_lookup_table_path'], 'code')
+    landcover_table = utils.read_csv_to_dataframe(
+        args['lulc_lookup_table_path'], 'code').to_dict(orient='index')
 
     target_transition_table = os.path.join(
         output_dir, TRANSITION_TABLE.format(suffix=suffix))

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2315,7 +2315,7 @@ def _schedule_habitat_tasks(
 
     """
     habitat_dataframe = utils.read_csv_to_dataframe(
-        habitat_table_path, cols_to_lower=True, expand_path_cols=['path'])
+        habitat_table_path, vals_to_lower=False, expand_path_cols=['path'])
     habitat_dataframe = habitat_dataframe.rename(
         columns={'protection distance (m)': 'distance'})
 
@@ -2834,7 +2834,8 @@ def assemble_results_and_calculate_exposure(
             with open(pickle_path, 'rb') as file:
                 final_values_dict[var_name] = pickle.load(file)
 
-    habitat_df = utils.read_csv_to_dataframe(habitat_protection_path)
+    habitat_df = utils.read_csv_to_dataframe(
+        habitat_protection_path, cols_to_lower=False, vals_to_lower=False)
     output_layer.StartTransaction()
     for feature in output_layer:
         shore_id = feature.GetField(SHORE_ID_FIELD)
@@ -3464,7 +3465,8 @@ def _validate_habitat_table_paths(habitat_table_path):
         ValueError if any vector in the ``path`` column cannot be opened.
     """
     habitat_dataframe = utils.read_csv_to_dataframe(
-        habitat_table_path, expand_path_cols=['path'])
+        habitat_table_path, cols_to_lower=False, vals_to_lower=False,
+        expand_path_cols=['path'])
     bad_paths = []
     for habitat_row in habitat_dataframe.itertuples():
         try:

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2315,7 +2315,7 @@ def _schedule_habitat_tasks(
 
     """
     habitat_dataframe = utils.read_csv_to_dataframe(
-        habitat_table_path, to_lower=True, expand_path_cols=['path'])
+        habitat_table_path, cols_to_lower=True, expand_path_cols=['path'])
     habitat_dataframe = habitat_dataframe.rename(
         columns={'protection distance (m)': 'distance'})
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -2315,7 +2315,7 @@ def _schedule_habitat_tasks(
 
     """
     habitat_dataframe = utils.read_csv_to_dataframe(
-        habitat_table_path, vals_to_lower=False, expand_path_cols=['path'])
+        habitat_table_path, convert_vals_to_lower=False, expand_path_cols=['path'])
     habitat_dataframe = habitat_dataframe.rename(
         columns={'protection distance (m)': 'distance'})
 
@@ -2835,7 +2835,7 @@ def assemble_results_and_calculate_exposure(
                 final_values_dict[var_name] = pickle.load(file)
 
     habitat_df = utils.read_csv_to_dataframe(
-        habitat_protection_path, cols_to_lower=False, vals_to_lower=False)
+        habitat_protection_path, convert_cols_to_lower=False, convert_vals_to_lower=False)
     output_layer.StartTransaction()
     for feature in output_layer:
         shore_id = feature.GetField(SHORE_ID_FIELD)
@@ -3465,7 +3465,7 @@ def _validate_habitat_table_paths(habitat_table_path):
         ValueError if any vector in the ``path`` column cannot be opened.
     """
     habitat_dataframe = utils.read_csv_to_dataframe(
-        habitat_table_path, cols_to_lower=False, vals_to_lower=False,
+        habitat_table_path, convert_cols_to_lower=False, convert_vals_to_lower=False,
         expand_path_cols=['path'])
     bad_paths = []
     for habitat_row in habitat_dataframe.itertuples():

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -458,8 +458,8 @@ def execute(args):
         None.
 
     """
-    crop_to_landcover_table = utils.build_lookup_from_csv(
-        args['landcover_to_crop_table_path'], 'crop_name', to_lower=True)
+    crop_to_landcover_table = utils.read_csv_to_dataframe(
+        args['landcover_to_crop_table_path'], 'crop_name').to_dict(orient='index')
     bad_crop_name_list = []
     for crop_name in crop_to_landcover_table:
         crop_climate_bin_raster_path = os.path.join(
@@ -540,8 +540,8 @@ def execute(args):
         climate_percentile_yield_table_path = os.path.join(
             args['model_data_path'],
             _CLIMATE_PERCENTILE_TABLE_PATTERN % crop_name)
-        crop_climate_percentile_table = utils.build_lookup_from_csv(
-            climate_percentile_yield_table_path, 'climate_bin', to_lower=True)
+        crop_climate_percentile_table = utils.read_csv_to_dataframe(
+            climate_percentile_yield_table_path, 'climate_bin').to_dict(orient='index')
         yield_percentile_headers = [
             x for x in list(crop_climate_percentile_table.values())[0]
             if x != 'climate_bin']
@@ -698,9 +698,10 @@ def execute(args):
 
     # both 'crop_nutrient.csv' and 'crop' are known data/header values for
     # this model data.
-    nutrient_table = utils.build_lookup_from_csv(
+    nutrient_table = utils.read_csv_to_dataframe(
         os.path.join(args['model_data_path'], 'crop_nutrient.csv'),
-        'crop', to_lower=False)
+        'crop', cols_to_lower=False, vals_to_lower=False
+        ).to_dict(orient='index')
     result_table_path = os.path.join(
         output_dir, 'result_table%s.csv' % file_suffix)
 

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -700,7 +700,7 @@ def execute(args):
     # this model data.
     nutrient_table = utils.read_csv_to_dataframe(
         os.path.join(args['model_data_path'], 'crop_nutrient.csv'),
-        'crop', cols_to_lower=False, vals_to_lower=False
+        'crop', convert_cols_to_lower=False, convert_vals_to_lower=False
         ).to_dict(orient='index')
     result_table_path = os.path.join(
         output_dir, 'result_table%s.csv' % file_suffix)

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -798,7 +798,7 @@ def execute(args):
     # this model data.
     nutrient_table = utils.read_csv_to_dataframe(
         os.path.join(args['model_data_path'], 'crop_nutrient.csv'),
-        'crop', cols_to_lower=False, vals_to_lower=False
+        'crop', convert_cols_to_lower=False, convert_vals_to_lower=False
         ).to_dict(orient='index')
 
     LOGGER.info("Generating report table")

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -484,11 +484,11 @@ def execute(args):
 
     LOGGER.info(
         "Checking if the landcover raster is missing lucodes")
-    crop_to_landcover_table = utils.build_lookup_from_csv(
-        args['landcover_to_crop_table_path'], 'crop_name', to_lower=True)
+    crop_to_landcover_table = utils.read_csv_to_dataframe(
+        args['landcover_to_crop_table_path'], 'crop_name').to_dict(orient='index')
 
-    crop_to_fertlization_rate_table = utils.build_lookup_from_csv(
-        args['fertilization_rate_table_path'], 'crop_name', to_lower=True)
+    crop_to_fertlization_rate_table = utils.read_csv_to_dataframe(
+        args['fertilization_rate_table_path'], 'crop_name').to_dict(orient='index')
 
     crop_lucodes = [
         x[_EXPECTED_LUCODE_TABLE_HEADER]
@@ -571,8 +571,8 @@ def execute(args):
         crop_regression_table_path = os.path.join(
             args['model_data_path'], _REGRESSION_TABLE_PATTERN % crop_name)
 
-        crop_regression_table = utils.build_lookup_from_csv(
-            crop_regression_table_path, 'climate_bin', to_lower=True)
+        crop_regression_table = utils.read_csv_to_dataframe(
+            crop_regression_table_path, 'climate_bin').to_dict(orient='index')
         for bin_id in crop_regression_table:
             for header in _EXPECTED_REGRESSION_TABLE_HEADERS:
                 if crop_regression_table[bin_id][header.lower()] == '':
@@ -796,9 +796,10 @@ def execute(args):
 
     # both 'crop_nutrient.csv' and 'crop' are known data/header values for
     # this model data.
-    nutrient_table = utils.build_lookup_from_csv(
+    nutrient_table = utils.read_csv_to_dataframe(
         os.path.join(args['model_data_path'], 'crop_nutrient.csv'),
-        'crop', to_lower=False)
+        'crop', cols_to_lower=False, vals_to_lower=False
+        ).to_dict(orient='index')
 
     LOGGER.info("Generating report table")
     result_table_path = os.path.join(

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -336,7 +336,7 @@ def build_datastack_archive(args, model_name, datastack_path):
                     data_dir, f'{key}_csv_data')
 
                 dataframe = utils.read_csv_to_dataframe(
-                    source_path, cols_to_lower=True)
+                    source_path, vals_to_lower=False)
                 csv_source_dir = os.path.abspath(os.path.dirname(source_path))
                 for spatial_column_name in spatial_columns:
                     # Iterate through the spatial columns, identify the set of

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -336,7 +336,7 @@ def build_datastack_archive(args, model_name, datastack_path):
                     data_dir, f'{key}_csv_data')
 
                 dataframe = utils.read_csv_to_dataframe(
-                    source_path, vals_to_lower=False)
+                    source_path, convert_vals_to_lower=False)
                 csv_source_dir = os.path.abspath(os.path.dirname(source_path))
                 for spatial_column_name in spatial_columns:
                     # Iterate through the spatial columns, identify the set of

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -336,7 +336,7 @@ def build_datastack_archive(args, model_name, datastack_path):
                     data_dir, f'{key}_csv_data')
 
                 dataframe = utils.read_csv_to_dataframe(
-                    source_path, to_lower=True)
+                    source_path, cols_to_lower=True)
                 csv_source_dir = os.path.abspath(os.path.dirname(source_path))
                 for spatial_column_name in spatial_columns:
                     # Iterate through the spatial columns, identify the set of

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -418,8 +418,8 @@ def execute(args):
     # Map non-forest landcover codes to carbon biomasses
     LOGGER.info('Calculating direct mapped carbon stocks')
     carbon_maps = []
-    biophysical_table = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode', to_lower=False)
+    biophysical_table = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
     biophysical_keys = [
         x.lower() for x in list(biophysical_table.values())[0].keys()]
     pool_list = [('c_above', True)]
@@ -630,8 +630,8 @@ def _calculate_lulc_carbon_map(
 
     """
     # classify forest pixels from lulc
-    biophysical_table = utils.build_lookup_from_csv(
-        biophysical_table_path, 'lucode', to_lower=False)
+    biophysical_table = utils.read_csv_to_dataframe(
+        biophysical_table_path, 'lucode').to_dict(orient='index')
 
     lucode_to_per_cell_carbon = {}
     cell_size = pygeoprocessing.get_raster_info(
@@ -696,8 +696,8 @@ def _map_distance_from_tropical_forest_edge(
 
     """
     # Build a list of forest lucodes
-    biophysical_table = utils.build_lookup_from_csv(
-        biophysical_table_path, 'lucode', to_lower=False)
+    biophysical_table = utils.read_csv_to_dataframe(
+        biophysical_table_path, 'lucode').to_dict(orient='index')
     forest_codes = [
         lucode for (lucode, ludata) in biophysical_table.items()
         if int(ludata['is_tropical_forest']) == 1]

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -380,11 +380,12 @@ def execute(args):
     LOGGER.info("Checking Threat and Sensitivity tables for compliance")
     # Get CSVs as dictionaries and ensure the key is a string for threats.
     threat_dict = {
-        str(key): value for key, value in utils.build_lookup_from_csv(
-            args['threats_table_path'], 'THREAT', to_lower=True,
-            expand_path_cols=['cur_path', 'fut_path', 'base_path']).items()}
-    sensitivity_dict = utils.build_lookup_from_csv(
-        args['sensitivity_table_path'], 'LULC', to_lower=True)
+        str(key): value for key, value in utils.read_csv_to_dataframe(
+            args['threats_table_path'], 'THREAT',
+            expand_path_cols=['cur_path', 'fut_path', 'base_path']
+            ).to_dict(orient='index').items()}
+    sensitivity_dict = utils.read_csv_to_dataframe(
+        args['sensitivity_table_path'], 'LULC').to_dict(orient='index')
 
     half_saturation_constant = float(args['half_saturation_constant'])
 
@@ -1156,11 +1157,12 @@ def validate(args, limit_to=None):
 
         # Get CSVs as dictionaries and ensure the key is a string for threats.
         threat_dict = {
-            str(key): value for key, value in utils.build_lookup_from_csv(
-                args['threats_table_path'], 'THREAT', to_lower=True,
-                expand_path_cols=['cur_path', 'fut_path', 'base_path']).items()}
-        sensitivity_dict = utils.build_lookup_from_csv(
-            args['sensitivity_table_path'], 'LULC', to_lower=True)
+            str(key): value for key, value in utils.read_csv_to_dataframe(
+                args['threats_table_path'], 'THREAT',
+                expand_path_cols=['cur_path', 'fut_path', 'base_path']
+                ).to_dict(orient='index').items()}
+        sensitivity_dict = utils.read_csv_to_dataframe(
+            args['sensitivity_table_path'], 'LULC').to_dict(orient='index')
 
         # check that the threat names in the threats table match with the
         # threats columns in the sensitivity table.

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1845,7 +1845,8 @@ def _open_table_as_dataframe(table_path, **kwargs):
         return excel_df
     else:
         return utils.read_csv_to_dataframe(
-            table_path, cols_to_lower=True, expand_path_cols=['path'], **kwargs)
+            table_path, vals_to_lower=False,
+            expand_path_cols=['path'], **kwargs)
 
 
 def _parse_info_table(info_table_path):

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1845,7 +1845,7 @@ def _open_table_as_dataframe(table_path, **kwargs):
         return excel_df
     else:
         return utils.read_csv_to_dataframe(
-            table_path, vals_to_lower=False,
+            table_path, convert_vals_to_lower=False,
             expand_path_cols=['path'], **kwargs)
 
 

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1845,7 +1845,7 @@ def _open_table_as_dataframe(table_path, **kwargs):
         return excel_df
     else:
         return utils.read_csv_to_dataframe(
-            table_path, to_lower=True, expand_path_cols=['path'], **kwargs)
+            table_path, cols_to_lower=True, expand_path_cols=['path'], **kwargs)
 
 
 def _parse_info_table(info_table_path):

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -619,8 +619,8 @@ def execute(args):
         if args['calc_' + nutrient_id]:
             nutrients_to_process.append(nutrient_id)
 
-    lucode_to_parameters = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode')
+    lucode_to_parameters = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
 
     _validate_inputs(nutrients_to_process, lucode_to_parameters)
 

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -1179,8 +1179,8 @@ def _parse_scenario_variables(args):
     else:
         farm_vector_path = None
 
-    guild_table = utils.build_lookup_from_csv(
-        guild_table_path, 'species', to_lower=True)
+    guild_table = utils.read_csv_to_dataframe(
+        guild_table_path, 'species').to_dict(orient='index')
 
     LOGGER.info('Checking to make sure guild table has all expected headers')
     guild_headers = list(guild_table.values())[0].keys()
@@ -1192,8 +1192,8 @@ def _parse_scenario_variables(args):
                 f"'{header}' but was unable to find one. Here are all the "
                 f"headers from {guild_table_path}: {', '.join(guild_headers)}")
 
-    landcover_biophysical_table = utils.build_lookup_from_csv(
-        landcover_biophysical_table_path, 'lucode', to_lower=True)
+    landcover_biophysical_table = utils.read_csv_to_dataframe(
+        landcover_biophysical_table_path, 'lucode').to_dict(orient='index')
     biophysical_table_headers = (
         list(landcover_biophysical_table.values())[0].keys())
     for header in _EXPECTED_BIOPHYSICAL_HEADERS:

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -1616,7 +1616,7 @@ def _validate_same_projection(base_vector_path, table_path):
     # This will load the table as a list of paths which we can iterate through
     # without bothering the rest of the table structure
     data_paths = utils.read_csv_to_dataframe(
-        table_path, to_lower=True, expand_path_cols=['path']
+        table_path, cols_to_lower=True, expand_path_cols=['path']
     ).squeeze('columns')['path'].tolist()
 
     base_vector = gdal.OpenEx(base_vector_path, gdal.OF_VECTOR)
@@ -1673,7 +1673,7 @@ def _validate_predictor_types(table_path):
         ValueError if any value in the ``type`` column does not match a valid
         type, ignoring leading/trailing whitespace.
     """
-    df = utils.read_csv_to_dataframe(table_path, to_lower=True)
+    df = utils.read_csv_to_dataframe(table_path, cols_to_lower=True)
     # ignore leading/trailing whitespace because it will be removed
     # when the type values are used
     type_list = set([type.strip() for type in df['type']])

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -853,8 +853,9 @@ def _schedule_predictor_data_processing(
         'line_intersect_length': _line_intersect_length,
     }
 
-    predictor_table = utils.build_lookup_from_csv(
-        predictor_table_path, 'id', expand_path_cols=['path'])
+    predictor_table = utils.read_csv_to_dataframe(
+        predictor_table_path, 'id', expand_path_cols=['path']
+        ).to_dict(orient='index')
     predictor_task_list = []
     predictor_json_list = []  # tracks predictor files to add to shp
 
@@ -1546,7 +1547,8 @@ def _validate_same_id_lengths(table_path):
         tables.
 
     """
-    predictor_table = utils.build_lookup_from_csv(table_path, 'id')
+    predictor_table = utils.read_csv_to_dataframe(
+        table_path, 'id').to_dict(orient='index')
     too_long = set()
     for p_id in predictor_table:
         if len(p_id) > 10:
@@ -1579,11 +1581,11 @@ def _validate_same_ids_and_types(
         tables.
 
     """
-    predictor_table = utils.build_lookup_from_csv(
-        predictor_table_path, 'id')
+    predictor_table = utils.read_csv_to_dataframe(
+        predictor_table_path, 'id').to_dict(orient='index')
 
-    scenario_predictor_table = utils.build_lookup_from_csv(
-        scenario_predictor_table_path, 'id')
+    scenario_predictor_table = utils.read_csv_to_dataframe(
+        scenario_predictor_table_path, 'id').to_dict(orient='index')
 
     predictor_table_pairs = set([
         (p_id, predictor_table[p_id]['type'].strip()) for p_id in predictor_table])
@@ -1616,7 +1618,7 @@ def _validate_same_projection(base_vector_path, table_path):
     # This will load the table as a list of paths which we can iterate through
     # without bothering the rest of the table structure
     data_paths = utils.read_csv_to_dataframe(
-        table_path, cols_to_lower=True, expand_path_cols=['path']
+        table_path, vals_to_lower=False, expand_path_cols=['path']
     ).squeeze('columns')['path'].tolist()
 
     base_vector = gdal.OpenEx(base_vector_path, gdal.OF_VECTOR)
@@ -1673,7 +1675,7 @@ def _validate_predictor_types(table_path):
         ValueError if any value in the ``type`` column does not match a valid
         type, ignoring leading/trailing whitespace.
     """
-    df = utils.read_csv_to_dataframe(table_path, cols_to_lower=True)
+    df = utils.read_csv_to_dataframe(table_path, vals_to_lower=False)
     # ignore leading/trailing whitespace because it will be removed
     # when the type values are used
     type_list = set([type.strip() for type in df['type']])

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -1618,7 +1618,7 @@ def _validate_same_projection(base_vector_path, table_path):
     # This will load the table as a list of paths which we can iterate through
     # without bothering the rest of the table structure
     data_paths = utils.read_csv_to_dataframe(
-        table_path, vals_to_lower=False, expand_path_cols=['path']
+        table_path, convert_vals_to_lower=False, expand_path_cols=['path']
     ).squeeze('columns')['path'].tolist()
 
     base_vector = gdal.OpenEx(base_vector_path, gdal.OF_VECTOR)
@@ -1675,7 +1675,7 @@ def _validate_predictor_types(table_path):
         ValueError if any value in the ``type`` column does not match a valid
         type, ignoring leading/trailing whitespace.
     """
-    df = utils.read_csv_to_dataframe(table_path, vals_to_lower=False)
+    df = utils.read_csv_to_dataframe(table_path, convert_vals_to_lower=False)
     # ignore leading/trailing whitespace because it will be removed
     # when the type values are used
     type_list = set([type.strip() for type in df['type']])

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -498,8 +498,8 @@ def execute(args):
 
     """
     file_suffix = utils.make_suffix_string(args, 'results_suffix')
-    biophysical_table = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode')
+    biophysical_table = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
 
     # Test to see if c or p values are outside of 0..1
     for table_key in ['usle_c', 'usle_p']:

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -562,11 +562,12 @@ def _execute(args):
     if (not args['user_defined_local_recharge'] and
             not args['user_defined_climate_zones']):
         rain_events_lookup = (
-            utils.build_lookup_from_csv(
-                args['rain_events_table_path'], 'month'))
+            utils.read_csv_to_dataframe(
+                args['rain_events_table_path'], 'month'
+                ).to_dict(orient='index'))
 
-    biophysical_table = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode')
+    biophysical_table = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
 
     bad_value_list = []
     for lucode, value in biophysical_table.items():
@@ -592,8 +593,9 @@ def _execute(args):
         # parse out the alpha lookup table of the form (month_id: alpha_val)
         alpha_month_map = dict(
             (key, val['alpha']) for key, val in
-            utils.build_lookup_from_csv(
-                args['monthly_alpha_path'], 'month').items())
+            utils.read_csv_to_dataframe(
+                args['monthly_alpha_path'], 'month'
+            ).to_dict(orient='index').items())
     else:
         # make all 12 entries equal to args['alpha_m']
         alpha_m = float(fractions.Fraction(args['alpha_m']))
@@ -761,8 +763,9 @@ def _execute(args):
         for month_id in range(N_MONTHS):
             if args['user_defined_climate_zones']:
                 cz_rain_events_lookup = (
-                    utils.build_lookup_from_csv(
-                        args['climate_zone_table_path'], 'cz_id'))
+                    utils.read_csv_to_dataframe(
+                        args['climate_zone_table_path'], 'cz_id'
+                    ).to_dict(orient='index'))
                 month_label = MONTH_ID_TO_LABEL[month_id]
                 climate_zone_rain_events_month = dict([
                     (cz_id, cz_rain_events_lookup[cz_id][month_label]) for

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -482,8 +482,8 @@ def execute(args):
         task_name='align input rasters')
 
     # Build a lookup dictionary mapping each LULC code to its row
-    biophysical_dict = utils.build_lookup_from_csv(
-        args['biophysical_table'], 'lucode')
+    biophysical_dict = utils.read_csv_to_dataframe(
+        args['biophysical_table'], 'lucode').to_dict(orient='index')
     # sort the LULC codes upfront because we use the sorted list in multiple
     # places. it's more efficient to do this once.
     sorted_lucodes = sorted(biophysical_dict)

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -410,8 +410,8 @@ def execute(args):
     intermediate_dir = os.path.join(
         args['workspace_dir'], 'intermediate')
     utils.make_directories([args['workspace_dir'], intermediate_dir])
-    biophysical_lucode_map = utils.build_lookup_from_csv(
-        args['biophysical_table_path'], 'lucode', to_lower=True)
+    biophysical_lucode_map = utils.read_csv_to_dataframe(
+        args['biophysical_table_path'], 'lucode').to_dict(orient='index')
 
     # cast to float and calculate relative weights
     # Use default weights for shade, albedo, eti if the user didn't provide
@@ -1079,8 +1079,8 @@ def calculate_energy_savings(
                   for field in target_building_layer.schema]
     type_field_index = fieldnames.index('type')
 
-    energy_consumption_table = utils.build_lookup_from_csv(
-        energy_consumption_table_path, 'type', to_lower=True)
+    energy_consumption_table = utils.read_csv_to_dataframe(
+        energy_consumption_table_path, 'type').to_dict(orient='index')
 
     target_building_layer.StartTransaction()
     last_time = time.time()

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -306,8 +306,8 @@ def execute(args):
         task_name='align raster stack')
 
     # Load CN table
-    cn_table = utils.build_lookup_from_csv(
-        args['curve_number_table_path'], 'lucode')
+    cn_table = utils.read_csv_to_dataframe(
+        args['curve_number_table_path'], 'lucode').to_dict(orient='index')
 
     # make cn_table into a 2d array where first dim is lucode, second is
     # 0..3 to correspond to CN_A..CN_D
@@ -648,8 +648,8 @@ def _calculate_damage_to_infrastructure_in_aoi(
     infrastructure_vector = gdal.OpenEx(structures_vector_path, gdal.OF_VECTOR)
     infrastructure_layer = infrastructure_vector.GetLayer()
 
-    damage_type_map = utils.build_lookup_from_csv(
-        structures_damage_table, 'type', to_lower=True)
+    damage_type_map = utils.read_csv_to_dataframe(
+        structures_damage_table, 'type').to_dict(orient='index')
 
     infrastructure_layer_defn = infrastructure_layer.GetLayerDefn()
     type_index = -1

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -902,8 +902,7 @@ def execute(args):
                     aoi_reprojection_task, lulc_mask_task]
             )
 
-    attr_table = utils.read_csv_to_dataframe(
-        args['lulc_attribute_table'], cols_to_lower=True)
+    attr_table = utils.read_csv_to_dataframe(args['lulc_attribute_table'])
     kernel_paths = {}  # search_radius, kernel path
     kernel_tasks = {}  # search_radius, kernel task
 
@@ -1749,8 +1748,8 @@ def _reclassify_urban_nature_area(
     Returns:
         ``None``
     """
-    attribute_table_dict = utils.build_lookup_from_csv(
-        lulc_attribute_table, key_field='lucode')
+    attribute_table_dict = utils.read_csv_to_dataframe(
+        lulc_attribute_table, 'lucode').to_dict(orient='index')
 
     squared_pixel_area = abs(
         numpy.multiply(*_square_off_pixels(lulc_raster_path)))

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -903,7 +903,7 @@ def execute(args):
             )
 
     attr_table = utils.read_csv_to_dataframe(
-        args['lulc_attribute_table'], to_lower=True)
+        args['lulc_attribute_table'], cols_to_lower=True)
     kernel_paths = {}  # search_radius, kernel path
     kernel_tasks = {}  # search_radius, kernel task
 

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -598,8 +598,8 @@ def expand_path(path, base_path):
 
 
 def read_csv_to_dataframe(
-        path, index_col=None, usecols=None, cols_to_lower=True,
-        vals_to_lower=True, expand_path_cols=[], sep=None, engine='python',
+        path, index_col=False, usecols=None, cols_to_lower=True,
+        vals_to_lower=True, expand_path_cols=None, sep=None, engine='python',
         encoding='utf-8-sig', **kwargs):
     """Return a dataframe representation of the CSV.
 

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -646,7 +646,7 @@ def read_csv_to_dataframe(
             path, index_col=False, sep=sep, engine=engine, encoding=encoding, **kwargs)
     except UnicodeDecodeError as error:
         LOGGER.error(
-            f'{path} must be encoded as UTF-8 or ASCII')
+            f'The file {path} must be encoded as UTF-8 or ASCII')
         raise error
 
     # strip whitespace from column names

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -674,7 +674,8 @@ def read_csv_to_dataframe(
     # Set 'index_col' as the index of the dataframe
     if index_col:
         try:
-            dataframe = dataframe.set_index(index_col, drop=False)
+            dataframe = dataframe.set_index(
+                index_col, drop=False, verify_integrity=True)
         except KeyError:
             # If 'index_col' is not a column then KeyError is raised for using
             # it as the index column

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -713,7 +713,7 @@ def read_csv_to_dataframe(
         # the columns are stripped of leading/trailing whitespace in
         # ``read_csv_to_dataframe``, and also lowercased if ``to_lower`` so we only
         # need to convert the rest of the table.
-        if index_col:
+        if index_col and isinstance(index_col, str):
             index_col = index_col.lower()
         # lowercase column names
         if usecols:

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -598,8 +598,8 @@ def expand_path(path, base_path):
 
 
 def read_csv_to_dataframe(
-        path, index_col=False, usecols=None, cols_to_lower=True,
-        vals_to_lower=True, expand_path_cols=None, sep=None, engine='python',
+        path, index_col=False, usecols=None, convert_cols_to_lower=True,
+        convert_vals_to_lower=True, expand_path_cols=None, sep=None, engine='python',
         encoding='utf-8-sig', **kwargs):
     """Return a dataframe representation of the CSV.
 
@@ -614,14 +614,14 @@ def read_csv_to_dataframe(
     Args:
         path (str): path to a CSV file
         index_col (str): name of column to use as the dataframe index. If
-            ``cols_to_lower``, this column name and the dataframe column names
+            ``convert_cols_to_lower``, this column name and the dataframe column names
             will be lowercased before they are compared. If ``usecols``
             is defined, this must be included in ``usecols``.
         usecols (list(str)): list of column names to subset from the dataframe.
-            If ``cols_to_lower``, these names and the dataframe column names
+            If ``convert_cols_to_lower``, these names and the dataframe column names
             will be lowercased before they are compared.
-        cols_to_lower (bool): if True, convert all column names to lowercase
-        vals_to_lower (bool): if True, convert all table values to lowercase
+        convert_cols_to_lower (bool): if True, convert all column names to lowercase
+        convert_vals_to_lower (bool): if True, convert all table values to lowercase
         expand_path_cols (list[string])): if provided, a list of the names of
             columns that contain paths to expand. Any relative paths in these
             columns will be expanded to absolute paths. It is assumed that
@@ -655,7 +655,7 @@ def read_csv_to_dataframe(
     dataframe.columns = dataframe.columns.str.strip()
 
     # convert column names to lowercase
-    if cols_to_lower:
+    if convert_cols_to_lower:
         dataframe.columns = dataframe.columns.str.lower()
         # if 'to_lower`, case handling is done before trying to access the data.
         # the columns are stripped of leading/trailing whitespace in
@@ -684,7 +684,7 @@ def read_csv_to_dataframe(
             raise
 
     # convert table values to lowercase
-    if vals_to_lower:
+    if convert_vals_to_lower:
         dataframe = dataframe.applymap(
             lambda x: x.lower() if isinstance(x, str) else x)
 

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -743,8 +743,7 @@ def execute(args):
     # arrays. Also store the amount of energy the machine produces
     # in a certain wave period/height state as a 2D array
     machine_perf_dict = {}
-    machine_perf_data = utils.read_csv_to_dataframe(
-        args['machine_perf_path'], cols_to_lower=False, vals_to_lower=False)
+    machine_perf_data = utils.read_csv_to_dataframe(args['machine_perf_path'])
     # Get the wave period fields, starting from the second column of the table
     machine_perf_dict['periods'] = machine_perf_data.columns.values[1:]
     # Build up the height field by taking the first column of the table

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -743,7 +743,8 @@ def execute(args):
     # arrays. Also store the amount of energy the machine produces
     # in a certain wave period/height state as a 2D array
     machine_perf_dict = {}
-    machine_perf_data = utils.read_csv_to_dataframe(args['machine_perf_path'])
+    machine_perf_data = utils.read_csv_to_dataframe(
+        args['machine_perf_path'], cols_to_lower=False, vals_to_lower=False)
     # Get the wave period fields, starting from the second column of the table
     machine_perf_dict['periods'] = machine_perf_data.columns.values[1:]
     # Build up the height field by taking the first column of the table
@@ -777,7 +778,7 @@ def execute(args):
     if 'land_gridPts_path' in args:
         # Create a grid_land_data dataframe for later use in valuation
         grid_land_data = utils.read_csv_to_dataframe(
-            args['land_gridPts_path'], cols_to_lower=True)
+            args['land_gridPts_path'], vals_to_lower=False)
         required_col_names = ['id', 'type', 'lat', 'long', 'location']
         grid_land_data, missing_grid_land_fields = _get_validated_dataframe(
             args['land_gridPts_path'], required_col_names)
@@ -1425,7 +1426,7 @@ def _get_validated_dataframe(csv_path, field_list):
         missing_fields (list): missing fields as string format in dataframe.
 
     """
-    dataframe = utils.read_csv_to_dataframe(csv_path, cols_to_lower=True)
+    dataframe = utils.read_csv_to_dataframe(csv_path, vals_to_lower=False)
     missing_fields = []
     for field in field_list:
         if field not in dataframe.columns:
@@ -1670,7 +1671,7 @@ def _machine_csv_to_dict(machine_csv_path):
     machine_dict = {}
     # make columns and indexes lowercased and strip whitespace
     machine_data = utils.read_csv_to_dataframe(
-        machine_csv_path, cols_to_lower=True, index_col=0)
+        machine_csv_path, 'name', vals_to_lower=False)
     machine_data.index = machine_data.index.str.strip()
     machine_data.index = machine_data.index.str.lower()
 

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -777,7 +777,7 @@ def execute(args):
     if 'land_gridPts_path' in args:
         # Create a grid_land_data dataframe for later use in valuation
         grid_land_data = utils.read_csv_to_dataframe(
-            args['land_gridPts_path'], vals_to_lower=False)
+            args['land_gridPts_path'], convert_vals_to_lower=False)
         required_col_names = ['id', 'type', 'lat', 'long', 'location']
         grid_land_data, missing_grid_land_fields = _get_validated_dataframe(
             args['land_gridPts_path'], required_col_names)
@@ -1425,7 +1425,7 @@ def _get_validated_dataframe(csv_path, field_list):
         missing_fields (list): missing fields as string format in dataframe.
 
     """
-    dataframe = utils.read_csv_to_dataframe(csv_path, vals_to_lower=False)
+    dataframe = utils.read_csv_to_dataframe(csv_path, convert_vals_to_lower=False)
     missing_fields = []
     for field in field_list:
         if field not in dataframe.columns:
@@ -1670,7 +1670,7 @@ def _machine_csv_to_dict(machine_csv_path):
     machine_dict = {}
     # make columns and indexes lowercased and strip whitespace
     machine_data = utils.read_csv_to_dataframe(
-        machine_csv_path, 'name', vals_to_lower=False)
+        machine_csv_path, 'name', convert_vals_to_lower=False)
     machine_data.index = machine_data.index.str.strip()
     machine_data.index = machine_data.index.str.lower()
 

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -777,7 +777,7 @@ def execute(args):
     if 'land_gridPts_path' in args:
         # Create a grid_land_data dataframe for later use in valuation
         grid_land_data = utils.read_csv_to_dataframe(
-            args['land_gridPts_path'], to_lower=True)
+            args['land_gridPts_path'], cols_to_lower=True)
         required_col_names = ['id', 'type', 'lat', 'long', 'location']
         grid_land_data, missing_grid_land_fields = _get_validated_dataframe(
             args['land_gridPts_path'], required_col_names)
@@ -1425,7 +1425,7 @@ def _get_validated_dataframe(csv_path, field_list):
         missing_fields (list): missing fields as string format in dataframe.
 
     """
-    dataframe = utils.read_csv_to_dataframe(csv_path, to_lower=True)
+    dataframe = utils.read_csv_to_dataframe(csv_path, cols_to_lower=True)
     missing_fields = []
     for field in field_list:
         if field not in dataframe.columns:
@@ -1670,7 +1670,7 @@ def _machine_csv_to_dict(machine_csv_path):
     machine_dict = {}
     # make columns and indexes lowercased and strip whitespace
     machine_data = utils.read_csv_to_dataframe(
-        machine_csv_path, to_lower=True, index_col=0)
+        machine_csv_path, cols_to_lower=True, index_col=0)
     machine_data.index = machine_data.index.str.strip()
     machine_data.index = machine_data.index.str.lower()
 

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -754,8 +754,7 @@ def execute(args):
         # If Price Table provided use that for price of energy, validate inputs
         time = int(val_parameters_dict['time_period'])
         if args['price_table']:
-            wind_price_df = utils.read_csv_to_dataframe(
-                args['wind_schedule'], cols_to_lower=True)
+            wind_price_df = utils.read_csv_to_dataframe(args['wind_schedule'])
 
             year_count = len(wind_price_df['year'])
             if year_count != time + 1:
@@ -1135,7 +1134,7 @@ def execute(args):
 
         # Read the grid points csv, and convert it to land and grid dictionary
         grid_land_df = utils.read_csv_to_dataframe(
-            args['grid_points_path'], cols_to_lower=True)
+            args['grid_points_path'], vals_to_lower=False)
 
         # Make separate dataframes based on 'TYPE'
         grid_df = grid_land_df.loc[(
@@ -1974,7 +1973,8 @@ def _read_csv_wind_data(wind_data_path, hub_height):
             to dictionaries that hold wind data at that location.
 
     """
-    wind_point_df = utils.read_csv_to_dataframe(wind_data_path)
+    wind_point_df = utils.read_csv_to_dataframe(
+        wind_data_path, cols_to_lower=False, vals_to_lower=False)
 
     # Calculate scale value at new hub height given reference values.
     # See equation 3 in users guide

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -755,7 +755,7 @@ def execute(args):
         time = int(val_parameters_dict['time_period'])
         if args['price_table']:
             wind_price_df = utils.read_csv_to_dataframe(
-                args['wind_schedule'], to_lower=True)
+                args['wind_schedule'], cols_to_lower=True)
 
             year_count = len(wind_price_df['year'])
             if year_count != time + 1:
@@ -1135,7 +1135,7 @@ def execute(args):
 
         # Read the grid points csv, and convert it to land and grid dictionary
         grid_land_df = utils.read_csv_to_dataframe(
-            args['grid_points_path'], to_lower=True)
+            args['grid_points_path'], cols_to_lower=True)
 
         # Make separate dataframes based on 'TYPE'
         grid_df = grid_land_df.loc[(

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1134,7 +1134,7 @@ def execute(args):
 
         # Read the grid points csv, and convert it to land and grid dictionary
         grid_land_df = utils.read_csv_to_dataframe(
-            args['grid_points_path'], vals_to_lower=False)
+            args['grid_points_path'], convert_vals_to_lower=False)
 
         # Make separate dataframes based on 'TYPE'
         grid_df = grid_land_df.loc[(
@@ -1974,7 +1974,7 @@ def _read_csv_wind_data(wind_data_path, hub_height):
 
     """
     wind_point_df = utils.read_csv_to_dataframe(
-        wind_data_path, cols_to_lower=False, vals_to_lower=False)
+        wind_data_path, convert_cols_to_lower=False, convert_vals_to_lower=False)
 
     # Calculate scale value at new hub height given reference values.
     # See equation 3 in users guide

--- a/tests/test_coastal_blue_carbon.py
+++ b/tests/test_coastal_blue_carbon.py
@@ -151,10 +151,10 @@ class TestPreprocessor(unittest.TestCase):
                        pprint.pformat(non_suffixed_files)))
 
         expected_landcover_codes = set(range(0, 24))
-        found_landcover_codes = set(utils.read_csv_to_dataframe(
+        found_landcover_codes = set(utils.build_lookup_from_csv(
             os.path.join(outputs_dir,
                          'carbon_biophysical_table_template_150225.csv'),
-            'code').to_dict(orient='index').keys())
+            'code').keys())
         self.assertEqual(expected_landcover_codes, found_landcover_codes)
 
     def test_transition_table(self):
@@ -188,8 +188,8 @@ class TestPreprocessor(unittest.TestCase):
             lulc_csv.write('0,mangrove,True\n')
             lulc_csv.write('1,parking lot,False\n')
 
-        landcover_table = utils.read_csv_to_dataframe(
-            landcover_table_path, 'code').to_dict(orient='index')
+        landcover_table = utils.build_lookup_from_csv(
+            landcover_table_path, 'code')
         target_table_path = os.path.join(self.workspace_dir,
                                          'transition_table.csv')
 
@@ -203,8 +203,8 @@ class TestPreprocessor(unittest.TestCase):
                       str(context.exception))
 
         # Re-load the landcover table
-        landcover_table = utils.read_csv_to_dataframe(
-            landcover_table_path, 'code').to_dict(orient='index')
+        landcover_table = utils.build_lookup_from_csv(
+            landcover_table_path, 'code')
         preprocessor._create_transition_table(
             landcover_table, [filename_a, filename_b], target_table_path)
 
@@ -358,6 +358,7 @@ class TestCBC2(unittest.TestCase):
             transition_csv.write('b,,NCC,accum\n')
             transition_csv.write('c,accum,,NCC\n')
             transition_csv.write(',,,\n')
+            transition_csv.write(',legend,,')  # simulate legend
 
         disturbance_matrices, accumulation_matrices = (
              coastal_blue_carbon._read_transition_matrix(

--- a/tests/test_coastal_blue_carbon.py
+++ b/tests/test_coastal_blue_carbon.py
@@ -151,10 +151,10 @@ class TestPreprocessor(unittest.TestCase):
                        pprint.pformat(non_suffixed_files)))
 
         expected_landcover_codes = set(range(0, 24))
-        found_landcover_codes = set(utils.build_lookup_from_csv(
+        found_landcover_codes = set(utils.read_csv_to_dataframe(
             os.path.join(outputs_dir,
                          'carbon_biophysical_table_template_150225.csv'),
-            'code').keys())
+            'code').to_dict(orient='index').keys())
         self.assertEqual(expected_landcover_codes, found_landcover_codes)
 
     def test_transition_table(self):
@@ -188,8 +188,8 @@ class TestPreprocessor(unittest.TestCase):
             lulc_csv.write('0,mangrove,True\n')
             lulc_csv.write('1,parking lot,False\n')
 
-        landcover_table = utils.build_lookup_from_csv(
-            landcover_table_path, 'code')
+        landcover_table = utils.read_csv_to_dataframe(
+            landcover_table_path, 'code').to_dict(orient='index')
         target_table_path = os.path.join(self.workspace_dir,
                                          'transition_table.csv')
 
@@ -203,8 +203,8 @@ class TestPreprocessor(unittest.TestCase):
                       str(context.exception))
 
         # Re-load the landcover table
-        landcover_table = utils.build_lookup_from_csv(
-            landcover_table_path, 'code')
+        landcover_table = utils.read_csv_to_dataframe(
+            landcover_table_path, 'code').to_dict(orient='index')
         preprocessor._create_transition_table(
             landcover_table, [filename_a, filename_b], target_table_path)
 
@@ -358,7 +358,6 @@ class TestCBC2(unittest.TestCase):
             transition_csv.write('b,,NCC,accum\n')
             transition_csv.write('c,accum,,NCC\n')
             transition_csv.write(',,,\n')
-            transition_csv.write(',legend,,')  # simulate legend
 
         disturbance_matrices, accumulation_matrices = (
              coastal_blue_carbon._read_transition_matrix(

--- a/tests/test_coastal_blue_carbon.py
+++ b/tests/test_coastal_blue_carbon.py
@@ -151,10 +151,10 @@ class TestPreprocessor(unittest.TestCase):
                        pprint.pformat(non_suffixed_files)))
 
         expected_landcover_codes = set(range(0, 24))
-        found_landcover_codes = set(utils.build_lookup_from_csv(
+        found_landcover_codes = set(utils.read_csv_to_dataframe(
             os.path.join(outputs_dir,
                          'carbon_biophysical_table_template_150225.csv'),
-            'code').keys())
+            'code').to_dict(orient='index').keys())
         self.assertEqual(expected_landcover_codes, found_landcover_codes)
 
     def test_transition_table(self):
@@ -188,8 +188,8 @@ class TestPreprocessor(unittest.TestCase):
             lulc_csv.write('0,mangrove,True\n')
             lulc_csv.write('1,parking lot,False\n')
 
-        landcover_table = utils.build_lookup_from_csv(
-            landcover_table_path, 'code')
+        landcover_table = utils.read_csv_to_dataframe(
+            landcover_table_path, 'code').to_dict(orient='index')
         target_table_path = os.path.join(self.workspace_dir,
                                          'transition_table.csv')
 
@@ -203,8 +203,8 @@ class TestPreprocessor(unittest.TestCase):
                       str(context.exception))
 
         # Re-load the landcover table
-        landcover_table = utils.build_lookup_from_csv(
-            landcover_table_path, 'code')
+        landcover_table = utils.read_csv_to_dataframe(
+            landcover_table_path, 'code').to_dict(orient='index')
         preprocessor._create_transition_table(
             landcover_table, [filename_a, filename_b], target_table_path)
 

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -379,7 +379,7 @@ class DatastackArchiveTests(unittest.TestCase):
 
         spatial_csv_dict = utils.read_csv_to_dataframe(
             archive_params['spatial_table'], 'ID',
-            cols_to_lower=True, vals_to_lower=True).to_dict(orient='index')
+            convert_cols_to_lower=True, convert_vals_to_lower=True).to_dict(orient='index')
         spatial_csv_dir = os.path.dirname(archive_params['spatial_table'])
         numpy.testing.assert_allclose(
             pygeoprocessing.raster_to_numpy_array(

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -377,8 +377,9 @@ class DatastackArchiveTests(unittest.TestCase):
             self.assertTrue(
                 filecmp.cmp(archive_params[key], params[key], shallow=False))
 
-        spatial_csv_dict = utils.build_lookup_from_csv(
-            archive_params['spatial_table'], 'ID', to_lower=True)
+        spatial_csv_dict = utils.read_csv_to_dataframe(
+            archive_params['spatial_table'], 'ID',
+            cols_to_lower=True, vals_to_lower=True).to_dict(orient='index')
         spatial_csv_dir = os.path.dirname(archive_params['spatial_table'])
         numpy.testing.assert_allclose(
             pygeoprocessing.raster_to_numpy_array(

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -973,7 +973,7 @@ class RecreationRegressionTests(unittest.TestCase):
         # make outputs to be overwritten
         predictor_dict = utils.read_csv_to_dataframe(
             predictor_table_path, 'id',
-            cols_to_lower=True, vals_to_lower=True).to_dict(orient='index')
+            convert_cols_to_lower=True, convert_vals_to_lower=True).to_dict(orient='index')
         predictor_list = predictor_dict.keys()
         tmp_working_dir = tempfile.mkdtemp(dir=self.workspace_dir)
         empty_json_list = [

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -971,8 +971,9 @@ class RecreationRegressionTests(unittest.TestCase):
         predictor_table_path = os.path.join(SAMPLE_DATA, 'predictors.csv')
 
         # make outputs to be overwritten
-        predictor_dict = utils.build_lookup_from_csv(
-            predictor_table_path, 'id')
+        predictor_dict = utils.read_csv_to_dataframe(
+            predictor_table_path, 'id',
+            cols_to_lower=True, vals_to_lower=True).to_dict(orient='index')
         predictor_list = predictor_dict.keys()
         tmp_working_dir = tempfile.mkdtemp(dir=self.workspace_dir)
         empty_json_list = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -738,7 +738,7 @@ class BuildLookupFromCSVTests(unittest.TestCase):
             table_file.write(csv_text)
 
         result = utils.build_lookup_from_csv(
-            table_path, 'lucode', to_lower=True, column_list=['val1', 'val2'])
+            table_path, 'lucode', to_lower=True, usecols=['lucode', 'val1', 'val2'])
 
         expected_result = {
             1: {'val1': 0.5, 'val2': 2, 'lucode': 1},
@@ -1030,7 +1030,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 b
                 """
             ).strip())
-        df = utils.read_csv_to_dataframe(csv_file, to_lower=True)
+        df = utils.read_csv_to_dataframe(csv_file, cols_to_lower=True)
         # header should be lowercase
         self.assertEqual(df.columns[0], 'header')
         # case of table values shouldn't change

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -831,7 +831,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1',
-            cols_to_lower=False, vals_to_lower=False).to_dict(orient='index')
+            convert_cols_to_lower=False, convert_vals_to_lower=False).to_dict(orient='index')
 
         self.assertEqual(lookup_dict[4]['HEADER2'], 'FOO')
         self.assertEqual(lookup_dict[4]['header3'], 'bar')
@@ -853,7 +853,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1',
-            cols_to_lower=False, vals_to_lower=False).to_dict(orient='index')
+            convert_cols_to_lower=False, convert_vals_to_lower=False).to_dict(orient='index')
 
         self.assertEqual(lookup_dict[4]['HEADER2'], 'FOO')
         self.assertEqual(lookup_dict[4]['header3'], 'bar')
@@ -957,7 +957,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
             f'{self.workspace_dir}{os.sep}foo.txt',
             utils.expand_path(f'{self.workspace_dir}{os.sep}foo.txt', base_path))
 
-    def test_cols_to_lower(self):
+    def test_convert_cols_to_lower(self):
         """utils: test that to_lower=True makes headers lowercase"""
         from natcap.invest import utils
 
@@ -972,14 +972,14 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 """
             ))
         df = utils.read_csv_to_dataframe(
-            csv_file, cols_to_lower=True, vals_to_lower=False)
+            csv_file, convert_cols_to_lower=True, convert_vals_to_lower=False)
         # header should be lowercase
         self.assertEqual(df.columns[0], 'header')
         # case of table values shouldn't change
         self.assertEqual(df['header'][0], 'A')
         self.assertEqual(df['header'][1], 'b')
 
-    def test_vals_to_lower(self):
+    def test_convert_vals_to_lower(self):
         """utils: test that to_lower=True makes headers lowercase"""
         from natcap.invest import utils
 
@@ -994,7 +994,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 """
             ))
         df = utils.read_csv_to_dataframe(
-            csv_file, cols_to_lower=False, vals_to_lower=True)
+            csv_file, convert_cols_to_lower=False, convert_vals_to_lower=True)
         # header should still be uppercase
         self.assertEqual(df.columns[0], 'HEADER')
         # case of table values should change
@@ -1100,7 +1100,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
             file_obj.write(" Col1, Col2 ,Col3 \n")
             file_obj.write(" val1, val2 ,val3 \n")
             file_obj.write(" , 2 1 ,  ")
-        df = utils.read_csv_to_dataframe(csv_file, cols_to_lower=False)
+        df = utils.read_csv_to_dataframe(csv_file, convert_cols_to_lower=False)
         # header should have no leading / trailing whitespace
         self.assertEqual(df.columns[0], 'Col1')
         self.assertEqual(df.columns[1], 'Col2')
@@ -1129,7 +1129,7 @@ class ReadCSVToDataframeTests(unittest.TestCase):
                 """
             ))
         df = utils.read_csv_to_dataframe(
-            csv_file, expand_path_cols=['path'], vals_to_lower=False)
+            csv_file, expand_path_cols=['path'], convert_vals_to_lower=False)
         self.assertEqual(
             f'{self.workspace_dir}{os.sep}foo.txt',
             df['path'][0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -618,12 +618,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 HEADER,
                 A,
                 b
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(csv_file)
         # header and table values should be lowercased
         self.assertEqual(df.columns[0], 'header')
@@ -802,12 +802,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1,HEADER2,header3
                 1,2,bar
                 4,5,FOO
                 """
-            ).strip())
+            ))
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1').to_dict(orient='index')
@@ -822,12 +822,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1,HEADER2,header3,missing_column,
                 1,2,3,
                 4,FOO,bar,
                 """
-            ).strip())
+            ))
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1',
@@ -844,12 +844,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1;HEADER2;header3;
                 1;2;3;
                 4;FOO;bar;
                 """
-            ).strip())
+            ))
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1',
@@ -866,12 +866,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with open(csv_file, 'w', encoding='utf-8') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1,HEADER2,header3
                 1,2,bar
                 4,5,FOO
                 """
-            ).strip())
+            ))
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header1').to_dict(orient='index')
         self.assertEqual(lookup_dict[4]['header2'], 5)
@@ -886,12 +886,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         # writing with utf-8-sig will prepend the BOM
         with open(csv_file, 'w', encoding='utf-8-sig') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1,HEADER2,header3
                 1,2,bar
                 4,5,FOO
                 """
-            ).strip())
+            ))
         # confirm that the file has the BOM prefix
         with open(csv_file, 'rb') as file_obj:
             self.assertTrue(file_obj.read().startswith(codecs.BOM_UTF8))
@@ -910,12 +910,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with codecs.open(csv_file, 'w', encoding='iso-8859-1') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header 1,HEADER 2,header 3
                 1,2,bar1
                 4,5,FOO
                 """
-            ).strip())
+            ))
 
         lookup_dict = utils.read_csv_to_dataframe(
             csv_file, 'header 1').to_dict(orient='index')
@@ -931,12 +931,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with codecs.open(csv_file, 'w', encoding='iso-8859-1') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header 1,HEADER 2,header 3
                 1,2,bar1
                 4,5,FÖÖ
                 """
-            ).strip())
+            ))
         with self.assertRaises(UnicodeDecodeError):
             utils.read_csv_to_dataframe(csv_file, 'header 1')
 
@@ -965,12 +965,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 HEADER,
                 A,
                 b
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(
             csv_file, cols_to_lower=True, vals_to_lower=False)
         # header should be lowercase
@@ -987,12 +987,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 HEADER,
                 A,
                 b
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(
             csv_file, cols_to_lower=False, vals_to_lower=True)
         # header should still be uppercase
@@ -1009,12 +1009,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         # writing with utf-8-sig will prepend the BOM
         with open(csv_file, 'w', encoding='utf-8-sig') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header1,header2,header3
                 1,2,bar
                 4,5,FOO
                 """
-            ).strip())
+            ))
         # confirm that the file has the BOM prefix
         with open(csv_file, 'rb') as file_obj:
             self.assertTrue(file_obj.read().startswith(codecs.BOM_UTF8))
@@ -1033,12 +1033,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         # encode with ISO Cyrillic, include a non-ASCII character
         with open(csv_file, 'w', encoding='iso8859_5') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 header,
                 fЮЮ,
                 bar
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(csv_file, encoding='iso8859_5')
         # with the encoding specified, special characters should work
         # and be lowercased
@@ -1053,12 +1053,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 h1;h2;h3
                 a;b;c
                 d;e;f
                 """
-            ).strip())
+            ))
         # using sep=None with the default engine='python',
         # it should infer what the separator is
         df = utils.read_csv_to_dataframe(csv_file, sep=None)
@@ -1079,12 +1079,12 @@ class ReadCSVToDataframeTests(unittest.TestCase):
 
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                """
+                """\
                 1,2,3
                 a,b,c
                 d,e,f
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(csv_file)
         # expect headers to be strings
         self.assertEqual(df.columns[0], '1')
@@ -1120,14 +1120,14 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         csv_file = os.path.join(self.workspace_dir, 'csv.csv')
         with open(csv_file, 'w') as file_obj:
             file_obj.write(textwrap.dedent(
-                f"""
+                f"""\
                 bar,path
                 1,foo.txt
                 2,foo/bar.txt
                 3,foo\\bar.txt
                 4,{self.workspace_dir}/foo.txt
                 """
-            ).strip())
+            ))
         df = utils.read_csv_to_dataframe(
             csv_file, expand_path_cols=['path'], vals_to_lower=False)
         self.assertEqual(


### PR DESCRIPTION
## Description
Fixes #1327 
Consolidated functionality into `read_csv_to_dataframe` and replaced uses of `build_lookup_from_csv(...)` with `read_csv_to_dataframe(...).to_dict(orient='index')`.

Split the `to_lower` functionality into two separate args, `cols_to_lower` and `vals_to_lower`. Some of this might be obsoleted by #1328, but I wanted to take it one step at a time.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
