### PR TITLE
restrict scipy version to one that does not use `packaging.tags`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2,<3.6.0
+GDAL>=3.4.2
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2
+GDAL>=3.4.2,<3.8.0
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
-scipy>=1.9.0
+scipy>=1.9.0,<1.12.0
 pygeoprocessing>=2.4.2  # pip-only
 taskgraph>=0.11.0
 psutil>=5.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2,<3.8.0
+GDAL>=3.4.2,<3.6.0
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
-scipy>=1.9.0,<1.12.0
+scipy>=1.9.0,!=1.12.*
 pygeoprocessing>=2.4.2  # pip-only
 taskgraph>=0.11.0
 psutil>=5.6.6


### PR DESCRIPTION
I'm not sure if we want to do this, but it does seem to allow our mac binary builds to work again. The change in scipy is probably this one in `_testutils.py`:

https://github.com/scipy/scipy/commit/96081aa10e929e807b199f8e441dd1693e304f03

Fixes #1508 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
