### PR TITLE
Prompt user to extract datastack archive to permanent location

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,8 @@ Unreleased Changes
       have been replaced with ``numpy.prod``.
       https://github.com/natcap/invest/issues/1410
     * Add support for python 3.11 (`#1103 <https://github.com/natcap/invest/issues/1103>`_)
+    * Datastack archives will now be correctly extracted
+      (`#1308 <https://github.com/natcap/invest/issues/1308>`_)
 * SDR
     * RKLS, USLE, avoided erosion, and avoided export rasters will now have
       nodata in streams (`#1415 <https://github.com/natcap/invest/issues/1415>`_)

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -177,7 +177,8 @@ def get_datastack_info(filepath, extract_path=None):
         filepath (string): The path to a file on disk that can be extracted as
             a datastack, parameter set, or logfile.
         extract_path (str): Path to a directory to extract the datastack, if
-            provided as an archive.
+            provided as an archive. Will be overwritten if it already exists,
+            or created if it does not already exist.
 
     Returns:
         A 2-tuple.  The first item of the tuple is one of:
@@ -192,16 +193,16 @@ def get_datastack_info(filepath, extract_path=None):
     if tarfile.is_tarfile(filepath):
         if not extract_path:
             raise ValueError('extract_path must be provided if using archive')
-        extract_dir = os.path.join(
-            extract_path,
-            os.path.splitext(os.path.basename(filepath))[0])
-        if not os.path.exists(extract_dir):
-            os.mkdir(extract_dir)
+        if os.path.isfile(extract_path):
+            os.remove(extract_path)
+        elif os.path.isdir(extract_path):
+            shutil.rmtree(extract_path)
+        os.mkdir(extract_path)
         # If it's a tarfile, we need to extract the parameters file to be able
         # to inspect the parameters and model details.
-        extract_datastack_archive(filepath, extract_dir)
+        extract_datastack_archive(filepath, extract_path)
         return 'archive', extract_parameter_set(
-            os.path.join(extract_dir, DATASTACK_PARAMETER_FILENAME))
+            os.path.join(extract_path, DATASTACK_PARAMETER_FILENAME))
 
     try:
         return 'json', extract_parameter_set(filepath)

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -192,12 +192,16 @@ def get_datastack_info(filepath, extract_path=None):
     if tarfile.is_tarfile(filepath):
         if not extract_path:
             raise ValueError('extract_path must be provided if using archive')
+        extract_dir = os.path.join(
+            extract_path,
+            os.path.splitext(os.path.basename(filepath))[0])
+        if not os.path.exists(extract_dir):
+            os.mkdir(extract_dir)
         # If it's a tarfile, we need to extract the parameters file to be able
         # to inspect the parameters and model details.
