### PR TITLE
Bugfix/1346 urban flood empty table value

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -118,6 +118,9 @@ Unreleased Changes
     * Fixed a bug where the model incorrectly raised an error if the
       biophysical table contained a row of all 0s.
       (`#1123 <https://github.com/natcap/invest/issues/1123>`_)
+    * Biophysical table Workbench validation now warns if there is a missing
+      curve number value.
+      (`#1346 <https://github.com/natcap/invest/issues/1346>`_)
 * Visitation: Recreation and Tourism
     * Fixed a bug where overlapping predictor polygons would be double-counted
       in ``polygon_area_coverage`` and ``polygon_percent_coverage`` calculations.

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -951,15 +951,15 @@ def validate(args, limit_to=None):
 
     if ("curve_number_table_path" not in invalid_keys and
             "curve_number_table_path" in sufficient_keys):
-        # Load CN table
+        # Load CN table. Resulting DF has index and CN_X columns only.
         cn_df = utils.read_csv_to_dataframe(
-            args['curve_number_table_path'], 'lucode')
-        cn_cols = ['cn_a', 'cn_b', 'cn_c', 'cn_d']
-        # utils func converts empty entries into an empty string
-        empty_values = cn_df[cn_cols]==""
-        if empty_values.any(axis=None):
-            empty_lucodes = empty_values[empty_values.any(axis=1)].index
-            lucode_list = list(empty_lucodes.values)
+            args['curve_number_table_path'],
+            MODEL_SPEC['args']['curve_number_table_path'])
+        # Check for NaN values.
+        nan_mask = cn_df.isna()
+        if nan_mask.any(axis=None):
+            nan_lucodes = nan_mask[nan_mask.any(axis=1)].index
+            lucode_list = list(nan_lucodes.values)
             validation_warnings.append((
                 ['curve_number_table_path'],
                 f'Missing curve numbers for lucode(s) {lucode_list}'))

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -360,3 +360,17 @@ class UFRMTests(unittest.TestCase):
             [(['curve_number_table_path'],
               validation.MESSAGES['MATCHED_NO_HEADERS'].format(
                   header='column', header_name='cn_a'))])
+
+        # test missing CN_X values raise warnings
+        args = self._make_args()
+        cn_table = pandas.read_csv(args['curve_number_table_path'])
+        cn_table.at[0, 'CN_A'] = numpy.nan
+        new_cn_path = os.path.join(
+            self.workspace_dir, 'cn_missing_value_table.csv')
+        cn_table.to_csv(new_cn_path, index=False)
+        args['curve_number_table_path'] = new_cn_path
+        result = urban_flood_risk_mitigation.validate(args)
+        self.assertEqual(
+            result,
+            [(['curve_number_table_path'],
+              'Missing curve numbers for lucode(s) [0]')])


### PR DESCRIPTION
## Description
Add validation for missing curve numbers in the biophysical table. Now, when a user enters a CSV table that is missing a "CN_X" column value they will see a validation error message referring to the `lucode` row of the missing value.

This is on hold until #1345, which will change how `utils.read_csv_to_dataframe` handles empty values. Currently empty values are returned as empty strings, but will be proper NaN values after the PR.

Did a quick verification of the UI via a dev build.

Fixes #1346 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the affected models' UIs (if relevant)
