### PR TITLE
force autotest script to exit with code 1 if any models failed.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -339,6 +339,7 @@ jobs:
         run: make CONDA="$MAMBA_EXE" binaries
 
       - name: Run invest-autotest with binaries
+        continue-on-error: true
         if : |
           github.event_name == 'push' &&
           (contains(github.ref, 'release') || github.ref == 'refs/heads/main')

--- a/scripts/invest-autotest.py
+++ b/scripts/invest-autotest.py
@@ -67,7 +67,7 @@ def run_model(modelname, binary, workspace, datastack):
         binary = binary.replace('/', '\\')
     # Using a list here allows subprocess to handle escaping of paths.
     command = [binary, 'run', '--workspace', workspace,
-               '--datastack', datastack, '--headless', modelname]
+               '--datastack', datastack, modelname]
 
     # Subprocess on linux/mac seems to prefer a list of args, but path escaping
     # (by passing the command as a list) seems to work better on Windows.
@@ -201,6 +201,8 @@ def main(user_args=None):
     print(status_messages)
     with open(os.path.join(args.workspace, 'model_results.txt'), 'w') as log:
         log.write(status_messages)
+    if failures > 0:
+        parser.exit(1, 'invest autotest failed')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm pretty sure this should do the job. An Actions `run` command that exits with `exit 1` should register as a failed step.

Fixes #1468 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
