### PR TITLE
AWY: add results suffix to a few files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,9 @@
 
 Unreleased Changes
 ------------------
+* Annual Water Yield
+    * Added the results_suffix to a few intermediate files where it was
+      missing. https://github.com/natcap/invest/issues/1517
 * Urban Nature Access
     * Fixed a ``NameError`` that occurred when running the model using
       search radii defined per population group with an exponential search

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2,<3.6.0
+GDAL>=3.4.2
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2
+GDAL>=3.4.2,<3.6.0
 Pyro4==4.77  # pip-only
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -576,8 +576,12 @@ def execute(args):
     wyield_path = os.path.join(
         per_pixel_output_dir, f'wyield{file_suffix}.tif')
     aet_path = os.path.join(per_pixel_output_dir, f'aet{file_suffix}.tif')
-
     demand_path = os.path.join(intermediate_dir, f'demand{file_suffix}.tif')
+    veg_raster_path = os.path.join(intermediate_dir, f'veg{file_suffix}.tif')
+    root_raster_path = os.path.join(
+        intermediate_dir, f'root_depth{file_suffix}.tif')
+    kc_raster_path = os.path.join(
+        intermediate_dir, f'kc_raster{file_suffix}.tif')
 
     watersheds_path = args['watersheds_path']
     watershed_results_vector_path = os.path.join(
@@ -694,39 +698,35 @@ def execute(args):
         'table_name': 'Biophysical'}
     # Create Kc raster from table values to use in future calculations
     LOGGER.info("Reclassifying temp_Kc raster")
