### PR TITLE
SQ: check the geometry name rather than the `wkb*` geometry type

### DIFF
--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -549,10 +549,10 @@ def _determine_valid_viewpoints(dem_path, structures_path):
 
             # Coordinates in map units to pass to viewshed algorithm
             geometry = point.GetGeometryRef()
-            if geometry.GetGeometryType() != ogr.wkbPoint:
+            if geometry.GetGeometryName() != 'POINT':
                 raise AssertionError(
-                    f"Feature {point.GetFID()} is not a Point geometry. "
-                    "Features must be a Point.")
+                    f"Feature {point.GetFID()} must be a POINT geometry, "
+                    f"not {geometry.GetGeometryName()}")
 
             viewpoint = (geometry.GetX(), geometry.GetY())
 

--- a/tests/test_scenic_quality.py
+++ b/tests/test_scenic_quality.py
@@ -126,7 +126,8 @@ class ScenicQualityTests(unittest.TestCase):
         with self.assertRaises(AssertionError) as cm:
             scenic_quality._determine_valid_viewpoints(
                 dem_path, viewpoints_path)
-        self.assertIn('Feature 1 is not a Point geometry', str(cm.exception))
+        self.assertIn('Feature 1 must be a POINT geometry, not LINESTRING',
+                      str(cm.exception))
 
     def test_exception_when_no_structures_aoi_overlap(self):
         """SQ: model raises exception when AOI does not overlap structures."""


### PR DESCRIPTION
This is a trivial change, but it allows for the actual geometry type checking to be more readable and to also provide more information to the user in case the check fails.

I didn't update HISTORY because the type checking hasn't been released yet.

Fixes #1351

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the affected models' UIs (if relevant)~~
