### PR TITLE
Close UG windows when main app window is closed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -55,7 +55,10 @@ Unreleased Changes
     * The workbench app is now distributed with a valid code signature
       (`#727 <https://github.com/natcap/invest/issues/727>`_)
     * Changing the language setting will now cause the app to relaunch
-      (`#1168 <https://github.com/natcap/invest/issues/1168>`_),
+      (`#1168 <https://github.com/natcap/invest/issues/1168>`_)
+    * Closing the main window will now close any user's guide windows that are
+      open. Fixed a bug where the app could not be reopened after closing.
+      (`#1258 <https://github.com/natcap/invest/issues/1258>`_)
 * Forest Carbon
     * The biophysical table is now case-insensitive.
 * HRA

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -62,6 +62,7 @@ if (!process.env.PORT) {
 let mainWindow;
 let splashScreen;
 let flaskSubprocess;
+let forceQuit = false;
 
 export function destroyWindow() {
   mainWindow = null;
@@ -133,6 +134,15 @@ export const createWindow = async () => {
     logger.error(details);
   });
 
+  mainWindow.on('close', (event) => {
+    // 'close' is triggered by the red traffic light button on mac
+    // override this behavior and just minimize,
+    // unless we're actually quitting the app
+    if (process.platform === 'darwin' & !forceQuit) {
+      event.preventDefault();
+    }
+  });
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
@@ -184,17 +194,20 @@ export function main() {
       createWindow();
     }
   });
-  app.on('window-all-closed', async () => {
+  app.on('window-all-closed', async (event) => {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
+    event.preventDefault();
     if (process.platform !== 'darwin') {
       app.quit();
     }
   });
+
   let shuttingDown = false;
   app.on('before-quit', async (event) => {
     // prevent quitting until after we're done with cleanup,
     // then programatically quit
+    forceQuit = true;
     if (shuttingDown) { return; }
     event.preventDefault();
     shuttingDown = true;

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -140,6 +140,7 @@ export const createWindow = async () => {
     // unless we're actually quitting the app
     if (process.platform === 'darwin' & !forceQuit) {
       event.preventDefault();
+      mainWindow.minimize()
     }
   });
 

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -195,18 +195,12 @@ export function main() {
       createWindow();
     }
   });
-  app.on('window-all-closed', (event) => {
-    // On OS X it is common for applications and their menu bar
-    // to stay active until the user quits explicitly with Cmd + Q
-    if (process.platform === 'darwin') {
-      event.preventDefault();
-    }
-  });
 
   let shuttingDown = false;
   app.on('before-quit', async (event) => {
     // prevent quitting until after we're done with cleanup,
     // then programatically quit
+    console.log('before-quit');
     forceQuit = true;
     if (shuttingDown) { return; }
     event.preventDefault();

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -195,12 +195,11 @@ export function main() {
       createWindow();
     }
   });
-  app.on('window-all-closed', async (event) => {
+  app.on('window-all-closed', (event) => {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
-    event.preventDefault();
-    if (process.platform !== 'darwin') {
-      app.quit();
+    if (process.platform === 'darwin') {
+      event.preventDefault();
     }
   });
 

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -200,7 +200,6 @@ export function main() {
   app.on('before-quit', async (event) => {
     // prevent quitting until after we're done with cleanup,
     // then programatically quit
-    console.log('before-quit');
     forceQuit = true;
     if (shuttingDown) { return; }
     event.preventDefault();

--- a/workbench/src/main/setupOpenLocalHtml.js
+++ b/workbench/src/main/setupOpenLocalHtml.js
@@ -11,6 +11,7 @@ export default function setupOpenLocalHtml(parentWindow, isDevMode) {
     ipcMainChannels.OPEN_LOCAL_HTML, (event, url) => {
       const [width, height] = parentWindow.getSize();
       const child = new BrowserWindow({
+        parent: parentWindow,
         width: width > 1000 ? 1000 : width, // UG content is never wider
         height: height,
         frame: true,


### PR DESCRIPTION
## Description
Fixes #1258

Also fixes a similar, mac-specific issue where the app could not be reopened after clicking the red traffic light button.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the affected models' UIs (if relevant)
