### PR TITLE
UNA: Handle the case where an admin geometry doesn't overlap any people

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -42,6 +42,9 @@ Unreleased Changes
     * Fixed a ``NameError`` that occurred when running the model using
       search radii defined per population group with an exponential search
       kernel. https://github.com/natcap/invest/issues/1502
+    * Fixed an issue where Urban Nature Access would crash if an administrative
+      boundary geometry did not overlap any people in the population raster.
+      https://github.com/natcap/invest/issues/1503
 
 3.14.1 (2023-12-18)
 -------------------

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -350,8 +350,9 @@ MODEL_SPEC = {
                                 "The average urban nature supply/demand "
                                 "balance available per person within this "
                                 "administrative unit. If no people reside "
-                                "within this administrative unit, this value "
-                                "will be NaN.")
+                                "within this administrative unit, this field "
+                                "will have no value (NaN, NULL or None, "
+                                "depending on your GIS software).")
                         },
                         "Pund_adm": {
                             "type": "number",

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -2057,12 +2057,13 @@ def _supply_demand_vector_for_single_raster_modes(
         }
 
         # Handle the case where an administrative unit might overlap no people
-        try:
-            stats['SUP_DEMadm_cap'] = (
+        if population_stats[fid]['sum'] == 0:
+            per_capita_supply = float('nan')
+        else:
+            per_capita_supply = (
                 urban_nature_budget_stats[fid]['sum'] /
                 population_stats[fid]['sum'])
-        except ZeroDivisionError:
-            stats['SUP_DEMadm_cap'] = float('nan')
+        stats['SUP_DEMadm_cap'] = per_capita_supply
 
         for pop_group_field in pop_group_fields:
             group = group_names[pop_group_field]

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -347,9 +347,11 @@ MODEL_SPEC = {
                             "type": "number",
                             "units": u.m**2/u.person,
                             "about": (
-                                "The averge urban nature supply/demand "
+                                "The average urban nature supply/demand "
                                 "balance available per person within this "
-                                "administrative unit.")
+                                "administrative unit. If no people reside "
+                                "within this administrative unit, this value "
+                                "will be NaN.")
                         },
                         "Pund_adm": {
                             "type": "number",
@@ -2050,12 +2052,18 @@ def _supply_demand_vector_for_single_raster_modes(
     stats_by_feature = {}
     for fid in urban_nature_budget_stats.keys():
         stats = {
-            'SUP_DEMadm_cap': (
-                urban_nature_budget_stats[fid]['sum'] /
-                population_stats[fid]['sum']),
             'Pund_adm': undersupplied_stats[fid]['sum'],
             'Povr_adm': oversupplied_stats[fid]['sum'],
         }
+
+        # Handle the case where an administrative unit might overlap no people
+        try:
+            stats['SUP_DEMadm_cap'] = (
+                urban_nature_budget_stats[fid]['sum'] /
+                population_stats[fid]['sum'])
+        except ZeroDivisionError:
+            stats['SUP_DEMadm_cap'] = float('nan')
+
         for pop_group_field in pop_group_fields:
             group = group_names[pop_group_field]
             group_proportion = pop_proportions_by_fid[fid][group]

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -839,6 +839,29 @@ class UNATests(unittest.TestCase):
             layer = None
             vector = None
 
+    def test_write_vector_for_single_raster_modes(self):
+        """UNA: create a summary vector for single-raster summary stats."""
+
+        from natcap.invest import urban_nature_access
+
+        args = _build_model_args(self.workspace_dir)
+
+        # Overwrite all population pixels with 0
+        try:
+            raster = gdal.Open(args['population_raster_path'], gdal.GA_Update)
+            band = raster.GetRasterBand(1)
+            array = band.ReadAsArray()
+            array.fill(0.0)
+            band.WriteArray(array)
+        finally:
+            raster = band = None
+
+        args['search_radius_mode'] = urban_nature_access.RADIUS_OPT_UNIFORM
+        args['search_radius'] = 1000
+
+        urban_nature_access.execute(args)
+
+
     def test_urban_nature_proportion(self):
         """UNA: Run the model with urban nature proportion."""
         from natcap.invest import urban_nature_access

--- a/tests/test_urban_nature_access.py
+++ b/tests/test_urban_nature_access.py
@@ -937,6 +937,25 @@ class UNATests(unittest.TestCase):
 
         urban_nature_access.execute(args)
 
+        summary_vector = gdal.OpenEx(
+            os.path.join(args['workspace_dir'], 'output',
+                         'admin_boundaries_suffix.gpkg'))
+        summary_layer = summary_vector.GetLayer()
+        self.assertEqual(summary_layer.GetFeatureCount(), 1)
+        summary_feature = summary_layer.GetFeature(1)
+
+        expected_field_values = {
+            'adm_unit_id': 0,
+            'Pund_adm': 0,
+            'Povr_adm': 0,
+            'SUP_DEMadm_cap': None,  # OGR converts NaN to None.
+        }
+        self.assertEqual(
+            set(defn.GetName() for defn in summary_layer.schema),
+            set(expected_field_values.keys()))
+        for fieldname, expected_value in expected_field_values.items():
+            self.assertAlmostEqual(
+                expected_value, summary_feature.GetField(fieldname))
 
     def test_urban_nature_proportion(self):
         """UNA: Run the model with urban nature proportion."""


### PR DESCRIPTION
This PR addresses a case where an admin geometry doesn't overlap any people in the population raster, as might happen with a rural park.  Per the science team, `NaN` (which OGR saves as NULL, it appears) is used as a value in this case.

Fixes #1503

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
~~- [ ] Tested the Workbench UI (if relevant)~~
