### PR TITLE
Restoring nodata values in pollination

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -73,6 +73,9 @@ Unreleased Changes
       than 2^31 pixels, the model would crash with an error relating to a
       negative (overflowed) index. https://github.com/natcap/invest/issues/1431
 * Pollination
+    * Fixed a regression where nodata values were not being properly compared.
+      This was only an issue in some development builds after 3.14.0.
+      (`#1458 <https://github.com/natcap/invest/issues/1458>`_)
     * Replaced custom kernel implementation with ``pygeoprocessing.kernels``.
       Convolution results may be slightly different (more accurate).
 * SDR

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -854,7 +854,8 @@ def execute(args):
                             foraged_flowers_index_path,
                             floral_resources_index_path_map[species],
                             convolve_ps_path],
-                        target_path=pollinator_abundance_path),
+                        target_path=pollinator_abundance_path,
+                        target_nodata=_INDEX_NODATA),
                     dependent_task_list=[
                         foraged_flowers_index_task_map[(species, season)],
                         floral_resources_index_task_map[species],
@@ -1430,7 +1431,9 @@ def _multiply_by_scalar(raster_path, scalar, target_path):
     pygeoprocessing.raster_map(
         op=lambda array: array * scalar,
         rasters=[raster_path],
-        target_path=target_path)
+        target_path=target_path,
+        target_nodata=_INDEX_NODATA,
+    )
 
 
 def _calculate_pollinator_supply_index(
@@ -1451,7 +1454,9 @@ def _calculate_pollinator_supply_index(
     pygeoprocessing.raster_map(
         op=lambda f_r, h_n: species_abundance * f_r * h_n,
         rasters=[habitat_nesting_suitability_path, floral_resources_path],
-        target_path=target_path)
+        target_path=target_path,
+        target_nodata=_INDEX_NODATA
+    )
 
 
 @validation.invest_validator


### PR DESCRIPTION
This fixes an issue that cropped up since 3.14.0, where nodata values weren't being properly set, and since pollination compared against very specific nodata values, the model outputs contained a lot of `inf` and `nan`.  Looks like this was a regression introduced in #1437 ... I'm sorry I didn't catch it during my review!

Fixes #1458 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
