### PR TITLE
Correcting how conda-forge channel is defined

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -64,7 +64,9 @@ runs:
       with:
         environment-file: environment.yml
         environment-name: env
-        channels: conda-forge
+        condarc: |
+              channels:
+                - conda-forge
         init-shell: bash
         cache-environment: true
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}


### PR DESCRIPTION
My builds started failing until I realized that setup-micromamba changed how it defined channels.
