### PR TITLE
Revert license location in electron build for code signing

### DIFF
--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -30,16 +30,6 @@ const config = {
     main: 'build/main/main.js',
     version: installerVersion,
   },
-  extraFiles: [
-    {
-      from: '../LICENSE.txt',
-      to: 'LICENSE.InVEST.txt',
-    },
-    {
-      from: '../NOTICE.txt',
-      to: 'NOTICE.InVEST.txt',
-    },
-  ],
   extraResources: [
     {
       from: '../dist/invest',
@@ -52,6 +42,14 @@ const config = {
     {
       from: 'resources/storage_token.txt',
       to: 'storage_token.txt',
+    },
+    {
+      from: '../LICENSE.txt',
+      to: 'LICENSE.InVEST.txt',
+    },
+    {
+      from: '../NOTICE.txt',
+      to: 'NOTICE.InVEST.txt',
     },
   ],
   appId: APP_ID,


### PR DESCRIPTION
## Description
We attempted to move the License file to the root directory by using `extraFiles` in the electron build config. This had a side effect that made the Mac code signing step fail. So reverting back to having the License and Notice files be in the `extraResources` location.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
