### PR TITLE
Fix UNA NameError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -35,9 +35,13 @@
 
 .. :changelog:
 
-..
-  Unreleased Changes
-  ------------------
+
+Unreleased Changes
+------------------
+* Urban Nature Access
+    * Fixed a ``NameError`` that occurred when running the model using
+      search radii defined per population group with an exponential search
+      kernel. https://github.com/natcap/invest/issues/1502
 
 3.14.1 (2023-12-18)
 -------------------

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -974,7 +974,7 @@ def execute(args):
             kernel_func = pygeoprocessing.kernels.exponential_decay_kernel
             kernel_kwargs = dict(
                 target_kernel_path=kernel_path,
-                max_distance=math.ceil(expected_distance) * 2 + 1,
+                max_distance=math.ceil(search_radius_in_pixels) * 2 + 1,
                 expected_distance=search_radius_in_pixels,
                 normalize=False)
         elif decay_function in [KERNEL_LABEL_GAUSSIAN, KERNEL_LABEL_DENSITY]:

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -594,6 +594,82 @@ class UNATests(unittest.TestCase):
             output_dir, 'accessible_urban_nature_to_pop_female.tif'),
             6221004.412597656, 1171.7352294921875, 11898.0712890625)
 
+    def test_radii_by_pop_group_exponential_kernal(self):
+        """UNA: Regression test defining radii by population group.
+
+        Issue for this bug: https://github.com/natcap/invest/issues/1502
+        """
+        from natcap.invest import urban_nature_access
+
+        args = _build_model_args(self.workspace_dir)
+        args['decay_function'] = urban_nature_access.KERNEL_LABEL_EXPONENTIAL
+        args['search_radius_mode'] = urban_nature_access.RADIUS_OPT_POP_GROUP
+        args['population_group_radii_table'] = os.path.join(
+            self.workspace_dir, 'pop_group_radii.csv')
+        del args['results_suffix']
+
+        with open(args['population_group_radii_table'], 'w') as pop_grp_table:
+            pop_grp_table.write(
+                textwrap.dedent("""\
+                    pop_group,search_radius_m
+                    pop_female,100
+                    pop_male,100"""))
+
+        admin_geom = [
+            shapely.geometry.box(
+                *pygeoprocessing.get_raster_info(
+                    args['lulc_raster_path'])['bounding_box'])]
+        fields = {
+            'pop_female': ogr.OFTReal,
+            'pop_male': ogr.OFTReal,
+        }
+        attributes = [
+            {'pop_female': 0.56, 'pop_male': 0.44}
+        ]
+        pygeoprocessing.shapely_geometry_to_vector(
+            admin_geom, args['admin_boundaries_vector_path'],
+            pygeoprocessing.get_raster_info(
+                args['population_raster_path'])['projection_wkt'],
+            'GeoJSON', fields, attributes)
+
+        urban_nature_access.execute(args)
+
+        summary_vector = gdal.OpenEx(
+            os.path.join(args['workspace_dir'], 'output',
+                         'admin_boundaries.gpkg'))
+        summary_layer = summary_vector.GetLayer()
+        self.assertEqual(summary_layer.GetFeatureCount(), 1)
+        summary_feature = summary_layer.GetFeature(1)
+
+        expected_field_values = {
+            'pop_female': attributes[0]['pop_female'],
+            'pop_male': attributes[0]['pop_male'],
+            'adm_unit_id': 0,
+            'Pund_adm': 0,
+            'Pund_adm_female': 2689.00244140625,
+            'Pund_adm_male': 2112.78759765625,
+            'Povr_adm': 0,
+            'Povr_adm_female': 153.55752563476562,
+            'Povr_adm_male': 120.65234375,
+            'SUP_DEMadm_cap': -17.907799109781322,
+            'SUP_DEMadm_cap_female': -17.90779830090304,
+            'SUP_DEMadm_cap_male': -17.907800139262825,
+        }
+        self.assertEqual(
+            set(defn.GetName() for defn in summary_layer.schema),
+            set(expected_field_values.keys()))
+        for fieldname, expected_value in expected_field_values.items():
+            self.assertAlmostEqual(
+                expected_value, summary_feature.GetField(fieldname))
+
+        output_dir = os.path.join(args['workspace_dir'], 'output')
+        self._assert_urban_nature(os.path.join(
+            output_dir, 'accessible_urban_nature_to_pop_male.tif'),
+            17812884.000976562, 7740.4287109375, 25977.67578125)
+        self._assert_urban_nature(os.path.join(
+            output_dir, 'accessible_urban_nature_to_pop_female.tif'),
+            17812884.000976562, 7740.4287109375, 25977.67578125)
+
     def test_modes_same_radii_same_results(self):
         """UNA: all modes have same results when consistent radii.
 


### PR DESCRIPTION
This PR fixes a `NameError` that only came up in a specific case, when using search radii defined per population group with an exponential kernel.

Fixes #1502

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
