### PR TITLE
REC bugfix - overlapping predictor polygons inflate area coverage metrics

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -96,6 +96,10 @@ Unreleased Changes
       set to 0. The old behavior was not well documented and caused some
       confusion when nodata pixels did not line up. It's safer not to fill in
       unknown data. (`#1317 <https://github.com/natcap/invest/issues/1317>`_)
+* Visitation: Recreation and Tourism
+    * Fixed a bug where overlapping predictor polygons would be double-counted
+      in ``polygon_area_coverage`` and ``polygon_percent_coverage`` calculations.
+      (`#1310 <https://github.com/natcap/invest/issues/1310>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -1101,6 +1101,7 @@ def _polygon_area(
             polygons[polygon_index]
             for polygon_index in potential_intersecting_poly_ids
             if prepped_polygons[polygon_index].intersects(geometry)]
+        # TODO: union first, then intersect & sum
         polygon_area_coverage = sum([
             (geometry.intersection(polygon)).area
             for polygon in intersecting_polygons])

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -1101,10 +1101,8 @@ def _polygon_area(
             polygons[polygon_index]
             for polygon_index in potential_intersecting_poly_ids
             if prepped_polygons[polygon_index].intersects(geometry)]
-        # TODO: union first, then intersect & sum
-        polygon_area_coverage = sum([
-            (geometry.intersection(polygon)).area
-            for polygon in intersecting_polygons])
+        union = shapely.ops.unary_union(intersecting_polygons)
+        polygon_area_coverage = geometry.intersection(union).area
 
         if mode == 'polygon_area_coverage':
             polygon_coverage_lookup[feature_id] = polygon_area_coverage

--- a/tests/test_recreation.py
+++ b/tests/test_recreation.py
@@ -459,7 +459,7 @@ class TestRecServer(unittest.TestCase):
             self.assertTrue(len(ws) == 0)
 
     @_timeout(30.0)
-    def test_regression_local_server(self):
+    def test_execute_local_server(self):
         """Recreation base regression test on sample data on local server.
 
         Executes Recreation model all the way through scenario prediction.
@@ -821,7 +821,7 @@ class RecreationRegressionTests(unittest.TestCase):
             numpy.testing.assert_allclose(results[key], expected_results[key])
 
     @unittest.skip("skipping to avoid remote server call (issue #3753)")
-    def test_base_regression(self):
+    def test_base_execute(self):
         """Recreation base regression test on fast sample data.
 
         Executes Recreation model with default data and default arguments.
@@ -851,7 +851,7 @@ class RecreationRegressionTests(unittest.TestCase):
             os.path.join(args['workspace_dir'], 'scenario_results.shp'),
             os.path.join(REGRESSION_DATA, 'scenario_results_40000.csv'))
 
-    def test_square_grid_regression(self):
+    def test_square_grid(self):
         """Recreation square grid regression test."""
         from natcap.invest.recreation import recmodel_client
 
@@ -868,7 +868,7 @@ class RecreationRegressionTests(unittest.TestCase):
         utils._assert_vectors_equal(
             out_grid_vector_path, expected_grid_vector_path)
 
-    def test_hex_grid_regression(self):
+    def test_hex_grid(self):
         """Recreation hex grid regression test."""
         from natcap.invest.recreation import recmodel_client
 
@@ -886,8 +886,8 @@ class RecreationRegressionTests(unittest.TestCase):
             out_grid_vector_path, expected_grid_vector_path)
 
     @unittest.skip("skipping to avoid remote server call (issue #3753)")
-    def test_no_grid_regression(self):
-        """Recreation base regression on ungridded AOI."""
+    def test_no_grid_execute(self):
+        """Recreation execute on ungridded AOI."""
         from natcap.invest.recreation import recmodel_client
 
         args = {


### PR DESCRIPTION
`unary_union` polygons instead of calculating the cumulative area of the individual polygons.

Fixes #1310

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
