### PR TITLE
I. #1054 update error message and test.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -116,6 +116,10 @@ Unreleased Changes
     * Fixed a bug where overlapping predictor polygons would be double-counted
       in ``polygon_area_coverage`` and ``polygon_percent_coverage`` calculations.
       (`#1310 <https://github.com/natcap/invest/issues/1310>`_)
+* Wind Energy
+    * Updated a misleading error message that is raised when the AOI does
+      not spatially overlap another input.
+      (`#1054 <https://github.com/natcap/invest/issues/1054>`_)
 
 3.13.0 (2023-03-17)
 -------------------

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -2634,7 +2634,7 @@ def _clip_vector_by_vector(
         # The "clip_vector_path" is always the AOI.
         raise ValueError(
             f"Clipping {base_vector_path} by {clip_vector_path} returned 0"
-            " features. This means the AOI and {base_vector_path} do not"
+            f" features. This means the AOI and {base_vector_path} do not"
             " intersect spatially. Please check that the AOI has spatial"
             " overlap with all input data.")
 

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -2631,10 +2631,12 @@ def _clip_vector_by_vector(
         shutil.rmtree(temp_dir, ignore_errors=True)
 
     if empty_clip:
+        # The "clip_vector_path" is always the AOI.
         raise ValueError(
             f"Clipping {base_vector_path} by {clip_vector_path} returned 0"
-            " features. If an AOI was provided this could mean the AOI and"
-            " Wind Data do not intersect spatially.")
+            " features. This means the AOI and {base_vector_path} do not"
+            " intersect spatially. Please check that the AOI has spatial"
+            " overlap with all input data.")
 
     LOGGER.info('Finished _clip_vector_by_vector')
 

--- a/tests/test_wind_energy.py
+++ b/tests/test_wind_energy.py
@@ -846,7 +846,7 @@ class WindEnergyRegressionTests(unittest.TestCase):
             wind_energy.execute(args)
 
         self.assertTrue(
-            "returned 0 features. If an AOI was" in str(cm.exception))
+            "returned 0 features. This means the AOI " in str(cm.exception))
 
 
 class WindEnergyValidationTests(unittest.TestCase):


### PR DESCRIPTION
## Description
Update the error message for Wind Energy when the AOI does not spatially overlap with another input. The "other" input can be a few different inputs and is not easily isolated given how this model is written.

Fixes #1054

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] ~~Updated the user's guide (if needed)~~
- [ ] ~~Tested the affected models' UIs (if relevant)~~
