### PR TITLE
Clarify threat table column about section in model spec.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,11 @@ Unreleased Changes
     * Fixed a bug where the model would crash when processing a float type
       bathymetry raster with no nodata value.
       https://github.com/natcap/invest/issues/992
+* Habitat Quality
+    * Updated the threat table column description to clarify that the threat
+      table columns: ``cur_path``, ``fut_path``, and ``base_path`` are meant
+      to be file system path strings.
+      https://github.com/natcap/invest/issues/1455
 * NDR
     * Fixing an issue where minor geometric issues in the watersheds input
       (such as a ring self-intersection) would raise an error in the model.

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -118,29 +118,33 @@ MODEL_SPEC = {
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "Map of the threat's distribution in the current "
-                        "scenario. Each pixel value is the relative intensity "
-                        "of the threat at that location. ")
+                        "File system path to a raster of the threat's "
+                        "distribution in the current scenario. Each pixel "
+                        "value in the threat raster is the relative intensity "
+                        "of the threat at that location, with values between "
+                        "0 and 1.")
                 },
                 "fut_path": {
                     "required": "lulc_fut_path",
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "Map of the threat's distribution in the future "
-                        "scenario. Each pixel value is the relative intensity "
-                        "of the threat at that location. "
-                        "Required if Future LULC is provided.")
+                        "File system path to a raster of the threat's "
+                        "distribution in a future scenario. Each pixel "
+                        "value in the threat raster is the relative intensity "
+                        "of the threat at that location, with values between "
+                        "0 and 1.")
                 },
                 "base_path": {
                     "required": "lulc_bas_path",
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "Map of the threat's distribution in the baseline "
-                        "scenario. Each pixel value is the relative intensity "
-                        "of the threat at that location. "
-                        "Required if Baseline LULC is provided.")
+                        "File system path to a raster of the threat's "
+                        "distribution in the baseline scenario. Each pixel "
+                        "value in the threat raster is the relative intensity "
+                        "of the threat at that location, with values between "
+                        "0 and 1. Required if Baseline LULC is provided.")
                 }
             },
             "about": gettext(

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -131,7 +131,7 @@ MODEL_SPEC = {
                     "about": gettext(
                         "File system path to a raster of the threat's "
                         "distribution in a future scenario. Each pixel "
-                        "value in the threat raster is the relative intensity "
+                        "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "
                         "0 and 1.")
                 },

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -120,7 +120,7 @@ MODEL_SPEC = {
                     "about": gettext(
                         "File system path to a raster of the threat's "
                         "distribution in the current scenario. Each pixel "
-                        "value in the threat raster is the relative intensity "
+                        "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "
                         "0 and 1.")
                 },

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -118,7 +118,7 @@ MODEL_SPEC = {
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "File system path to a raster of the threat's "
+                        "Path to a raster of the threat's "
                         "distribution in the current scenario. Each pixel "
                         "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "
@@ -129,7 +129,7 @@ MODEL_SPEC = {
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "File system path to a raster of the threat's "
+                        "Path to a raster of the threat's "
                         "distribution in a future scenario. Each pixel "
                         "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "
@@ -140,7 +140,7 @@ MODEL_SPEC = {
                     "type": "raster",
                     "bands": {1: {"type": "ratio"}},
                     "about": gettext(
-                        "File system path to a raster of the threat's "
+                        "Path to a raster of the threat's "
                         "distribution in the baseline scenario. Each pixel "
                         "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -142,7 +142,7 @@ MODEL_SPEC = {
                     "about": gettext(
                         "File system path to a raster of the threat's "
                         "distribution in the baseline scenario. Each pixel "
-                        "value in the threat raster is the relative intensity "
+                        "value in this raster is the relative intensity "
                         "of the threat at that location, with values between "
                         "0 and 1. Required if Baseline LULC is provided.")
                 }


### PR DESCRIPTION
## Description
Per @newtpatrol recommendation, updating the about section for the `[cur|fut|base]_path` columns in the threats table to clarify that we are indeed looking for file system path strings.

Fixes #1455 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
