### PR TITLE
Get the location of the electron logfiles from the logger itself

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -61,6 +61,9 @@ Unreleased Changes
     * Version metadata at import time is now fetched with
       ``importlib.metadata`` instead of ``pkg_resources``.
       (`#1442 <https://github.com/natcap/invest/issues/1442>`_)
+* Workbench
+    * Fixed a broken "Find my logfiles" button on MacOS.
+      https://github.com/natcap/invest/issues/1452
 * Coastal Vulnerability
     * Fixed a bug where the model would crash when processing a float type
       bathymetry raster with no nodata value.

--- a/workbench/src/main/setupGetElectronPaths.js
+++ b/workbench/src/main/setupGetElectronPaths.js
@@ -3,12 +3,13 @@ import path from 'path';
 import { app, ipcMain } from 'electron';
 
 import { ipcMainChannels } from './ipcMainChannels';
+import { getLogger } from './logger';
 
 export default function setupGetElectronPaths() {
   ipcMain.on(ipcMainChannels.GET_ELECTRON_PATHS, (event) => {
     event.returnValue = {
       resourcesPath: process.resourcesPath,
-      logfilePath: path.join(app.getPath('userData'), 'logs', 'main.log')
+      logfilePath: getLogger().transports.file.getFile().path
     };
   });
 }

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -136,12 +136,12 @@ export function setupInvestRunHandlers(investExe) {
       logger.debug('invest subprocess stdio streams closed');
     });
 
-    investRun.on('exit', (code) => {
+    investRun.on('exit', (code, signal) => {
       delete runningJobs[tabID];
       event.reply(`invest-exit-${tabID}`, {
         code: code,
       });
-      logger.debug(code);
+      logger.debug(`invest exited with code: ${code} and signal: ${signal}`);
       fs.unlink(datastackPath, (err) => {
         if (err) { logger.error(err); }
         fs.rmdir(tempDatastackDir, (e) => {

--- a/workbench/src/preload/api.js
+++ b/workbench/src/preload/api.js
@@ -2,7 +2,6 @@
 const { ipcRenderer } = require('electron');
 // using `import` for electron messes with vite and yields a bad bundle.
 // `import`` is okay for local modules though
-
 import { ipcMainChannels } from '../main/ipcMainChannels';
 
 // Most IPC initiates in renderer and main does the listening,


### PR DESCRIPTION
Instead of assuming we know where the logfiles are, ask the logger.
Fixes #1452 

There's also some additional logging here on the exit of an invest subprocess.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
