### PR TITLE
Two fixes for SDR - convert processing stack to `long` and reduce rasterizations.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -52,6 +52,12 @@ Unreleased Changes
       administrative units vector now has the correct values for these fields,
       consistent with the user's guide chapter.
       https://github.com/natcap/invest/issues/1512
+* SDR
+    * Fixed an issue encountered in the sediment deposition function where
+      rasters with more than 2^32 pixels would raise a cryptic error relating
+      to negative dimensions. https://github.com/natcap/invest/issues/1431
+    * Optimized the creation of the summary vector by minimizing the number of
+      times the target vector needs to be rasterized.
 
 3.14.1 (2023-12-18)
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
 scipy>=1.9.0
 #pygeoprocessing>=2.4.2  # pip-only
-git+https://github.com/phargogh/pygeoprocessing.git@feature/366-eliminate-duplicate-rasterization-in-alignment#egg=pygeoprocessing
+git+https://github.com/phargogh/pygeoprocessing.git@feature/366-eliminate-duplicate-rasterization-in-alignment#egg=pygeoprocessing  # pip-only
 taskgraph>=0.11.0
 psutil>=5.6.6
 chardet>=3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,7 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
 scipy>=1.9.0
-#pygeoprocessing>=2.4.2  # pip-only
-git+https://github.com/phargogh/pygeoprocessing.git@feature/366-eliminate-duplicate-rasterization-in-alignment#egg=pygeoprocessing  # pip-only
+pygeoprocessing>=2.4.2  # pip-only
 taskgraph>=0.11.0
 psutil>=5.6.6
 chardet>=3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
 scipy>=1.9.0
-pygeoprocessing>=2.4.2  # pip-only
+#pygeoprocessing>=2.4.2  # pip-only
+git+https://github.com/phargogh/pygeoprocessing.git@feature/366-eliminate-duplicate-rasterization-in-alignment#egg=pygeoprocessing
 taskgraph>=0.11.0
 psutil>=5.6.6
 chardet>=3.0.4

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -614,7 +614,6 @@ def execute(args):
         'mask_vector_path': args['watersheds_path'],
         'mask_raster_path': f_reg['watersheds_mask_path'],
     }
