### PR TITLE
Close tabs on middle click

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -59,6 +59,9 @@ Unreleased Changes
     * Closing the main window will now close any user's guide windows that are
       open. Fixed a bug where the app could not be reopened after closing.
       (`#1258 <https://github.com/natcap/invest/issues/1258>`_)
+    * Middle clicking an InVEST model tab was opening a blank window. Now
+      middle clicking will close that tab as expected.
+      (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
 * Forest Carbon
     * The biophysical table is now case-insensitive.
 * HRA

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -220,7 +220,17 @@ export default class App extends React.Component {
             key={id}
             className={id === activeTab ? 'active' : ''}
           >
-            <Nav.Link eventKey={id}>
+            <Nav.Link
+              eventKey={id}
+              onAuxClick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                if (event.button === 1) {
+                  // middle mouse button clicked, close tab
+                  this.closeInvestModel(id);
+                }
+              }}
+            >
               {statusSymbol}
               {` ${job.modelHumanName}`}
             </Nav.Link>


### PR DESCRIPTION
## Description
Prevent the default behavior of a middle click opening a new window / tab on an InVEST Tab and instead close that tab.

I was unsure of whether this should live on the `Nav.Link` element or up one on the `Nav.Item` element. I opted for `Nav.Link` because the default nature of middle click on links...

I was unsure of whether this deserved a test? I could not find a "close tab" / "switch tab" test in `investtabtest`

Manually verified behavior on Windows with mouse wheel middle click in development build.

Fixes #1261 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- ~[ ] Updated the user's guide (if needed)~
- [x] Tested the affected models' UIs (if relevant)
