### PR TITLE
Update tests for pandas 2.2.0

### DIFF
--- a/tests/test_crop_production.py
+++ b/tests/test_crop_production.py
@@ -61,7 +61,8 @@ class CropProductionTests(unittest.TestCase):
         agg_result_table = pandas.read_csv(
             agg_result_table_path)
         pandas.testing.assert_frame_equal(
-            expected_agg_result_table, agg_result_table, check_dtype=False)
+            expected_agg_result_table, agg_result_table,
+            check_dtype=False, check_exact=False)
 
         expected_result_table = pandas.read_csv(
             os.path.join(TEST_DATA_PATH, 'expected_result_table.csv')
@@ -316,7 +317,8 @@ class CropProductionTests(unittest.TestCase):
         agg_result_table = pandas.read_csv(
             os.path.join(args['workspace_dir'], 'aggregate_results.csv'))
         pandas.testing.assert_frame_equal(
-            expected_agg_result_table, agg_result_table, check_dtype=False)
+            expected_agg_result_table, agg_result_table,
+            check_dtype=False, check_exact=False)
 
         result_table_path = os.path.join(
             args['workspace_dir'], 'result_table.csv')


### PR DESCRIPTION
## Description
Fixes #1506 
New in pandas 2.2.0, `assert_frame_equal` defaults to exact comparison when testing against integers. The expected values are floats so we need to allow for the usual amount of float tolerance. https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#other-api-changes

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