-    aligned_list.append(f_reg['watersheds_mask_path'])
     align_task = task_graph.add_task(
         func=pygeoprocessing.align_and_resize_raster_stack,
         args=(
@@ -626,7 +625,7 @@ def execute(args):
             'raster_align_index': 0,
             'vector_mask_options': vector_mask_options,
         },
-        target_path_list=aligned_list,
+        target_path_list=aligned_list + [f_reg['watersheds_mask_path']],
         task_name='align input rasters')
 
     mutual_mask_task = task_graph.add_task(

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -471,6 +471,7 @@ _INTERMEDIATE_BASE_FILES = {
     'aligned_erodibility_path': 'aligned_erodibility.tif',
     'aligned_erosivity_path': 'aligned_erosivity.tif',
     'aligned_lulc_path': 'aligned_lulc.tif',
+    'watersheds_mask_path': 'watersheds_mask.tif',
     'mask_path': 'mask.tif',
     'masked_dem_path': 'masked_dem.tif',
     'masked_drainage_path': 'masked_drainage.tif',
@@ -609,7 +610,11 @@ def execute(args):
     target_pixel_size = (min_pixel_size, -min_pixel_size)
 
     target_sr_wkt = dem_raster_info['projection_wkt']
-    vector_mask_options = {'mask_vector_path': args['watersheds_path']}
+    vector_mask_options = {
+        'mask_vector_path': args['watersheds_path'],
+        'mask_raster_path': f_reg['watersheds_mask_path'],
+    }
+    aligned_list.append(f_reg['watersheds_mask_path'])
     align_task = task_graph.add_task(
         func=pygeoprocessing.align_and_resize_raster_stack,
         args=(

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -472,7 +472,6 @@ _INTERMEDIATE_BASE_FILES = {
     'aligned_erodibility_path': 'aligned_erodibility.tif',
     'aligned_erosivity_path': 'aligned_erosivity.tif',
     'aligned_lulc_path': 'aligned_lulc.tif',
-    'watersheds_mask_path': 'watersheds_mask.tif',
     'mask_path': 'mask.tif',
     'masked_dem_path': 'masked_dem.tif',
     'masked_drainage_path': 'masked_drainage.tif',
@@ -613,7 +612,6 @@ def execute(args):
     target_sr_wkt = dem_raster_info['projection_wkt']
     vector_mask_options = {
         'mask_vector_path': args['watersheds_path'],
-        'mask_raster_path': f_reg['watersheds_mask_path'],
     }
     align_task = task_graph.add_task(
         func=pygeoprocessing.align_and_resize_raster_stack,
@@ -626,7 +624,7 @@ def execute(args):
             'raster_align_index': 0,
             'vector_mask_options': vector_mask_options,
         },
-        target_path_list=aligned_list + [f_reg['watersheds_mask_path']],
+        target_path_list=aligned_list,
         task_name='align input rasters')
 
     mutual_mask_task = task_graph.add_task(

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -293,6 +293,8 @@ cdef class _ManagedRaster:
                 numpy.float64)
         except ValueError as error:
             print("Attempted to use the following dimensions:")
+            print(f"  self.block_nx={self.block_nx}, self.block_ny={self.block_ny}")
+            print(f"  block_xi={block_xi}, block_yi={block_yi}")
             print(f"  xoff={xoff}, yoff={yoff}, win_xsize={win_xsize}, win_ysize={win_ysize}")
             print(f"  block_index={block_index}")
             raise error

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -449,14 +449,14 @@ def calculate_sediment_deposition(
     flow_dir_info = pygeoprocessing.get_raster_info(mfd_flow_direction_path)
     n_cols, n_rows = flow_dir_info['raster_size']
     cdef int mfd_nodata = 0
-    cdef stack[int] processing_stack
+    cdef stack[long] processing_stack
     cdef float sdr_nodata = pygeoprocessing.get_raster_info(
         sdr_path)['nodata'][0]
     cdef float e_prime_nodata = pygeoprocessing.get_raster_info(
         e_prime_path)['nodata'][0]
     cdef long col_index, row_index, win_xsize, win_ysize, xoff, yoff
     cdef long global_col, global_row, j, k
-    cdef unsigned long flat_index
+    cdef long flat_index
     cdef long seed_col = 0
     cdef long seed_row = 0
     cdef long neighbor_row, neighbor_col, ds_neighbor_row, ds_neighbor_col

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -259,14 +259,14 @@ cdef class _ManagedRaster:
                 (xi & (self.block_xmod))]
 
     cdef void _load_block(self, int block_index) except *:
-        cdef int block_xi = block_index % self.block_nx
-        cdef int block_yi = block_index // self.block_nx
+        cdef long block_xi = block_index % self.block_nx
+        cdef long block_yi = block_index // self.block_nx
 
         # we need the offsets to subtract from global indexes for cached array
-        cdef int xoff = block_xi << self.block_xbits
-        cdef int yoff = block_yi << self.block_ybits
+        cdef long xoff = block_xi << self.block_xbits
+        cdef long yoff = block_yi << self.block_ybits
 
-        cdef int xi_copy, yi_copy
+        cdef long xi_copy, yi_copy
         cdef numpy.ndarray[double, ndim=2] block_array
         cdef double *double_buffer
         cdef clist[BlockBufferPair] removed_value_list
@@ -275,8 +275,8 @@ cdef class _ManagedRaster:
 
         # initially the win size is the same as the block size unless
         # we're at the edge of a raster
-        cdef int win_xsize = self.block_xsize
-        cdef int win_ysize = self.block_ysize
+        cdef long win_xsize = self.block_xsize
+        cdef long win_ysize = self.block_ysize
 
         # load a new block
         if xoff+win_xsize > self.raster_x_size:


### PR DESCRIPTION
This PR comes out of work done while helping Jesse to run SDR on a 30m DEM of all of Colombia.  There are 2 main fixes:

* The processing stack is now of type `long`.  The raster has more than 2^32 pixels, so `int` was overflowing and resulting in the negative dimensions error encountered.
* I reworked the zonal statistics step in SDR to reduce the number of times rasterization happens.  `pygeoprocessing.zonal_statistics` already supports this, so all I did was reformat the function call.

Fixes #1431

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
