### PR TITLE
UFRM bugfix - all 0s in biophysical table are okay

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -96,6 +96,10 @@ Unreleased Changes
       set to 0. The old behavior was not well documented and caused some
       confusion when nodata pixels did not line up. It's safer not to fill in
       unknown data. (`#1317 <https://github.com/natcap/invest/issues/1317>`_)
+* Urban Flood Risk
+    * Fixed a bug where the model incorrectly raised an error if the
+      biophysical table contained a row of all 0s.
+      (`#1123 <https://github.com/natcap/invest/issues/1123>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -871,14 +871,14 @@ def _lu_to_cn_op(
     # this is an array where each column represents a valid landcover
     # pixel and the rows are the curve number index for the landcover
     # type under that pixel (0..3 are CN_A..CN_D and 4 is "unknown")
-    valid_lucodes = lucode_array[valid_mask].astype(int)
+    valid_lucode_array = lucode_array[valid_mask].astype(int)
 
     try:
-        cn_matrix = lucode_to_cn_table[valid_lucodes]
+        cn_matrix = lucode_to_cn_table[valid_lucode_array]
     except IndexError:
         # Find the code that raised the IndexError, and possibly
         # any others that also would have.
-        lucodes = numpy.unique(valid_lucodes)
+        lucodes = numpy.unique(valid_lucode_array)
         missing_codes = lucodes[lucodes >= lucode_to_cn_table.shape[0]]
         raise ValueError(
             f'The biophysical table is missing a row for lucode(s) '
@@ -886,10 +886,11 @@ def _lu_to_cn_op(
 
     # Even without an IndexError, still must guard against
     # lucodes that can index into the sparse matrix but were
-    # missing from the biophysical table. They have rows of all 0.
-    if not cn_matrix.sum(1).all():
-        empty_rows = numpy.where(lucode_to_cn_table.sum(1) == 0)
-        missing_codes = numpy.intersect1d(valid_lucodes, empty_rows)
+    # missing from the biophysical table. Do this by intersecting
+    # rows with no stored values with the lulc array
+    empty_rows = cn_matrix.getnnz(1) == 0
+    if empty_rows.any():
+        missing_codes = numpy.intersect1d(valid_lucode_array, empty_rows)
         raise ValueError(
             f'The biophysical table is missing a row for lucode(s) '
             f'{missing_codes.tolist()}')

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -216,7 +216,8 @@ class UFRMTests(unittest.TestCase):
         try:
             urban_flood_risk_mitigation.execute(args)
         except ValueError:
-            self.fail('unexpected ValueError')
+            self.fail('unexpected ValueError when testing curve number row with all zeros')
+
 
     def test_ufrm_string_damage_to_infrastructure(self):
         """UFRM: handle str(int) structure indices.

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -198,6 +198,26 @@ class UFRMTests(unittest.TestCase):
             f'{[16, 17, 18, 21]}')
         self.assertEqual(expected_message, actual_message)
 
+    def test_ufrm_explicit_zeros_in_table(self):
+        """UFRM: assert no exception on row of all zeros."""
+        import pandas
+        from natcap.invest import urban_flood_risk_mitigation
+        args = self._make_args()
+
+        good_cn_table_path = os.path.join(
+            self.workspace_dir, 'good_cn_table.csv')
+        cn_table = pandas.read_csv(args['curve_number_table_path'])
+
+        # a user may define a row with all 0s
+        cn_table.iloc[0] = [0] * cn_table.shape[1]
+        cn_table.to_csv(good_cn_table_path, index=False)
+        args['curve_number_table_path'] = good_cn_table_path
+
+        try:
+            urban_flood_risk_mitigation.execute(args)
+        except ValueError:
+            self.fail('unexpected ValueError')
+
     def test_ufrm_string_damage_to_infrastructure(self):
         """UFRM: handle str(int) structure indices.
 


### PR DESCRIPTION
Added a test and fixed the logic by which we check for non-existent values in a sparse matrix, which are different from explicit 0s .

Fixes #1123 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
