### PR TITLE
Workbench: cleanup the process shutdown routines

### DIFF
--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -167,6 +167,7 @@ test('Run a real invest model', async () => {
   const downloadModal = await page.waitForSelector('.modal-dialog');
   const downloadModalCancel = await downloadModal.waitForSelector(
     'aria/[name="Cancel"][role="button"]');
+  await page.waitForTimeout(300); // waiting for click handler to be ready
   await downloadModalCancel.click();
   // We need to get the modelButton from w/in this list-group because there
   // are buttons with the same name in the Recent Jobs container.
@@ -235,11 +236,13 @@ test('Check local userguide links', async () => {
   const downloadModal = await page.waitForSelector('.modal-dialog');
   const downloadModalCancel = await downloadModal.waitForSelector(
     'aria/[name="Cancel"][role="button"]');
+  await page.waitForTimeout(500); // waiting for click handler to be ready
   await downloadModalCancel.click();
 
   const investList = await page.waitForSelector('.invest-list-group');
   const modelButtons = await investList.$$('aria/[role="button"]');
 
+  await page.waitForTimeout(300); // first btn click does not register w/o this pause
   for (const btn of modelButtons) {
     await btn.click();
     const link = await page.waitForSelector('text/User\'s Guide');

--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -133,13 +133,16 @@ beforeEach(() => {
 
 afterEach(async () => {
   try {
+    const pages = await BROWSER.pages();
+    await Promise.all(pages.map(page => page.close()));
     await BROWSER.close();
   } catch (error) {
     console.log(BINARY_PATH);
     console.error(error);
+  } finally {
+    ELECTRON_PROCESS.removeAllListeners();
+    ELECTRON_PROCESS.kill();
   }
-  ELECTRON_PROCESS.removeAllListeners();
-  ELECTRON_PROCESS.kill();
 });
 
 test('Run a real invest model', async () => {

--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -16,6 +16,7 @@ import { APP_HAS_RUN_TOKEN } from '../../src/main/setupCheckFirstRun';
 
 jest.setTimeout(240000);
 const PORT = 9009;
+const WAIT_TO_CLICK = 300; // ms
 let ELECTRON_PROCESS;
 let BROWSER;
 
@@ -166,7 +167,7 @@ test('Run a real invest model', async () => {
   const downloadModal = await page.waitForSelector('.modal-dialog');
   const downloadModalCancel = await downloadModal.waitForSelector(
     'aria/[name="Cancel"][role="button"]');
-  await page.waitForTimeout(300); // waiting for click handler to be ready
+  await page.waitForTimeout(WAIT_TO_CLICK); // waiting for click handler to be ready
   await downloadModalCancel.click();
   // We need to get the modelButton from w/in this list-group because there
   // are buttons with the same name in the Recent Jobs container.
@@ -235,17 +236,17 @@ test('Check local userguide links', async () => {
   const downloadModal = await page.waitForSelector('.modal-dialog');
   const downloadModalCancel = await downloadModal.waitForSelector(
     'aria/[name="Cancel"][role="button"]');
-  await page.waitForTimeout(500); // waiting for click handler to be ready
+  await page.waitForTimeout(WAIT_TO_CLICK); // waiting for click handler to be ready
   await downloadModalCancel.click();
 
   const investList = await page.waitForSelector('.invest-list-group');
   const modelButtons = await investList.$$('aria/[role="button"]');
 
-  await page.waitForTimeout(300); // first btn click does not register w/o this pause
+  await page.waitForTimeout(WAIT_TO_CLICK); // first btn click does not register w/o this pause
   for (const btn of modelButtons) {
     await btn.click();
     const link = await page.waitForSelector('text/User\'s Guide');
-    await page.waitForTimeout(300); // link.click() not working w/o this pause
+    await page.waitForTimeout(WAIT_TO_CLICK); // link.click() not working w/o this pause
     const hrefHandle = await link.getProperty('href');
     const hrefValue = await hrefHandle.jsonValue();
     await link.click();

--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -139,8 +139,7 @@ afterEach(async () => {
   } catch (error) {
     console.log(BINARY_PATH);
     console.error(error);
-  } finally {
-    ELECTRON_PROCESS.removeAllListeners();
+    // Normally BROWSER.close() will kill this process
     ELECTRON_PROCESS.kill();
   }
 });


### PR DESCRIPTION
There was a race condition in the shutdown routine of the workbench. It would mainly come up during the Windows puppeteer test, where the python subprocess would not be given a chance to exit before electron & jest exited. Using `execSync` instead of `exec` to call `taskkill` seems reliable. 

Fixed #1356 by removing the potential for an infinite loop while shutting down the python process. Polling the server to see if it was still live was actually papering over the real problem of the race condition mentioned above.

Fixes #1362 by making sure to close instances of pptr `pages` before trying to close the `browser`. 

Unrelated to that, tests were sometimes unreliable because the script was trying to click on buttons before their click handlers were ready. I added some pauses in the execution to accommodate that and things appear reliable now.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