-        with tarfile.open(filepath) as archive:
-            archive.extractall(extract_path)
-            return 'archive', extract_parameter_set(
-                os.path.join(extract_path, DATASTACK_PARAMETER_FILENAME))
+        extract_datastack_archive(filepath, extract_dir)
+        return 'archive', extract_parameter_set(
+            os.path.join(extract_dir, DATASTACK_PARAMETER_FILENAME))
 
     try:
         return 'json', extract_parameter_set(filepath)

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -149,9 +149,9 @@ def post_datastack_file():
     Returns:
         A JSON string.
     """
-    filepath = request.get_json()
+    payload = request.get_json()
     stack_type, stack_info = datastack.get_datastack_info(
-        filepath)
+        payload['filepath'], payload.get('extractPath', None))
     model_name = PYNAME_TO_MODEL_NAME_MAP[stack_info.model_name]
     result_dict = {
         'type': stack_type,

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -610,7 +610,8 @@ class ParameterSetTest(unittest.TestCase):
         datastack.build_datastack_archive(
             params, 'test_datastack_modules.simple_parameters', archive_path)
 
-        stack_type, stack_info = datastack.get_datastack_info(archive_path)
+        stack_type, stack_info = datastack.get_datastack_info(
+            archive_path, extract_path=self.workspace)
 
         self.assertEqual(stack_type, 'archive')
         self.assertEqual(stack_info, datastack.ParameterSet(

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -611,7 +611,7 @@ class ParameterSetTest(unittest.TestCase):
             params, 'test_datastack_modules.simple_parameters', archive_path)
 
         stack_type, stack_info = datastack.get_datastack_info(
-            archive_path, extract_path=self.workspace)
+            archive_path, extract_path=os.path.join(self.workspace, 'archive'))
 
         self.assertEqual(stack_type, 'archive')
         self.assertEqual(stack_info, datastack.ParameterSet(

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -102,7 +102,7 @@ class EndpointFunctionTests(unittest.TestCase):
         with open(filepath, 'w') as file:
             file.write(json.dumps(expected_datastack))
         response = test_client.post(
-            f'{ROUTE_PREFIX}/post_datastack_file', json=filepath)
+            f'{ROUTE_PREFIX}/post_datastack_file', json={'filepath': filepath})
         response_data = json.loads(response.get_data(as_text=True))
         self.assertEqual(
             set(response_data),

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -278,18 +278,15 @@ class SetupTab extends React.Component {
     const { pyModuleName, switchTabs, t } = this.props;
     let datastack;
     try {
-      if (filepath.endsWith('gz')) {
+      if (filepath.endsWith('gz')) {  // .tar.gz, .tgz
         const extractLocation = await ipcRenderer.invoke(
-          ipcMainChannels.SHOW_OPEN_DIALOG,
-          {
-            defaultPath: '~/Downloads',
-            properties: ['openDirectory'],
-          }
+          ipcMainChannels.SHOW_SAVE_DIALOG,
+          { title: t('Choose location to extract archive') }
         );
-        if (extractLocation.filePaths) {
+        if (extractLocation.filePath) {
           datastack = await fetchDatastackFromFile({
             filepath: filepath,
-            extractPath: extractLocation.filePaths[0]});
+            extractPath: extractLocation.filePath});
         } else {
           return;
         }

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -278,7 +278,24 @@ class SetupTab extends React.Component {
     const { pyModuleName, switchTabs, t } = this.props;
     let datastack;
     try {
-      datastack = await fetchDatastackFromFile(filepath);
+      if (filepath.endsWith('tgz')) {
+        const extractLocation = await ipcRenderer.invoke(
+          ipcMainChannels.SHOW_OPEN_DIALOG,
+          {
+            defaultPath: '~/Downloads',
+            properties: ['openDirectory'],
+          }
+        );
+        if (extractLocation.filePaths) {
+          datastack = await fetchDatastackFromFile({
+            filepath: filepath,
+            extractPath: extractLocation.filePaths[0]});
+        } else {
+          return;
+        }
+      } else {
+          datastack = await fetchDatastackFromFile({ filepath: filepath });
+      }
     } catch (error) {
       logger.error(error);
       alert( // eslint-disable-line no-alert

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -278,7 +278,7 @@ class SetupTab extends React.Component {
     const { pyModuleName, switchTabs, t } = this.props;
     let datastack;
     try {
-      if (filepath.endsWith('tgz')) {
+      if (filepath.endsWith('gz')) {
         const extractLocation = await ipcRenderer.invoke(
           ipcMainChannels.SHOW_OPEN_DIALOG,
           {

--- a/workbench/tests/invest/flaskapp.test.js
+++ b/workbench/tests/invest/flaskapp.test.js
@@ -101,7 +101,8 @@ describe('requests to flask endpoints', () => {
     });
 
     // Second test the datastack is read and parsed
-    const data2 = await server_requests.fetchDatastackFromFile(filepath);
+    const data2 = await server_requests.fetchDatastackFromFile(
+      { filepath: filepath });
     const expectedKeys2 = [
       'type',
       'args',


### PR DESCRIPTION
## Description
Fixes #1308
Using the Save As dialog to prompt users to choose a location to extract their datastack archive. Now the entire archive is extracted and the file paths loaded into the input form are valid. This does introduce a slight delay while extraction happens, but I didn't think it was bad enough to need a loading indicator. 

The dialog looks like this on mac:
<img width="769" alt="image" src="https://github.com/natcap/invest/assets/43770515/98fc1dcf-85d5-45a4-93e5-e1ba6cade310">


## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
