### PR TITLE
stick to node version 18 in build environments

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
 
       - name: Restore node_modules cache
         id: nodemodules-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 18
 
       - name: Restore node_modules cache
         id: nodemodules-cache


### PR DESCRIPTION
GHA was getting a bit ahead of us by building in a node v20, environment. I haven't tried that yet, and created a separate issue to deal with all the package upgrades that might go along with that. 

Fixes #1465 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
