### PR TITLE
Fixing the Workbench's broken "Open" button

### DIFF
--- a/workbench/src/renderer/components/OpenButton/index.jsx
+++ b/workbench/src/renderer/components/OpenButton/index.jsx
@@ -29,7 +29,7 @@ class OpenButton extends React.Component {
     if (!data.canceled) {
       let datastack;
       try {
-        datastack = await fetchDatastackFromFile(data.filePaths[0]);
+        datastack = await fetchDatastackFromFile({ filepath: data.filePaths[0] });
       } catch (error) {
         logger.error(error);
         alert(

--- a/workbench/tests/renderer/openbutton.test.js
+++ b/workbench/tests/renderer/openbutton.test.js
@@ -2,8 +2,12 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { ipcRenderer } from 'electron';
 
 import OpenButton from '../../src/renderer/components/OpenButton';
+import { fetchDatastackFromFile } from '../../src/renderer/server_requests';
+
+jest.mock('../../src/renderer/server_requests');
 
 test('Open File: displays a tooltip on hover', async () => {
   const { findByRole, findByText, queryByText } = render(
@@ -21,4 +25,32 @@ test('Open File: displays a tooltip on hover', async () => {
   await waitFor(() => {
     expect(queryByText(hoverText)).toBeNull();
   });
+});
+
+test('Open File: sends correct payload', async () => {
+  const mockDatastack = {
+    model_run_name: 'foo',
+    model_human_name: 'Foo',
+    args: {},
+  };
+  const filename = 'data.json';
+  const mockDialogData = { canceled: false, filePaths: [filename] };
+  ipcRenderer.invoke.mockResolvedValue(mockDialogData);
+  fetchDatastackFromFile.mockResolvedValue(mockDatastack);
+  const { findByRole } = render(
+    <OpenButton
+      openInvestModel={() => {}}
+      batchUpdateArgs={() => {}}
+    />
+  );
+
+  const openButton = await findByRole('button', { name: 'Open' });
+  await userEvent.click(openButton);
+
+  await waitFor(() => {
+    expect(fetchDatastackFromFile).toHaveBeenCalled();
+  });
+  const payload = fetchDatastackFromFile.mock.calls[0][0];
+  expect(Object.keys(payload)).toEqual(['filepath']);
+  expect(payload['filepath']).toEqual(filename);
 });


### PR DESCRIPTION
These are changes that we just happened to miss during #1428 , which changed the `/post_datastack_file'` API just slightly.

Fixes #1485 

No update to history because this bug was never released.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
