### PR TITLE
Handle BOMs when loading HRA criteria tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -62,6 +62,10 @@ Unreleased Changes
     * Fixed a bug where the model would crash when processing a float type
       bathymetry raster with no nodata value.
       https://github.com/natcap/invest/issues/992
+* HRA
+    * Fixed an issue preventing the HRA criteria table from loading when the
+      table was UTF-8 encoded with a Byte-Order Marker.
+      https://github.com/natcap/invest/issues/1460
 * NDR
     * Fixing an issue where minor geometric issues in the watersheds input
       (such as a ring self-intersection) would raise an error in the model.

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -1830,7 +1830,7 @@ def _parse_criteria_table(criteria_table_path, target_composite_csv_path):
     # This function requires that the table is read as a numpy array, so it's
     # easiest to read the table directly.
     table = pandas.read_csv(criteria_table_path, header=None, sep=None,
-                            engine='python').to_numpy()
+                            engine='python', encoding='utf-8-sig').to_numpy()
 
     # clean up any leading or trailing whitespace.
     for row_num in range(table.shape[0]):

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -353,7 +353,8 @@ class HRAUnitTests(unittest.TestCase):
 
         # Sanity check: make sure the file has the expected BOM
         bom_char = "\uFEFF"  # byte-order marker in 16-bit hex value
-        assert open(criteria_table_path).read().startswith(bom_char)
+        with open(criteria_table_path) as criteria_table:
+            assert criteria_table.read().startswith(bom_char)
 
         target_composite_csv_path = os.path.join(self.workspace_dir,
                                                  'composite.csv')

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -326,6 +326,36 @@ class HRAUnitTests(unittest.TestCase):
         pandas.testing.assert_frame_equal(
             expected_composite_dataframe, composite_dataframe)
 
+    def test_criteria_table_parsing_with_bom(self):
+        """HRA: criteria table - parse a BOM."""
+        from natcap.invest import hra
+
+        criteria_table_path = os.path.join(self.workspace_dir, 'criteria.csv')
+        with open(criteria_table_path, 'w') as criteria_table:
+            bom_char = "\uFEFF"  # byte-order marker in 16-bit hex value
+            criteria_table.write(
+                textwrap.dedent(
+                    f"""\
+                    {bom_char}HABITAT NAME,eelgrass,,,hardbottom,,,CRITERIA TYPE
+                    HABITAT RESILIENCE ATTRIBUTES,RATING,DQ,WEIGHT,RATING,DQ,WEIGHT,E/C
+                    recruitment rate,2,2,2,2,2,2,C
+                    connectivity rate,2,2,2,2,2,2,C
+                    ,,,,,,,
+                    HABITAT STRESSOR OVERLAP PROPERTIES,,,,,,,
+                    oil,RATING,DQ,WEIGHT,RATING,DQ,WEIGHT,E/C
+                    frequency of disturbance,2,2,3,2,2,3,C
+                    management effectiveness,2,2,1,2,2,1,E
+                    ,,,,,,,
+                    fishing,RATING,DQ,WEIGHT,RATING,DQ,WEIGHT,E/C
+                    frequency of disturbance,2,2,3,2,2,3,C
+                    management effectiveness,2,2,1,2,2,1,E
+                    """
+                ))
+        target_composite_csv_path = os.path.join(self.workspace_dir,
+                                                 'composite.csv')
+        hra._parse_criteria_table(criteria_table_path,
+                                  target_composite_csv_path)
+
     def test_criteria_table_file_not_found(self):
         """HRA: criteria table - spatial file not found."""
         from natcap.invest import hra

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -352,9 +352,9 @@ class HRAUnitTests(unittest.TestCase):
                 ))
 
         # Sanity check: make sure the file has the expected BOM
-        bom_char = "\uFEFF"  # byte-order marker in 16-bit hex value
-        with open(criteria_table_path) as criteria_table:
-            assert criteria_table.read().startswith(bom_char)
+        # Gotta use binary mode so that python doesn't silently strip the BOM
+        with open(criteria_table_path, 'rb') as criteria_table:
+            self.assertTrue(criteria_table.read().startswith(b"\xef\xbb\xbf"))
 
         target_composite_csv_path = os.path.join(self.workspace_dir,
                                                  'composite.csv')

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -331,12 +331,11 @@ class HRAUnitTests(unittest.TestCase):
         from natcap.invest import hra
 
         criteria_table_path = os.path.join(self.workspace_dir, 'criteria.csv')
-        with open(criteria_table_path, 'w') as criteria_table:
-            bom_char = "\uFEFF"  # byte-order marker in 16-bit hex value
+        with open(criteria_table_path, 'w', encoding='utf-8-sig') as criteria_table:
             criteria_table.write(
                 textwrap.dedent(
-                    f"""\
-                    {bom_char}HABITAT NAME,eelgrass,,,hardbottom,,,CRITERIA TYPE
+                    """\
+                    HABITAT NAME,eelgrass,,,hardbottom,,,CRITERIA TYPE
                     HABITAT RESILIENCE ATTRIBUTES,RATING,DQ,WEIGHT,RATING,DQ,WEIGHT,E/C
                     recruitment rate,2,2,2,2,2,2,C
                     connectivity rate,2,2,2,2,2,2,C
@@ -351,6 +350,11 @@ class HRAUnitTests(unittest.TestCase):
                     management effectiveness,2,2,1,2,2,1,E
                     """
                 ))
+
+        # Sanity check: make sure the file has the expected BOM
+        bom_char = "\uFEFF"  # byte-order marker in 16-bit hex value
+        assert open(criteria_table_path).read().startswith(bom_char)
+
         target_composite_csv_path = os.path.join(self.workspace_dir,
                                                  'composite.csv')
         hra._parse_criteria_table(criteria_table_path,


### PR DESCRIPTION
This PR corrects (and tests for) loading the HRA criteria table using the UTF-8-SIG encoding.

Fixes #1460 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
