### PR TITLE
Converting path separators in `expand_path` if on a POSIX system

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,6 +79,8 @@ Unreleased Changes
     * Fixed an issue preventing the HRA criteria table from loading when the
       table was UTF-8 encoded with a Byte-Order Marker.
       https://github.com/natcap/invest/issues/1460
+    * Fixed an issue with the cross-OS loading of InVEST datastack files.
+      https://github.com/natcap/invest/issues/1065
 * NDR
     * Fixing an issue where minor geometric issues in the watersheds input
       (such as a ring self-intersection) would raise an error in the model.

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -2,8 +2,8 @@
 import codecs
 import contextlib
 import logging
-import math
 import os
+import platform
 import re
 import shutil
 import tempfile
@@ -405,6 +405,8 @@ def expand_path(path, base_path):
     """
     if not path:
         return None
+    if platform.system() in {'Darwin', 'Linux'} and '\\' in path:
+        path = path.replace('\\', '/')
     if os.path.isabs(path):
         return os.path.abspath(path)  # normalize path separators
     return os.path.abspath(os.path.join(os.path.dirname(base_path), path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1187,7 +1187,7 @@ class ExpandPathTests(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.workspace_dir)
 
-    @unittest.skipIf(platform.system == 'Windows',
+    @unittest.skipIf(platform.system() == 'Windows',
                      "Function behavior differs across systems.")
     def test_os_path_normalization_linux(self):
         """Utils: test path separator conversion Win to Linux."""
@@ -1201,14 +1201,14 @@ class ExpandPathTests(unittest.TestCase):
         path = utils.expand_path(rel_path, relative_to)
         self.assertEquals(path, expected_path)
 
-    @unittest.skipIf(platform.system != 'Windows',
+    @unittest.skipIf(platform.system() != 'Windows',
                      "Function behavior differs across systems.")
     def test_os_path_normalization_windows(self):
         """Utils: test path separator conversion Mac/Linux to Windows."""
         from natcap.invest import utils
 
-        # Assumption: a path was created on Windows and is now being loaded on
-        # a Mac or Linux computer.
+        # Assumption: a path was created on mac/linux and is now being loaded
+        # on a Windows computer.
         rel_path = "foo/bar.shp"
         relative_to = os.path.join(self.workspace_dir, 'test.csv')
         expected_path = os.path.join(self.workspace_dir, "foo\\bar.shp")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,6 +2,7 @@
 import codecs
 import functools
 import os
+import platform
 import shutil
 import string
 import tempfile
@@ -1195,9 +1196,18 @@ class TestGetValidatedDataframe(unittest.TestCase):
         self.assertEqual(
             f'{self.workspace_dir}{os.sep}foo{os.sep}bar.txt',
             df['path'][1])
-        self.assertEqual(
-            f'{self.workspace_dir}{os.sep}foo\\bar.txt',
-            df['path'][2])
+
+        # utils.expand_path() will convert Windows path separators to linux if
+        # we're on mac/linux
+        if platform.system() == 'Windows':
+            self.assertEqual(
+                f'{self.workspace_dir}{os.sep}foo\\bar.txt',
+                df['path'][2])
+        else:
+            self.assertEqual(
+                f'{self.workspace_dir}{os.sep}foo/bar.txt',
+                df['path'][2])
+
         self.assertEqual(
             f'{self.workspace_dir}{os.sep}foo.txt',
             df['path'][3])


### PR DESCRIPTION
This patch fixes an issue most common when loading datastacks created on a Windows computer and then loaded on Linux/OSX, and it's only because python doesn't handle mixed path separators at all.

Fixes #1065

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