-    tmp_Kc_raster_path = os.path.join(intermediate_dir, 'kc_raster.tif')
     create_Kc_raster_task = graph.add_task(
         func=utils.reclassify_raster,
-        args=((clipped_lulc_path, 1), Kc_dict, tmp_Kc_raster_path,
+        args=((clipped_lulc_path, 1), Kc_dict, kc_raster_path,
               gdal.GDT_Float32, nodata_dict['out_nodata'],
               reclass_error_details),
-        target_path_list=[tmp_Kc_raster_path],
+        target_path_list=[kc_raster_path],
         dependent_task_list=[align_raster_stack_task],
         task_name='create_Kc_raster')
 
     # Create root raster from table values to use in future calculations
     LOGGER.info("Reclassifying tmp_root raster")
-    tmp_root_raster_path = os.path.join(
-        intermediate_dir, 'root_depth.tif')
     create_root_raster_task = graph.add_task(
         func=utils.reclassify_raster,
-        args=((clipped_lulc_path, 1), root_dict, tmp_root_raster_path,
+        args=((clipped_lulc_path, 1), root_dict, root_raster_path,
               gdal.GDT_Float32, nodata_dict['out_nodata'],
               reclass_error_details),
-        target_path_list=[tmp_root_raster_path],
+        target_path_list=[root_raster_path],
         dependent_task_list=[align_raster_stack_task],
         task_name='create_root_raster')
 
     # Create veg raster from table values to use in future calculations
     # of determining which AET equation to use
     LOGGER.info("Reclassifying tmp_veg raster")
-    tmp_veg_raster_path = os.path.join(intermediate_dir, 'veg.tif')
     create_veg_raster_task = graph.add_task(
         func=utils.reclassify_raster,
-        args=((clipped_lulc_path, 1), vegetated_dict, tmp_veg_raster_path,
+        args=((clipped_lulc_path, 1), vegetated_dict, veg_raster_path,
               gdal.GDT_Float32, nodata_dict['out_nodata'],
               reclass_error_details),
-        target_path_list=[tmp_veg_raster_path],
+        target_path_list=[veg_raster_path],
         dependent_task_list=[align_raster_stack_task],
         task_name='create_veg_raster')
 
@@ -737,7 +737,7 @@ def execute(args):
         func=pygeoprocessing.raster_map,
         kwargs=dict(
             op=numpy.multiply,  # PET = ET0 * KC
-            rasters=[eto_path, tmp_Kc_raster_path],
+            rasters=[eto_path, kc_raster_path],
             target_path=tmp_pet_path,
             target_nodata=nodata_dict['out_nodata']),
         target_path_list=[tmp_pet_path],
@@ -747,8 +747,8 @@ def execute(args):
 
     # List of rasters to pass into the vectorized fractp operation
     raster_list = [
-        tmp_Kc_raster_path, eto_path, precip_path, tmp_root_raster_path,
-        depth_to_root_rest_layer_path, pawc_path, tmp_veg_raster_path]
+        kc_raster_path, eto_path, precip_path, root_raster_path,
+        depth_to_root_rest_layer_path, pawc_path, veg_raster_path]
 
     LOGGER.debug('Performing fractp operation')
     calculate_fractp_task = graph.add_task(

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -376,61 +376,61 @@ MODEL_SPEC = {
                             }
                         }
                     }
+                }
+            }
+        },
+        "intermediate": {
+            "type": "directory",
+            "contents": {
+                "clipped_lulc.tif": {
+                    "about": "Aligned and clipped copy of LULC input.",
+                    "bands": {1: {"type": "integer"}}
                 },
-                "intermediate": {
-                    "type": "directory",
-                    "contents": {
-                        "clipped_lulc.tif": {
-                            "about": "Aligned and clipped copy of LULC input.",
-                            "bands": {1: {"type": "integer"}}
-                        },
-                        "depth_to_root_rest_layer.tif": {
-                            "about": (
-                                "Aligned and clipped copy of root restricting "
-                                "layer depth input."),
-                            "bands": {
-                                1: {"type": "number", "units": u.millimeter}
-                            }
-                        },
-                        "eto.tif": {
-                            "about": "Aligned and clipped copy of ET0 input.",
-                            "bands": {
-                                1: {"type": "number", "units": u.millimeter}
-                            }
-                        },
-                        "kc_raster.tif": {
-                            "about": "Map of KC values.",
-                            "bands": {
-                                1: {"type": "number", "units": u.none}
-                            }
-                        },
-                        "pawc.tif": {
-                            "about": "Aligned and clipped copy of PAWC input.",
-                            "bands": {1: {"type": "ratio"}},
-                        },
-                        "pet.tif": {
-                            "about": "Map of potential evapotranspiration.",
-                            "bands": {
-                                1: {"type": "number", "units": u.millimeter}
-                            }
-                        },
-                        "precip.tif": {
-                            "about": "Aligned and clipped copy of precipitation input.",
-                            "bands": {
-                                1: {"type": "number", "units": u.millimeter}
-                            }
-                        },
-                        "root_depth.tif": {
-                            "about": "Map of root depth.",
-                            "bands": {
-                                1: {"type": "number", "units": u.millimeter}
-                            }
-                        },
-                        "veg.tif": {
-                            "about": "Map of vegetated state.",
-                            "bands": {1: {"type": "integer"}},
-                        }
+                "depth_to_root_rest_layer.tif": {
+                    "about": (
+                        "Aligned and clipped copy of root restricting "
+                        "layer depth input."),
+                    "bands": {
+                        1: {"type": "number", "units": u.millimeter}
                     }
+                },
+                "eto.tif": {
+                    "about": "Aligned and clipped copy of ET0 input.",
+                    "bands": {
+                        1: {"type": "number", "units": u.millimeter}
+                    }
+                },
+                "kc_raster.tif": {
+                    "about": "Map of KC values.",
+                    "bands": {
+                        1: {"type": "number", "units": u.none}
+                    }
+                },
+                "pawc.tif": {
+                    "about": "Aligned and clipped copy of PAWC input.",
+                    "bands": {1: {"type": "ratio"}},
+                },
+                "pet.tif": {
+                    "about": "Map of potential evapotranspiration.",
+                    "bands": {
+                        1: {"type": "number", "units": u.millimeter}
+                    }
+                },
+                "precip.tif": {
+                    "about": "Aligned and clipped copy of precipitation input.",
+                    "bands": {
+                        1: {"type": "number", "units": u.millimeter}
+                    }
+                },
+                "root_depth.tif": {
+                    "about": "Map of root depth.",
+                    "bands": {
+                        1: {"type": "number", "units": u.millimeter}
+                    }
+                },
+                "veg.tif": {
+                    "about": "Map of vegetated state.",
+                    "bands": {1: {"type": "integer"}},
                 }
             }
         },

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -21,7 +21,7 @@ from . import gettext
 LOGGER = logging.getLogger(__name__)
 
 CARBON_OUTPUTS = {
-    f"c_{scenario}_{pool}.tif": {
+    f"c_{pool}_{scenario}.tif": {
         "about": (
             f"Raster of {pool_name} carbon values in the {scenario_name} "
             "scenario, mapped from the Carbon Pools table to the LULC."),
@@ -252,7 +252,7 @@ MODEL_SPEC = {
             }},
             "created_if": "lulc_redd_path"
         },
-        "intermediate": {
+        "intermediate_outputs": {
             "type": "directory",
             "contents": {
                 **CARBON_OUTPUTS


### PR DESCRIPTION
A few intermediate file outputs were missing the suffix. Based on the variable names, perhaps these files used to be temporary and that's why they didn't get the suffix. But they are no longer temporary. 

I also corrected a couple minor bugs in the output spec for this model (`intermediate` folder not nested within `output`) and in the carbon model.

Fixes #1517 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
