### PR TITLE
Release 3.14.0 prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := e7d32d65612f4f3578a4fb57824af4e297c65283
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 51a061b036b74034dcea81c029dfd1a44921bc71
+GIT_UG_REPO_REV             := 1db6aa847e07b774700ad1432172c791c4729dde
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 2e7cd618c661ec3f3b2a3bddfd2ce7d4704abc05
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := e7d32d65612f4f3578a4fb57824af4e297c65283
+GIT_TEST_DATA_REPO_REV      := f15ac3e0a17c446e5a4bec4ccd50ce8cec359595
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-Cython
+Cython<3.0.0
 virtualenv>=12.0.1
 pytest
 pytest-subtests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2
+GDAL>=3.4.2,<3.7.0
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=1.7.1,<1.8.2  # https://github.com/shapely/shapely/issues/1385
 scipy>=1.9.0
-pygeoprocessing>=2.4.0  # pip-only
+pygeoprocessing==2.4.0  # pip-only
 taskgraph[niced_processes]>=0.11.0  # pip-only
 psutil>=5.6.6
 chardet>=3.0.4


### PR DESCRIPTION
## Description
A few changes to prep for the 3.14.0 release

- Bump `invest-test-data` to latest revision
- Bump UG to latest revision
- Set Cython<3 in requirements to avoid complex numbers issue
- Set Pygeoprocessing to 2.4.0 to avoid using newly released 2.4.1
- Set GDAL<3.7 to avoid issue with newly added Int8 data type

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
