### PR TITLE
Add license agreement back to installer

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -80,6 +80,9 @@ Unreleased Changes
       (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
     * Updated InVEST logo to use new version with registered trademark symbol.
       (`https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy`_)
+    * InVEST is licensed using a permissive open source license. But we have
+      decided to add back the license and agreement step to the installer to
+      be upfront and explicit about how InVEST is licensed.
 * Coastal Blue Carbon
     * Added validation for the transition table, raising a validation error if
       unexpected values are encountered.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -80,7 +80,7 @@ Unreleased Changes
       (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
     * Updated InVEST logo to use new version with registered trademark symbol.
       (`InVEST TM and Logo Use Policy 
-       <https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy>`_)
+      <https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy>`_)
     * InVEST is licensed using a permissive open source license. But we have
       decided to add back the license and agreement step to the installer to
       be upfront and explicit about how InVEST is licensed.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,7 +79,8 @@ Unreleased Changes
       middle clicking will close that tab as expected.
       (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
     * Updated InVEST logo to use new version with registered trademark symbol.
-      (`https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy`_)
+      (`InVEST TM and Logo Use Policy
+       https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy`_)
     * InVEST is licensed using a permissive open source license. But we have
       decided to add back the license and agreement step to the installer to
       be upfront and explicit about how InVEST is licensed.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,7 +79,7 @@ Unreleased Changes
       middle clicking will close that tab as expected.
       (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
     * Updated InVEST logo to use new version with registered trademark symbol.
-      (`InVEST TM and Logo Use Policy 
+      (`InVEST TM and Logo Use Policy
       <https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy>`_)
     * InVEST is licensed using a permissive open source license. But we have
       decided to add back the license and agreement step to the installer to

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,7 +79,7 @@ Unreleased Changes
       middle clicking will close that tab as expected.
       (`#1261 <https://github.com/natcap/invest/issues/1261>`_)
     * Updated InVEST logo to use new version with registered trademark symbol.
-      (`InVEST TM and Logo Use Policy
+      (`InVEST TM and Logo Use Policy 
        <https://naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy>`_)
     * InVEST is licensed using a permissive open source license. But we have
       decided to add back the license and agreement step to the installer to

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,9 +2,13 @@ The "Natural Capital Project" is defined as the parties of Stanford University,
 University of Minnesota, Chinese Academy of Sciences, The Nature Conservancy,
 World Wildlife Fund, Stockholm Resilience Centre and the Royal Swedish Academy
 of Sciences.
-InVEST® is a registered trademark of Stanford University. Stanford University
+
+InVEST is a registered trademark of Stanford University. Stanford University
 owns and maintains the trademark, and cooperates with the Natural Capital
 Project to develop this policy and any trademark licensing. Visit
 naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
 complete trademark and logo policy.
+
 Copyright (c) 2023, Natural Capital Project
+
+------------------------------------------------------------------------------

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,13 +1,13 @@
 The "Natural Capital Project" is defined as the parties of Stanford University,
- University of Minnesota, Chinese Academy of Sciences, The Nature Conservancy,
- World Wildlife Fund, Stockholm Resilience Centre and the Royal Swedish Academy
- of Sciences.
+University of Minnesota, Chinese Academy of Sciences, The Nature Conservancy,
+World Wildlife Fund, Stockholm Resilience Centre and the Royal Swedish Academy
+of Sciences.
 
 InVEST is a registered trademark of Stanford University. Stanford University
- owns and maintains the trademark, and cooperates with the Natural Capital
- Project to develop this policy and any trademark licensing. Visit
- naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
- complete trademark and logo policy.
+owns and maintains the trademark, and cooperates with the Natural Capital
+Project to develop this policy and any trademark licensing. Visit
+naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
+complete trademark and logo policy.
 
 Copyright (c) 2023, Natural Capital Project
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,13 +1,13 @@
 The "Natural Capital Project" is defined as the parties of Stanford University,
-University of Minnesota, Chinese Academy of Sciences, The Nature Conservancy,
-World Wildlife Fund, Stockholm Resilience Centre and the Royal Swedish Academy
-of Sciences.
+ University of Minnesota, Chinese Academy of Sciences, The Nature Conservancy,
+ World Wildlife Fund, Stockholm Resilience Centre and the Royal Swedish Academy
+ of Sciences.
 
 InVEST is a registered trademark of Stanford University. Stanford University
-owns and maintains the trademark, and cooperates with the Natural Capital
-Project to develop this policy and any trademark licensing. Visit
-naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
-complete trademark and logo policy.
+ owns and maintains the trademark, and cooperates with the Natural Capital
+ Project to develop this policy and any trademark licensing. Visit
+ naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
+ complete trademark and logo policy.
 
 Copyright (c) 2023, Natural Capital Project
 

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -72,6 +72,7 @@ const config = {
     installerHeader: 'resources/InVEST-header-wcvi-rocks.bmp',
     oneClick: false,
     uninstallDisplayName: PRODUCT_NAME,
+    license: 'build/license_en.txt',
   },
   files: [
     'build/**/*',

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -15,10 +15,11 @@
     "test-electron-app": "jest --runInBand --testMatch **/tests/binary_tests/*.test.js",
     "test-sampledata-registry": "jest --runInBand --testMatch **/tests/sampledata_linkcheck/*.test.js",
     "postinstall": "electron-builder install-app-deps",
+    "build-license": "cat ../NOTICE.txt ../LICENSE.txt > build/license_en.txt",
     "build-main": "babel --delete-dir-on-start src/main -d build/main --verbose --config-file ./babel.config.js --ignore **/__mocks__/* -s both --copy-files --no-copy-ignored",
     "build:preload": "cd src/preload && vite build",
     "build-renderer": "vite --config vite.config.js build",
-    "build": "yarn build-renderer && yarn build-main && yarn build:preload",
+    "build": "yarn build-renderer && yarn build-main && yarn build:preload && yarn build-license",
     "token": "cd .. && make jprint-DATA_BASE_URL > workbench/resources/storage_token.txt",
     "dist": "yarn run token && cross-env DEBUG=electron-builder electron-builder build --config electron-builder-config.js"
   },


### PR DESCRIPTION
## Description
After a consult with Stanford OTL we decided that it would be best to be upfront and explicit with the license in which we distribute InVEST and provide that to users during installation.

The NOTICE and LICENSE are concatenated and shown during installation. I altered NOTICE a bit to make this concatenation more readable. I think it's fine for now and if we ever add items to the NOTICE file can rethink how best to handle it. Removed registered TM symbol from NOTICE because it was not playing nice with NSIS.

Fixes #1394 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
