### PR TITLE
Clarify text in UNA `urban_nature` field, update UNA sample data metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := a58b9c7bdd8a31cab469ea919fe0ebf23a6c668e
+GIT_SAMPLE_DATA_REPO_REV    := 2e7cd618c661ec3f3b2a3bddfd2ce7d4704abc05
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -81,11 +81,11 @@ MODEL_SPEC = {
                 'urban_nature': {
                     'type': 'ratio',
                     'about': (
-                        "The proportion (0-1) indicating how much of the land "
-                        "in this LULC type is urban nature. "
-                        "0 indicates no area this LULC type is urban nature, "
-                        "1 indicates that this LULC type is entirely urban "
-                        "nature."
+                        "The proportion (0-1) indicating the naturalness of "
+                        "the land types. 0 indicates the naturalness level of "
+                        "this LULC type is lowest (0% nature), while 1 "
+                        "indicates that of this LULC type is the highest "
+                        "(100% nature)"
                     ),
                 },
                 'search_radius_m': {


### PR DESCRIPTION
Change from science team came in _juuust_ after #1382 was merged.

But might as well update the sample data metadata spreadsheet as well (RE:#1354)


Fixes #1180 
Fixes #1354 


Marking as a draft for a little while, just in case there are additional tweaks.