### PR TITLE
Allow invest autotest to run in a PR during the autorelease process

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -453,10 +453,16 @@ jobs:
           name: ${{ runner.os }}_puppeteer_log.zip'
           path: ${{ matrix.puppeteer-log }}
 
+      - name: echo stuff
+        run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.head_ref }}
+
       - name: Run invest-autotest with binaries
         if : |
-          github.event_name == 'push' &&
-          (startsWith(github.ref, 'release') || github.ref == 'refs/heads/main')
+          (github.event_name == 'push' &&
+          (startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main')) ||
+          (github.event_name == 'pull_request' && startsWith(github.head_ref, 'task/GHA'))
         run: make invest_autotest
 
       - name: Tar the workspace to preserve permissions (macOS)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -453,16 +453,11 @@ jobs:
           name: ${{ runner.os }}_puppeteer_log.zip'
           path: ${{ matrix.puppeteer-log }}
 
-      - name: echo stuff
-        run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.head_ref }}
-
       - name: Run invest-autotest with binaries
         if : |
           (github.event_name == 'push' &&
           (startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main')) ||
-          (github.event_name == 'pull_request' && startsWith(github.head_ref, 'task/GHA'))
+          (github.event_name == 'pull_request' && startsWith(github.head_ref, 'autorelease'))
         run: make invest_autotest
 
       - name: Tar the workspace to preserve permissions (macOS)


### PR DESCRIPTION
Normally we don't want this step to run on every push and in every PR, but we make an exception for PRs that are part of the autorelease process.

I tested the logic in a draft PR and got the step to run. (https://github.com/natcap/invest/pull/1500)

Fixes #1495 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
