### PR TITLE
Wind energy: handle the case where the grid points path is empty or None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,6 +44,9 @@ Unreleased Changes
 * SDR
     * RKLS, USLE, avoided erosion, and avoided export rasters will now have
       nodata in streams (`#1415 <https://github.com/natcap/invest/issues/1415>`_)
+* Wind Energy
+    * Fixed a bug where model would error when the grid points path was empty
+      (`#1417 <https://github.com/natcap/invest/issues/1417>`_)
 
 3.14.0 (2023-09-08)
 -------------------

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1127,7 +1127,7 @@ def execute(args):
         LOGGER.info('Valuation Not Selected. Model completed')
         return
 
-    if 'grid_points_path' in args:
+    if 'grid_points_path' in args and args['grid_points_path']:
         # Handle Grid Points
         LOGGER.info('Grid Points Provided. Reading in the grid points')
 

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -319,7 +319,8 @@ ArgInput.propTypes = {
     units: PropTypes.string, // for numbers only
   }).isRequired,
   userguide: PropTypes.string.isRequired,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  value: PropTypes.oneOfType(
+    [PropTypes.string, PropTypes.bool, PropTypes.number]),
   touched: PropTypes.bool,
   isValid: PropTypes.bool,
   validationMessage: PropTypes.string,

--- a/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -179,7 +179,8 @@ class ArgsForm extends React.Component {
 ArgsForm.propTypes = {
   argsValues: PropTypes.objectOf(
     PropTypes.shape({
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+      value: PropTypes.oneOfType(
+        [PropTypes.string, PropTypes.bool, PropTypes.number]),
       touched: PropTypes.bool,
     })
   ).isRequired,

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -591,7 +591,8 @@ SetupTab.propTypes = {
     enabledFunctions: PropTypes.objectOf(PropTypes.func),
     dropdownFunctions: PropTypes.objectOf(PropTypes.func),
   }).isRequired,
-  argsInitValues: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.bool])),
+  argsInitValues: PropTypes.objectOf(PropTypes.oneOfType(
+    [PropTypes.string, PropTypes.bool, PropTypes.number])),
   investExecute: PropTypes.func.isRequired,
   sidebarSetupElementId: PropTypes.string.isRequired,
   sidebarFooterElementId: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description
Fixes #1417 
Rob ran into this issue where the model tried to read an empty string as a CSV path.

Also fixing a PropTypes issue that came up when I loaded the datastack to reproduce this issue - numbers should be allowed. This did not affect the functionality.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
