### PR TITLE
Routing wrapper function

### DIFF
--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -36,6 +36,8 @@ cdef class _ManagedRaster:
     cdef int block_ybits
     cdef long raster_x_size
     cdef long raster_y_size
+    cdef float pixel_x_size
+    cdef float pixel_y_size
     cdef int block_nx
     cdef int block_ny
     cdef int write_mode
@@ -72,4 +74,4 @@ cdef inline int is_close(double x, double y):
         return 1
     return abs(x - y) <= (1e-8 + 1e-05 * abs(y))
 
-cdef route(flow_dir_path, seed_fn, route_fn)
+cdef route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args)

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -69,9 +69,9 @@ cdef int *COL_OFFSETS
 cdef int *FLOW_DIR_REVERSE_DIRECTION
 cdef int *INFLOW_OFFSETS
 
-cdef inline int is_close(double x, double y):
+cdef inline bint is_close(double x, double y):
     if isnan(x) and isnan(y):
         return 1
     return abs(x - y) <= (1e-8 + 1e-05 * abs(y))
 
-cdef route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args)
+cdef void route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args)

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -42,7 +42,7 @@ cdef class _ManagedRaster:
     cdef bytes raster_path
     cdef int band_id
     cdef int closed
-    cdef float nodata
+    cdef object nodata
 
     cdef inline void set(_ManagedRaster self, long xi, long yi, double value)
     cdef inline double get(_ManagedRaster self, long xi, long yi)

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -15,7 +15,7 @@ cdef struct s_neighborTuple:
 ctypedef s_neighborTuple NeighborTuple
 
 # this is a least recently used cache written in C++ in an external file,
-# exposing here so _ManagedRaster can use it
+# exposing here so ManagedRaster can use it
 cdef extern from "LRUCache.h" nogil:
     cdef cppclass LRUCache[KEY_T, VAL_T]:
         LRUCache(int)
@@ -25,7 +25,7 @@ cdef extern from "LRUCache.h" nogil:
         bint exist(KEY_T &)
         VAL_T get(KEY_T &)
 
-cdef class _ManagedRaster:
+cdef class ManagedRaster:
     cdef LRUCache[int, double*]* lru_cache
     cdef cset[int] dirty_blocks
     cdef int block_xsize
@@ -46,12 +46,12 @@ cdef class _ManagedRaster:
     cdef int closed
     cdef object nodata
 
-    cdef inline void set(_ManagedRaster self, long xi, long yi, double value)
-    cdef inline double get(_ManagedRaster self, long xi, long yi)
-    cdef void _load_block(_ManagedRaster self, int block_index) except *
+    cdef inline void set(ManagedRaster self, long xi, long yi, double value)
+    cdef inline double get(ManagedRaster self, long xi, long yi)
+    cdef void _load_block(ManagedRaster self, int block_index) except *
 
 
-cdef class ManagedFlowDirRaster(_ManagedRaster):
+cdef class ManagedFlowDirRaster(ManagedRaster):
 
     cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi)
 

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -42,6 +42,7 @@ cdef class _ManagedRaster:
     cdef bytes raster_path
     cdef int band_id
     cdef int closed
+    cdef float nodata
 
     cdef inline void set(_ManagedRaster self, long xi, long yi, double value)
     cdef inline double get(_ManagedRaster self, long xi, long yi)
@@ -70,3 +71,5 @@ cdef inline int is_close(double x, double y):
     if isnan(x) and isnan(y):
         return 1
     return abs(x - y) <= (1e-8 + 1e-05 * abs(y))
+
+cdef route(flow_dir_path, seed_fn, route_fn)

--- a/src/natcap/invest/managed_raster/managed_raster.pyx
+++ b/src/natcap/invest/managed_raster/managed_raster.pyx
@@ -19,7 +19,7 @@ from libcpp.stack cimport stack
 from libcpp.vector cimport vector
 
 
-cdef route(flow_dir_path, seed_fn, route_fn):
+cdef route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args):
     """
     Args:
         seed_fn (callable): function that accepts an (x, y) coordinate
@@ -49,9 +49,10 @@ cdef route(flow_dir_path, seed_fn, route_fn):
         for row_index in range(win_ysize):
             global_row = yoff + row_index
             for col_index in range(win_xsize):
+
                 global_col = xoff + col_index
 
-                if seed_fn(global_col, global_row):
+                if seed_fn(global_col, global_row, *seed_fn_args):
                     processing_stack.push(global_row * n_cols + global_col)
 
         while processing_stack.size() > 0:
@@ -62,7 +63,7 @@ cdef route(flow_dir_path, seed_fn, route_fn):
             global_row = flat_index / n_cols
             global_col = flat_index % n_cols
 
-            to_push = route_fn(global_col, global_row)
+            to_push = route_fn(global_col, global_row, *route_fn_args)
             for index in to_push:
                 processing_stack.push(index)
 
@@ -112,6 +113,7 @@ cdef class _ManagedRaster:
         self.block_xsize, self.block_ysize = raster_info['block_size']
         self.block_xmod = self.block_xsize - 1
         self.block_ymod = self.block_ysize - 1
+        self.pixel_x_size, pixel_y_size = raster_info['pixel_size']
         self.nodata = raster_info['nodata'][band_id - 1]
 
         if not (1 <= band_id <= raster_info['n_bands']):

--- a/src/natcap/invest/managed_raster/managed_raster.pyx
+++ b/src/natcap/invest/managed_raster/managed_raster.pyx
@@ -19,7 +19,7 @@ from libcpp.stack cimport stack
 from libcpp.vector cimport vector
 
 
-cdef route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args):
+cdef route(str flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args):
     """
     Args:
         seed_fn (callable): function that accepts an (x, y) coordinate
@@ -63,8 +63,8 @@ cdef route(flow_dir_path, seed_fn, route_fn, seed_fn_args, route_fn_args):
             global_row = flat_index / n_cols
             global_col = flat_index % n_cols
 
-            to_push = route_fn(global_col, global_row, *route_fn_args)
-            for index in to_push:
+            next_pixels = route_fn(global_col, global_row, *route_fn_args)
+            for index in next_pixels:
                 processing_stack.push(index)
 
 
@@ -91,7 +91,7 @@ cdef int *INFLOW_OFFSETS = [4, 5, 6, 7, 0, 1, 2, 3]
 # a class to allow fast random per-pixel access to a raster for both setting
 # and reading pixels.  Copied from src/pygeoprocessing/routing/routing.pyx,
 # revision 891288683889237cfd3a3d0a1f09483c23489fca.
-cdef class _ManagedRaster:
+cdef class ManagedRaster:
 
     def __cinit__(self, raster_path, band_id, write_mode):
         """Create new instance of Managed Raster.
@@ -154,7 +154,7 @@ cdef class _ManagedRaster:
         self.closed = 0
 
     def __dealloc__(self):
-        """Deallocate _ManagedRaster.
+        """Deallocate ManagedRaster.
 
         This operation manually frees memory from the LRUCache and writes any
         dirty memory blocks back to the raster if `self.write_mode` is True.
@@ -162,12 +162,12 @@ cdef class _ManagedRaster:
         self.close()
 
     def close(self):
-        """Close the _ManagedRaster and free up resources.
+        """Close the ManagedRaster and free up resources.
 
             This call writes any dirty blocks to disk, frees up the memory
             allocated as part of the cache, and frees all GDAL references.
 
-            Any subsequent calls to any other functions in _ManagedRaster will
+            Any subsequent calls to any other functions in ManagedRaster will
             have undefined behavior.
         """
         if self.closed:
@@ -367,7 +367,7 @@ cdef class _ManagedRaster:
             raster = None
 
 
-cdef class ManagedFlowDirRaster(_ManagedRaster):
+cdef class ManagedFlowDirRaster(ManagedRaster):
 
     cdef bint is_local_high_point(self, long xi, long yi):
         """Check if a given pixel is a local high point.

--- a/src/natcap/invest/managed_raster/managed_raster.pyx
+++ b/src/natcap/invest/managed_raster/managed_raster.pyx
@@ -110,8 +110,9 @@ cdef class _ManagedRaster:
         raster_info = pygeoprocessing.get_raster_info(raster_path)
         self.raster_x_size, self.raster_y_size = raster_info['raster_size']
         self.block_xsize, self.block_ysize = raster_info['block_size']
-        self.block_xmod = self.block_xsize-1
-        self.block_ymod = self.block_ysize-1
+        self.block_xmod = self.block_xsize - 1
+        self.block_ymod = self.block_ysize - 1
+        self.nodata = raster_info['nodata'][band_id - 1]
 
         if not (1 <= band_id <= raster_info['n_bands']):
             err_msg = (

--- a/src/natcap/invest/ndr/ndr_core.pyx
+++ b/src/natcap/invest/ndr/ndr_core.pyx
@@ -17,6 +17,7 @@ from ..managed_raster.managed_raster cimport _ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
 from ..managed_raster.managed_raster cimport INFLOW_OFFSETS
+from ..managed_raster.managed_raster cimport route
 
 cdef extern from "time.h" nogil:
     ctypedef int time_t
@@ -65,7 +66,6 @@ def ndr_eff_calculation(
     flow_dir_info = pygeoprocessing.get_raster_info(mfd_flow_direction_path)
     n_cols, n_rows = flow_dir_info['raster_size']
 
-    cdef stack[long] processing_stack
     stream_info = pygeoprocessing.get_raster_info(stream_path)
     # cell sizes must be square, so no reason to test at this point.
     cdef float cell_size = abs(stream_info['pixel_size'][0])
@@ -102,141 +102,124 @@ def ndr_eff_calculation(
     cdef _ManagedRaster to_process_flow_directions_raster = _ManagedRaster(
         to_process_flow_directions_path, 1, True)
 
-    cdef long col_index, row_index, win_xsize, win_ysize, xoff, yoff
-    cdef long global_col, global_row
-    cdef unsigned long flat_index
-    cdef long outflow_weight, flow_dir
+    cdef long flow_dir
     cdef long ds_col, ds_row, i
     cdef float current_step_factor, step_size, crit_len
     cdef long neighbor_row, neighbor_col
     cdef int neighbor_outflow_dir, neighbor_outflow_dir_mask, neighbor_process_flow_dir
     cdef int outflow_dirs, dir_mask
 
-    for offset_dict in pygeoprocessing.iterblocks(
-            (mfd_flow_direction_path, 1), offset_only=True, largest_block=0):
-        # use cython variables to avoid python overhead of dict values
-        win_xsize = offset_dict['win_xsize']
-        win_ysize = offset_dict['win_ysize']
-        xoff = offset_dict['xoff']
-        yoff = offset_dict['yoff']
-        for row_index in range(win_ysize):
-            global_row = yoff + row_index
-            for col_index in range(win_xsize):
-                global_col = xoff + col_index
-                outflow_dirs = <int>to_process_flow_directions_raster.get(
-                    global_col, global_row)
-                should_seed = 0
-                # see if this pixel drains to nodata or the edge, if so it's
-                # a drain
-                for neighbor in (
-                        mfd_flow_direction_raster.get_downslope_neighbors(
-                            global_col, global_row, skip_oob=False)):
-                    if (neighbor.x < 0 or neighbor.x >= n_cols or
-                        neighbor.y < 0 or neighbor.y >= n_rows or
-                        to_process_flow_directions_raster.get(
-                            neighbor.x, neighbor.y) == 0):
-                        should_seed = 1
-                        outflow_dirs &= ~(1 << neighbor.direction)
+    def ndr_seed_fn(col, row):
+        should_seed = False
+        outflow_dirs = <int>to_process_flow_directions_raster.get(col, row)
+        # see if this pixel drains to nodata or the edge, if so it's
+        # a drain
+        for neighbor in (
+                mfd_flow_direction_raster.get_downslope_neighbors(
+                    col, row, skip_oob=False)):
+            if (neighbor.x < 0 or neighbor.x >= n_cols or
+                neighbor.y < 0 or neighbor.y >= n_rows or
+                to_process_flow_directions_raster.get(
+                    neighbor.x, neighbor.y) == 0):
+                should_seed = True
+                outflow_dirs &= ~(1 << neighbor.direction)
 
-                if should_seed:
-                    # mark all outflow directions processed
-                    to_process_flow_directions_raster.set(
-                        global_col, global_row, outflow_dirs)
-                    processing_stack.push(global_row * n_cols + global_col)
+        if should_seed:
+            # mark all outflow directions processed
+            to_process_flow_directions_raster.set(
+                col, row, outflow_dirs)
 
-        while processing_stack.size() > 0:
-            # loop invariant, we don't push a cell on the stack that
-            # hasn't already been set for processing.
-            flat_index = processing_stack.top()
-            processing_stack.pop()
-            global_row = flat_index / n_cols
-            global_col = flat_index % n_cols
+        return should_seed
 
-            crit_len = <float>crit_len_raster.get(global_col, global_row)
-            retention_eff_lulc = retention_eff_lulc_raster.get(
-                global_col, global_row)
-            flow_dir = <int>mfd_flow_direction_raster.get(
-                    global_col, global_row)
-            if stream_raster.get(global_col, global_row) == 1:
-                # if it's a stream effective retention is 0.
-                effective_retention_raster.set(global_col, global_row, STREAM_EFFECTIVE_RETENTION)
-            elif (is_close(crit_len, crit_len_nodata) or
-                  is_close(retention_eff_lulc, retention_eff_nodata) or
-                  flow_dir == 0):
-                # if it's nodata, effective retention is nodata.
-                effective_retention_raster.set(
-                    global_col, global_row, effective_retention_nodata)
-            else:
-                working_retention_eff = 0.0
-                has_outflow = False
-                for neighbor in mfd_flow_direction_raster.get_downslope_neighbors(
-                        global_col, global_row, skip_oob=False):
-                    has_outflow = True
-                    if (neighbor.x < 0 or neighbor.x >= n_cols or
-                        neighbor.y < 0 or neighbor.y >= n_rows):
-                        continue
+    def ndr_route_fn(col, row):
+        to_push = []
+        crit_len = <float>crit_len_raster.get(col, row)
+        retention_eff_lulc = retention_eff_lulc_raster.get(col, row)
+        flow_dir = <int>mfd_flow_direction_raster.get(col, row)
+        if stream_raster.get(col, row) == 1:
+            # if it's a stream effective retention is 0.
+            effective_retention_raster.set(col, row, STREAM_EFFECTIVE_RETENTION)
+        elif (is_close(crit_len, crit_len_nodata) or
+              is_close(retention_eff_lulc, retention_eff_nodata) or
+              flow_dir == 0):
+            # if it's nodata, effective retention is nodata.
+            effective_retention_raster.set(
+                col, row, effective_retention_nodata)
+        else:
+            working_retention_eff = 0.0
+            has_outflow = False
+            for neighbor in mfd_flow_direction_raster.get_downslope_neighbors(
+                    col, row, skip_oob=False):
+                has_outflow = True
+                if (neighbor.x < 0 or neighbor.x >= n_cols or
+                    neighbor.y < 0 or neighbor.y >= n_rows):
+                    continue
 
-                    if neighbor.direction % 2 == 1:
-                        step_size = <float>(cell_size * 1.41421356237)
-                    else:
-                        step_size = cell_size
-                    # guard against a critical length factor that's 0
-                    if crit_len > 0:
-                        current_step_factor = <float>(
-                            exp(-5 * step_size / crit_len))
-                    else:
-                        current_step_factor = 0.0
-
-                    neighbor_effective_retention = (
-                        effective_retention_raster.get(
-                            neighbor.x, neighbor.y))
-
-                    # Case 1: downslope neighbor is a stream pixel
-                    if neighbor_effective_retention == STREAM_EFFECTIVE_RETENTION:
-                        intermediate_retention = (
-                            retention_eff_lulc * (1 - current_step_factor))
-
-                    # Case 2: the current LULC's retention exceeds the neighbor's retention.
-                    elif retention_eff_lulc > neighbor_effective_retention:
-                        intermediate_retention = (
-                            (neighbor_effective_retention * current_step_factor) +
-                            (retention_eff_lulc * (1 - current_step_factor)))
-
-                    # Case 3: the other 2 cases have not been hit.
-                    else:
-                        intermediate_retention = neighbor_effective_retention
-
-                    working_retention_eff += (
-                        intermediate_retention * neighbor.flow_proportion)
-
-                if has_outflow:
-                    effective_retention_raster.set(
-                        global_col, global_row, working_retention_eff)
+                if neighbor.direction % 2 == 1:
+                    step_size = <float>(cell_size * 1.41421356237)
                 else:
-                    raise Exception("got to a cell that has no outflow!")
-            # search upslope to see if we need to push a cell on the stack
-            # for i in range(8):
-            for neighbor in mfd_flow_direction_raster.get_upslope_neighbors(
-                    global_col, global_row):
-                neighbor_outflow_dir = INFLOW_OFFSETS[neighbor.direction]
-                neighbor_outflow_dir_mask = 1 << neighbor_outflow_dir
-                neighbor_process_flow_dir = <int>(
-                    to_process_flow_directions_raster.get(
+                    step_size = cell_size
+                # guard against a critical length factor that's 0
+                if crit_len > 0:
+                    current_step_factor = <float>(
+                        exp(-5 * step_size / crit_len))
+                else:
+                    current_step_factor = 0.0
+
+                neighbor_effective_retention = (
+                    effective_retention_raster.get(
                         neighbor.x, neighbor.y))
-                if neighbor_process_flow_dir == 0:
-                    # skip, due to loop invariant this must be a nodata pixel
-                    continue
-                if neighbor_process_flow_dir & neighbor_outflow_dir_mask == 0:
-                    # no outflow
-                    continue
-                # mask out the outflow dir that this iteration processed
-                neighbor_process_flow_dir &= ~neighbor_outflow_dir_mask
-                to_process_flow_directions_raster.set(
-                    neighbor.x, neighbor.y, neighbor_process_flow_dir)
-                if neighbor_process_flow_dir == 0:
-                    # if 0 then all downslope have been processed,
-                    # push on stack, otherwise another downslope pixel will
-                    # pick it up
-                    processing_stack.push(neighbor.y * n_cols + neighbor.x)
+
+                # Case 1: downslope neighbor is a stream pixel
+                if neighbor_effective_retention == STREAM_EFFECTIVE_RETENTION:
+                    intermediate_retention = (
+                        retention_eff_lulc * (1 - current_step_factor))
+
+                # Case 2: the current LULC's retention exceeds the neighbor's retention.
+                elif retention_eff_lulc > neighbor_effective_retention:
+                    intermediate_retention = (
+                        (neighbor_effective_retention * current_step_factor) +
+                        (retention_eff_lulc * (1 - current_step_factor)))
+
+                # Case 3: the other 2 cases have not been hit.
+                else:
+                    intermediate_retention = neighbor_effective_retention
+
+                working_retention_eff += (
+                    intermediate_retention * neighbor.flow_proportion)
+
+            if has_outflow:
+                effective_retention_raster.set(
+                    col, row, working_retention_eff)
+            else:
+                raise Exception("got to a cell that has no outflow!")
+        # search upslope to see if we need to push a cell on the stack
+        # for i in range(8):
+        for neighbor in mfd_flow_direction_raster.get_upslope_neighbors(col, row):
+            neighbor_outflow_dir = INFLOW_OFFSETS[neighbor.direction]
+            neighbor_outflow_dir_mask = 1 << neighbor_outflow_dir
+            neighbor_process_flow_dir = <int>(
+                to_process_flow_directions_raster.get(
+                    neighbor.x, neighbor.y))
+            if neighbor_process_flow_dir == 0:
+                # skip, due to loop invariant this must be a nodata pixel
+                continue
+            if neighbor_process_flow_dir & neighbor_outflow_dir_mask == 0:
+                # no outflow
+                continue
+            # mask out the outflow dir that this iteration processed
+            neighbor_process_flow_dir &= ~neighbor_outflow_dir_mask
+            to_process_flow_directions_raster.set(
+                neighbor.x, neighbor.y, neighbor_process_flow_dir)
+            if neighbor_process_flow_dir == 0:
+                # if 0 then all downslope have been processed,
+                # push on stack, otherwise another downslope pixel will
+                # pick it up
+                to_push.append(neighbor.y * n_cols + neighbor.x)
+        return to_push
+
+
+    route(mfd_flow_direction_path, ndr_seed_fn, ndr_route_fn)
+
     to_process_flow_directions_raster.close()
     os.remove(to_process_flow_directions_path)

--- a/src/natcap/invest/ndr/ndr_core.pyx
+++ b/src/natcap/invest/ndr/ndr_core.pyx
@@ -72,10 +72,6 @@ def ndr_eff_calculation(
     cdef ManagedFlowDirRaster mfd_flow_direction_raster = ManagedFlowDirRaster(
         mfd_flow_direction_path, 1, False)
 
-    cdef float retention_eff_nodata = pygeoprocessing.get_raster_info(
-        retention_eff_lulc_path)['nodata'][0]
-    cdef float crit_len_nodata = pygeoprocessing.get_raster_info(
-        crit_len_path)['nodata'][0]
     # cell sizes must be square, so no reason to test at this point.
     cdef float cell_size = abs(pygeoprocessing.get_raster_info(
         stream_path)['pixel_size'][0])
@@ -150,8 +146,8 @@ def ndr_eff_calculation(
         if stream_raster.get(col, row) == 1:
             # if it's a stream effective retention is 0.
             effective_retention_raster.set(col, row, STREAM_EFFECTIVE_RETENTION)
-        elif (is_close(crit_len, crit_len_nodata) or
-              is_close(retention_eff_lulc, retention_eff_nodata) or
+        elif (is_close(crit_len, crit_len_raster.nodata) or
+              is_close(retention_eff_lulc, retention_eff_lulc_raster.nodata) or
               flow_dir == 0):
             # if it's nodata, effective retention is nodata.
             effective_retention_raster.set(

--- a/src/natcap/invest/ndr/ndr_core.pyx
+++ b/src/natcap/invest/ndr/ndr_core.pyx
@@ -9,7 +9,7 @@ cimport cython
 from osgeo import gdal
 
 from libc.math cimport exp
-from ..managed_raster.managed_raster cimport _ManagedRaster
+from ..managed_raster.managed_raster cimport ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
 from ..managed_raster.managed_raster cimport INFLOW_OFFSETS
@@ -21,7 +21,7 @@ cdef float EFFECTIVE_RETENTION_NODATA = -1.0
 
 
 cdef bint ndr_seed_fn(int x, int y,
-        _ManagedRaster to_process_flow_directions_raster,
+        ManagedRaster to_process_flow_directions_raster,
         ManagedFlowDirRaster mfd_flow_direction_raster):
     """Determine if a given pixel can be a seed pixel.
 
@@ -55,10 +55,10 @@ cdef bint ndr_seed_fn(int x, int y,
 
 
 def ndr_route_fn(int x, int y, ManagedFlowDirRaster mfd_flow_direction_raster,
-        _ManagedRaster to_process_flow_directions_raster,
-        _ManagedRaster stream_raster, _ManagedRaster crit_len_raster,
-        _ManagedRaster effective_retention_raster,
-        _ManagedRaster retention_eff_lulc_raster):
+        ManagedRaster to_process_flow_directions_raster,
+        ManagedRaster stream_raster, ManagedRaster crit_len_raster,
+        ManagedRaster effective_retention_raster,
+        ManagedRaster retention_eff_lulc_raster):
     """Perform routed operations for NDR.
 
     Args:
@@ -165,24 +165,24 @@ def ndr_eff_calculation(
         crit_len_path, effective_retention_path):
     """Calculate flow downhill effective_retention to the channel.
 
-        Args:
-            mfd_flow_direction_path (string): a path to a raster with
-                pygeoprocessing.routing MFD flow direction values.
-            stream_path (string): a path to a raster where 1 indicates a
-                stream all other values ignored must be same dimensions and
-                projection as mfd_flow_direction_path.
-            retention_eff_lulc_path (string): a path to a raster indicating
-                the maximum retention efficiency that the landcover on that
-                pixel can accumulate.
-            crit_len_path (string): a path to a raster indicating the critical
-                length of the retention efficiency that the landcover on this
-                pixel.
-            effective_retention_path (string): path to a raster that is
-                created by this call that contains a per-pixel effective
-                sediment retention to the stream.
+    Args:
+        mfd_flow_direction_path (string): a path to a raster with
+            pygeoprocessing.routing MFD flow direction values.
+        stream_path (string): a path to a raster where 1 indicates a
+            stream all other values ignored must be same dimensions and
+            projection as mfd_flow_direction_path.
+        retention_eff_lulc_path (string): a path to a raster indicating
+            the maximum retention efficiency that the landcover on that
+            pixel can accumulate.
+        crit_len_path (string): a path to a raster indicating the critical
+            length of the retention efficiency that the landcover on this
+            pixel.
+        effective_retention_path (string): path to a raster that is
+            created by this call that contains a per-pixel effective
+            sediment retention to the stream.
 
-        Returns:
-            None.
+    Returns:
+        None.
 
     """
     pygeoprocessing.new_raster_from_base(
@@ -193,12 +193,12 @@ def ndr_eff_calculation(
         dir=os.path.dirname(effective_retention_path))
     os.close(fp)
 
-    cdef _ManagedRaster stream_raster = _ManagedRaster(stream_path, 1, False)
-    cdef _ManagedRaster crit_len_raster = _ManagedRaster(
+    cdef ManagedRaster stream_raster = ManagedRaster(stream_path, 1, False)
+    cdef ManagedRaster crit_len_raster = ManagedRaster(
         crit_len_path, 1, False)
-    cdef _ManagedRaster retention_eff_lulc_raster = _ManagedRaster(
+    cdef ManagedRaster retention_eff_lulc_raster = ManagedRaster(
         retention_eff_lulc_path, 1, False)
-    cdef _ManagedRaster effective_retention_raster = _ManagedRaster(
+    cdef ManagedRaster effective_retention_raster = ManagedRaster(
         effective_retention_path, 1, True)
     cdef ManagedFlowDirRaster mfd_flow_direction_raster = ManagedFlowDirRaster(
         mfd_flow_direction_path, 1, False)
@@ -217,7 +217,7 @@ def ndr_eff_calculation(
     pygeoprocessing.raster_calculator(
         [(mfd_flow_direction_path, 1)], _mfd_to_flow_dir_op,
         to_process_flow_directions_path, gdal.GDT_Byte, None)
-    cdef _ManagedRaster to_process_flow_directions_raster = _ManagedRaster(
+    cdef ManagedRaster to_process_flow_directions_raster = ManagedRaster(
         to_process_flow_directions_path, 1, True)
 
     route(

--- a/src/natcap/invest/ndr/ndr_core.pyx
+++ b/src/natcap/invest/ndr/ndr_core.pyx
@@ -1,9 +1,6 @@
-# cython: profile=False
 # cython: language_level=2
 import tempfile
-import logging
 import os
-import collections
 
 import numpy
 import pygeoprocessing
@@ -11,7 +8,6 @@ cimport numpy
 cimport cython
 from osgeo import gdal
 
-from libcpp.stack cimport stack
 from libc.math cimport exp
 from ..managed_raster.managed_raster cimport _ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
@@ -19,14 +15,150 @@ from ..managed_raster.managed_raster cimport is_close
 from ..managed_raster.managed_raster cimport INFLOW_OFFSETS
 from ..managed_raster.managed_raster cimport route
 
-cdef extern from "time.h" nogil:
-    ctypedef int time_t
-    time_t time(time_t*)
-
-LOGGER = logging.getLogger(__name__)
-
 # Within a stream, the effective retention is 0
 cdef int STREAM_EFFECTIVE_RETENTION = 0
+cdef float EFFECTIVE_RETENTION_NODATA = -1.0
+
+
+cdef bint ndr_seed_fn(int x, int y,
+        _ManagedRaster to_process_flow_directions_raster,
+        ManagedFlowDirRaster mfd_flow_direction_raster):
+    """Determine if a given pixel can be a seed pixel.
+
+    To be a seed pixel, it must drain to nodata or off the edge of the raster.
+
+    Args:
+        x (int): column index of the pixel in raster space
+        y (int): row index of the pixel in raster space
+
+    Returns:
+        True if the pixel qualifies as a seed pixel, False otherwise
+    """
+    cdef bint should_seed = False
+    cdef int outflow_dirs = <int>to_process_flow_directions_raster.get(x, y)
+    # see if this pixel drains to nodata or the edge, if so it's
+    # a drain
+    for neighbor in (
+            mfd_flow_direction_raster.get_downslope_neighbors(
+                x, y, skip_oob=False)):
+        if (neighbor.x < 0 or neighbor.x >= mfd_flow_direction_raster.raster_x_size or
+            neighbor.y < 0 or neighbor.y >= mfd_flow_direction_raster.raster_y_size or
+            to_process_flow_directions_raster.get(
+                neighbor.x, neighbor.y) == 0):
+            should_seed = True
+            outflow_dirs &= ~(1 << neighbor.direction)
+    if should_seed:
+        # mark all outflow directions processed
+        to_process_flow_directions_raster.set(
+            x, y, outflow_dirs)
+    return should_seed
+
+
+def ndr_route_fn(int x, int y, ManagedFlowDirRaster mfd_flow_direction_raster,
+        _ManagedRaster to_process_flow_directions_raster,
+        _ManagedRaster stream_raster, _ManagedRaster crit_len_raster,
+        _ManagedRaster effective_retention_raster,
+        _ManagedRaster retention_eff_lulc_raster):
+    """Perform routed operations for NDR.
+
+    Args:
+        x (int): column index of the pixel in raster space
+        y (int): row index of the pixel in raster space
+
+    Returns:
+        list of integer indexes of pixels to push onto the stack.
+        Flat indexes are used.
+    """
+    next_pixels = []
+    cdef int neighbor_outflow_dir, neighbor_outflow_dir_mask, neighbor_process_flow_dir
+    cdef float current_step_factor, step_size
+    cdef float working_retention_eff
+    cdef float crit_len = crit_len_raster.get(x, y)
+    cdef float retention_eff_lulc = retention_eff_lulc_raster.get(x, y)
+    cdef int flow_dir = <int>mfd_flow_direction_raster.get(x, y)
+    if stream_raster.get(x, y) == 1:
+        # if it's a stream effective retention is 0.
+        effective_retention_raster.set(x, y, STREAM_EFFECTIVE_RETENTION)
+    elif (is_close(crit_len, crit_len_raster.nodata) or
+          is_close(retention_eff_lulc, retention_eff_lulc_raster.nodata) or
+          flow_dir == 0):
+        # if it's nodata, effective retention is nodata.
+        effective_retention_raster.set(
+            x, y, EFFECTIVE_RETENTION_NODATA)
+    else:
+        working_retention_eff = 0.0
+        has_outflow = False
+        for neighbor in mfd_flow_direction_raster.get_downslope_neighbors(
+                x, y, skip_oob=False):
+            has_outflow = True
+            if (neighbor.x < 0 or neighbor.x >= mfd_flow_direction_raster.raster_x_size or
+                neighbor.y < 0 or neighbor.y >= mfd_flow_direction_raster.raster_y_size):
+                continue
+
+            # cell sizes must be square, so no reason to test at this point.
+            if neighbor.direction % 2 == 1:
+                step_size = <float>(stream_raster.pixel_x_size * 1.41421356237)
+            else:
+                step_size = stream_raster.pixel_x_size
+            # guard against a critical length factor that's 0
+            if crit_len > 0:
+                current_step_factor = <float>(
+                    exp(-5 * step_size / crit_len))
+            else:
+                current_step_factor = 0.0
+
+            neighbor_effective_retention = (
+                effective_retention_raster.get(
+                    neighbor.x, neighbor.y))
+
+            # Case 1: downslope neighbor is a stream pixel
+            if neighbor_effective_retention == STREAM_EFFECTIVE_RETENTION:
+                intermediate_retention = (
+                    retention_eff_lulc * (1 - current_step_factor))
+
+            # Case 2: the current LULC's retention exceeds the neighbor's retention.
+            elif retention_eff_lulc > neighbor_effective_retention:
+                intermediate_retention = (
+                    (neighbor_effective_retention * current_step_factor) +
+                    (retention_eff_lulc * (1 - current_step_factor)))
+
+            # Case 3: the other 2 cases have not been hit.
+            else:
+                intermediate_retention = neighbor_effective_retention
+
+            working_retention_eff += (
+                intermediate_retention * neighbor.flow_proportion)
+
+        if has_outflow:
+            effective_retention_raster.set(
+                x, y, working_retention_eff)
+        else:
+            raise Exception("got to a cell that has no outflow!")
+    # search upslope to see if we need to push a cell on the stack
+    # for i in range(8):
+    for neighbor in mfd_flow_direction_raster.get_upslope_neighbors(x, y):
+        neighbor_outflow_dir = INFLOW_OFFSETS[neighbor.direction]
+        neighbor_outflow_dir_mask = 1 << neighbor_outflow_dir
+        neighbor_process_flow_dir = <int>(
+            to_process_flow_directions_raster.get(
+                neighbor.x, neighbor.y))
+        if neighbor_process_flow_dir == 0:
+            # skip, due to loop invariant this must be a nodata pixel
+            continue
+        if neighbor_process_flow_dir & neighbor_outflow_dir_mask == 0:
+            # no outflow
+            continue
+        # mask out the outflow dir that this iteration processed
+        neighbor_process_flow_dir &= ~neighbor_outflow_dir_mask
+        to_process_flow_directions_raster.set(
+            neighbor.x, neighbor.y, neighbor_process_flow_dir)
+        if neighbor_process_flow_dir == 0:
+            # if 0 then all downslope have been processed,
+            # push on stack, otherwise another downslope pixel will
+            # pick it up
+            next_pixels.append(neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
+    return next_pixels
+
 
 def ndr_eff_calculation(
         mfd_flow_direction_path, stream_path, retention_eff_lulc_path,
@@ -53,10 +185,9 @@ def ndr_eff_calculation(
             None.
 
     """
-    cdef float effective_retention_nodata = -1.0
     pygeoprocessing.new_raster_from_base(
         mfd_flow_direction_path, effective_retention_path, gdal.GDT_Float32,
-        [effective_retention_nodata])
+        [EFFECTIVE_RETENTION_NODATA])
     fp, to_process_flow_directions_path = tempfile.mkstemp(
         suffix='.tif', prefix='flow_to_process',
         dir=os.path.dirname(effective_retention_path))
@@ -72,10 +203,6 @@ def ndr_eff_calculation(
     cdef ManagedFlowDirRaster mfd_flow_direction_raster = ManagedFlowDirRaster(
         mfd_flow_direction_path, 1, False)
 
-    # cell sizes must be square, so no reason to test at this point.
-    cdef float cell_size = abs(pygeoprocessing.get_raster_info(
-        stream_path)['pixel_size'][0])
-
     # create direction raster in bytes
     def _mfd_to_flow_dir_op(mfd_array):
         result = numpy.zeros(mfd_array.shape, dtype=numpy.int8)
@@ -90,143 +217,19 @@ def ndr_eff_calculation(
     pygeoprocessing.raster_calculator(
         [(mfd_flow_direction_path, 1)], _mfd_to_flow_dir_op,
         to_process_flow_directions_path, gdal.GDT_Byte, None)
-
     cdef _ManagedRaster to_process_flow_directions_raster = _ManagedRaster(
         to_process_flow_directions_path, 1, True)
 
-    def ndr_seed_fn(col, row):
-        """Determine if a given pixel can be a seed pixel.
-
-        To be a seed pixel, it must drain to nodata or off the edge of the raster.
-
-        Args:
-            col (int): column index of the pixel in raster space
-            row (int): row index of the pixel in raster space
-
-        Returns:
-            True if the pixel qualifies as a seed pixel, False otherwise
-        """
-        cdef bint should_seed = False
-        cdef int outflow_dirs = <int>to_process_flow_directions_raster.get(col, row)
-        # see if this pixel drains to nodata or the edge, if so it's
-        # a drain
-        for neighbor in (
-                mfd_flow_direction_raster.get_downslope_neighbors(
-                    col, row, skip_oob=False)):
-            if (neighbor.x < 0 or neighbor.x >= mfd_flow_direction_raster.raster_x_size or
-                neighbor.y < 0 or neighbor.y >= mfd_flow_direction_raster.raster_y_size or
-                to_process_flow_directions_raster.get(
-                    neighbor.x, neighbor.y) == 0):
-                should_seed = True
-                outflow_dirs &= ~(1 << neighbor.direction)
-        if should_seed:
-            # mark all outflow directions processed
-            to_process_flow_directions_raster.set(
-                col, row, outflow_dirs)
-        return should_seed
-
-    def ndr_route_fn(col, row):
-        """Perform routed operations for NDR.
-
-        Args:
-            col (int): column index of the pixel in raster space
-            row (int): row index of the pixel in raster space
-
-        Returns:
-            list of integer indexes of pixels to push onto the stack.
-            Flat indexes are used.
-        """
-        to_push = []
-        cdef int neighbor_outflow_dir, neighbor_outflow_dir_mask, neighbor_process_flow_dir
-        cdef float current_step_factor, step_size
-        cdef float working_retention_eff
-        cdef float crit_len = <float>crit_len_raster.get(col, row)
-        cdef float retention_eff_lulc = retention_eff_lulc_raster.get(col, row)
-        cdef int flow_dir = <int>mfd_flow_direction_raster.get(col, row)
-        if stream_raster.get(col, row) == 1:
-            # if it's a stream effective retention is 0.
-            effective_retention_raster.set(col, row, STREAM_EFFECTIVE_RETENTION)
-        elif (is_close(crit_len, crit_len_raster.nodata) or
-              is_close(retention_eff_lulc, retention_eff_lulc_raster.nodata) or
-              flow_dir == 0):
-            # if it's nodata, effective retention is nodata.
-            effective_retention_raster.set(
-                col, row, effective_retention_nodata)
-        else:
-            working_retention_eff = 0.0
-            has_outflow = False
-            for neighbor in mfd_flow_direction_raster.get_downslope_neighbors(
-                    col, row, skip_oob=False):
-                has_outflow = True
-                if (neighbor.x < 0 or neighbor.x >= mfd_flow_direction_raster.raster_x_size or
-                    neighbor.y < 0 or neighbor.y >= mfd_flow_direction_raster.raster_y_size):
-                    continue
-
-                if neighbor.direction % 2 == 1:
-                    step_size = <float>(cell_size * 1.41421356237)
-                else:
-                    step_size = cell_size
-                # guard against a critical length factor that's 0
-                if crit_len > 0:
-                    current_step_factor = <float>(
-                        exp(-5 * step_size / crit_len))
-                else:
-                    current_step_factor = 0.0
-
-                neighbor_effective_retention = (
-                    effective_retention_raster.get(
-                        neighbor.x, neighbor.y))
-
-                # Case 1: downslope neighbor is a stream pixel
-                if neighbor_effective_retention == STREAM_EFFECTIVE_RETENTION:
-                    intermediate_retention = (
-                        retention_eff_lulc * (1 - current_step_factor))
-
-                # Case 2: the current LULC's retention exceeds the neighbor's retention.
-                elif retention_eff_lulc > neighbor_effective_retention:
-                    intermediate_retention = (
-                        (neighbor_effective_retention * current_step_factor) +
-                        (retention_eff_lulc * (1 - current_step_factor)))
-
-                # Case 3: the other 2 cases have not been hit.
-                else:
-                    intermediate_retention = neighbor_effective_retention
-
-                working_retention_eff += (
-                    intermediate_retention * neighbor.flow_proportion)
-
-            if has_outflow:
-                effective_retention_raster.set(
-                    col, row, working_retention_eff)
-            else:
-                raise Exception("got to a cell that has no outflow!")
-        # search upslope to see if we need to push a cell on the stack
-        # for i in range(8):
-        for neighbor in mfd_flow_direction_raster.get_upslope_neighbors(col, row):
-            neighbor_outflow_dir = INFLOW_OFFSETS[neighbor.direction]
-            neighbor_outflow_dir_mask = 1 << neighbor_outflow_dir
-            neighbor_process_flow_dir = <int>(
-                to_process_flow_directions_raster.get(
-                    neighbor.x, neighbor.y))
-            if neighbor_process_flow_dir == 0:
-                # skip, due to loop invariant this must be a nodata pixel
-                continue
-            if neighbor_process_flow_dir & neighbor_outflow_dir_mask == 0:
-                # no outflow
-                continue
-            # mask out the outflow dir that this iteration processed
-            neighbor_process_flow_dir &= ~neighbor_outflow_dir_mask
-            to_process_flow_directions_raster.set(
-                neighbor.x, neighbor.y, neighbor_process_flow_dir)
-            if neighbor_process_flow_dir == 0:
-                # if 0 then all downslope have been processed,
-                # push on stack, otherwise another downslope pixel will
-                # pick it up
-                to_push.append(neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
-        return to_push
-
-
-    route(mfd_flow_direction_path, ndr_seed_fn, ndr_route_fn)
+    route(
+        flow_dir_path=mfd_flow_direction_path,
+        seed_fn=ndr_seed_fn,
+        route_fn=ndr_route_fn,
+        seed_fn_args=[
+            to_process_flow_directions_raster, mfd_flow_direction_raster],
+        route_fn_args=[
+            mfd_flow_direction_raster, to_process_flow_directions_raster,
+            stream_raster, crit_len_raster, effective_retention_raster,
+            retention_eff_lulc_raster])
 
     to_process_flow_directions_raster.close()
     os.remove(to_process_flow_directions_path)

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -12,6 +12,7 @@ from osgeo import gdal
 
 from libc.time cimport time as ctime
 from libcpp.stack cimport stack
+from libcpp.vector cimport vector
 from ..managed_raster.managed_raster cimport _ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
@@ -24,6 +25,152 @@ cdef extern from "time.h" nogil:
 
 LOGGER = logging.getLogger(__name__)
 
+
+cdef bint sed_dep_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_raster,
+        _ManagedRaster sediment_deposition_raster):
+    """Determine if a given pixel can be a seed pixel.
+
+    To be a seed pixel, it must be a local high point and have data in
+    the sediment deposition raster.
+
+    Args:
+        x (int): column index of the pixel in raster space
+        y (int): row index of the pixel in raster space
+
+    Returns:
+        True if the pixel qualifies as a seed pixel, False otherwise
+    """
+    # if this can be a seed pixel and hasn't already been
+    # calculated, put it on the stack
+    return (flow_dir_raster.is_local_high_point(x, y) and
+            is_close(sediment_deposition_raster.get(x, y),
+                     sediment_deposition_raster.nodata))
+
+
+cdef route_sed_dep(int x, int y,
+        ManagedFlowDirRaster mfd_flow_direction_raster,
+        _ManagedRaster e_prime_raster, _ManagedRaster f_raster,
+        _ManagedRaster sdr_raster, _ManagedRaster sediment_deposition_raster):
+    """Perform routed operations for SDR.
+
+    Args:
+        x (int): column index of the pixel in raster space
+        y (int): row index of the pixel in raster space
+
+    Returns:
+        list of integer indexes of pixels to push onto the stack.
+        Flat indexes are used.
+    """
+    cdef float f_j_weighted_sum = 0
+    cdef float downslope_sdr_weighted_sum = 0
+    cdef float sdr_i, sdr_j, f_j
+    cdef bint upslope_neighbors_processed
+    cdef vector[long] next_pixels
+    # (sum over j ∈ J of f_j * p(i,j) in the equation for t_i)
+    # calculate the upslope f_j contribution to this pixel,
+    # the weighted sum of flux flowing onto this pixel from
+    # all neighbors
+    for neighbor in (
+            mfd_flow_direction_raster.get_upslope_neighbors(
+                x, y)):
+
+        f_j = f_raster.get(neighbor.x, neighbor.y)
+        if is_close(f_j, f_raster.nodata):
+            continue
+
+        # add the neighbor's flux value, weighted by the
+        # flow proportion
+        f_j_weighted_sum += neighbor.flow_proportion * f_j
+
+    # calculate sum of SDR values of immediate downslope
+    # neighbors, weighted by proportion of flow into each
+    # neighbor
+    # (sum over k ∈ K of SDR_k * p(i,k) in the equation above)
+    for neighbor in (
+            mfd_flow_direction_raster.get_downslope_neighbors(
+                x, y)):
+        sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
+        if is_close(sdr_j, sdr_raster.nodata):
+            continue
+        if sdr_j == 0:
+            # this means it's a stream, for SDR deposition
+            # purposes, we set sdr to 1 to indicate this
+            # is the last step on which to retain sediment
+            sdr_j = 1
+
+        downslope_sdr_weighted_sum += (
+            sdr_j * neighbor.flow_proportion)
+
+        # check if we can add neighbor j to the stack yet
+        #
+        # if there is a downslope neighbor it
+        # couldn't have been pushed on the processing
+        # stack yet, because the upslope was just
+        # completed
+        upslope_neighbors_processed = True
+        # iterate over each neighbor-of-neighbor
+        for neighbor_of_neighbor in (
+                mfd_flow_direction_raster.get_upslope_neighbors(
+                    neighbor.x, neighbor.y)):
+            # no need to push the one we're currently
+            # calculating back onto the stack
+            if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
+                    neighbor.direction):
+                continue
+            if is_close(
+                    sediment_deposition_raster.get(
+                        neighbor_of_neighbor.x, neighbor_of_neighbor.y
+                    ), sediment_deposition_raster.nodata):
+                upslope_neighbors_processed = False
+                break
+        # if all upslope neighbors of neighbor j are
+        # processed, we can push j onto the stack.
+        if upslope_neighbors_processed:
+            next_pixels.push_back(
+                neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
+
+    # nodata pixels should propagate to the results
+    sdr_i = sdr_raster.get(x, y)
+    if is_close(sdr_i, sdr_raster.nodata):
+        return next_pixels
+    e_prime_i = e_prime_raster.get(x, y)
+    if is_close(e_prime_i, e_prime_raster.nodata):
+        return next_pixels
+
+    # This condition reflects property A in the user's guide.
+    if downslope_sdr_weighted_sum < sdr_i:
+        # i think this happens because of our low resolution
+        # flow direction, it's okay to zero out.
+        downslope_sdr_weighted_sum = sdr_i
+
+    # these correspond to the full equations for
+    # dr_i, t_i, and f_i given in the docstring
+    if sdr_i == 1:
+        # This reflects property B in the user's guide and is
+        # an edge case to avoid division-by-zero.
+        dr_i = 1
+    else:
+        dr_i = (downslope_sdr_weighted_sum - sdr_i) / (1 - sdr_i)
+
+    # Lisa's modified equations
+    t_i = dr_i * f_j_weighted_sum  # deposition, a.k.a trapped sediment
+    f_i = (1 - dr_i) * f_j_weighted_sum + e_prime_i  # flux
+
+    # On large flow paths, it's possible for dr_i, f_i and t_i
+    # to have very small negative values that are numerically
+    # equivalent to 0. These negative values were raising
+    # questions on the forums and it's easier to clamp the
+    # values here than to explain IEEE 754.
+    if dr_i < 0:
+        dr_i = 0
+    if t_i < 0:
+        t_i = 0
+    if f_i < 0:
+        f_i = 0
+
+    sediment_deposition_raster.set(x, y, t_i)
+    f_raster.set(x, y, f_i)
+    return next_pixels
 
 def calculate_sediment_deposition(
         mfd_flow_direction_path, e_prime_path, f_path, sdr_path,
@@ -97,146 +244,15 @@ def calculate_sediment_deposition(
     cdef _ManagedRaster sediment_deposition_raster = _ManagedRaster(
         target_sediment_deposition_path, 1, True)
 
-    def seed_fn(x, y):
-        """Determine if a given pixel can be a seed pixel.
-
-        To be a seed pixel, it must be a local high point and have data in
-        the sediment deposition raster.
-
-        Args:
-            x (int): column index of the pixel in raster space
-            y (int): row index of the pixel in raster space
-
-        Returns:
-            True if the pixel qualifies as a seed pixel, False otherwise
-        """
-        # if this can be a seed pixel and hasn't already been
-        # calculated, put it on the stack
-        return (mfd_flow_direction_raster.is_local_high_point(x, y) and
-                is_close(sediment_deposition_raster.get(x, y),
-                         sediment_deposition_raster.nodata))
-
-    def route_fn(x, y):
-        """Perform routed operations for SDR.
-
-        Args:
-            x (int): column index of the pixel in raster space
-            y (int): row index of the pixel in raster space
-
-        Returns:
-            list of integer indexes of pixels to push onto the stack.
-            Flat indexes are used.
-        """
-        cdef float f_j_weighted_sum
-        cdef float downslope_sdr_weighted_sum, sdr_i, sdr_j
-        # (sum over j ∈ J of f_j * p(i,j) in the equation for t_i)
-        # calculate the upslope f_j contribution to this pixel,
-        # the weighted sum of flux flowing onto this pixel from
-        # all neighbors
-        f_j_weighted_sum = 0
-        for neighbor in (
-                mfd_flow_direction_raster.get_upslope_neighbors(
-                    x, y)):
-
-            f_j = f_raster.get(neighbor.x, neighbor.y)
-            if is_close(f_j, f_raster.nodata):
-                continue
-
-            # add the neighbor's flux value, weighted by the
-            # flow proportion
-            f_j_weighted_sum += neighbor.flow_proportion * f_j
-
-        # calculate sum of SDR values of immediate downslope
-        # neighbors, weighted by proportion of flow into each
-        # neighbor
-        # (sum over k ∈ K of SDR_k * p(i,k) in the equation above)
-        downslope_sdr_weighted_sum = 0
-        to_push = []
-        for neighbor in (
-                mfd_flow_direction_raster.get_downslope_neighbors(
-                    x, y)):
-            sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
-            if is_close(sdr_j, sdr_raster.nodata):
-                continue
-            if sdr_j == 0:
-                # this means it's a stream, for SDR deposition
-                # purposes, we set sdr to 1 to indicate this
-                # is the last step on which to retain sediment
-                sdr_j = 1
-
-            downslope_sdr_weighted_sum += (
-                sdr_j * neighbor.flow_proportion)
-
-            # check if we can add neighbor j to the stack yet
-            #
-            # if there is a downslope neighbor it
-            # couldn't have been pushed on the processing
-            # stack yet, because the upslope was just
-            # completed
-            upslope_neighbors_processed = 1
-            # iterate over each neighbor-of-neighbor
-            for neighbor_of_neighbor in (
-                    mfd_flow_direction_raster.get_upslope_neighbors(
-                        neighbor.x, neighbor.y)):
-                # no need to push the one we're currently
-                # calculating back onto the stack
-                if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
-                        neighbor.direction):
-                    continue
-                if is_close(
-                        sediment_deposition_raster.get(
-                            neighbor_of_neighbor.x, neighbor_of_neighbor.y
-                        ), sediment_deposition_raster.nodata):
-                    upslope_neighbors_processed = 0
-                    break
-            # if all upslope neighbors of neighbor j are
-            # processed, we can push j onto the stack.
-            if upslope_neighbors_processed:
-                to_push.append(
-                    neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
-
-        # nodata pixels should propagate to the results
-        sdr_i = sdr_raster.get(x, y)
-        if is_close(sdr_i, sdr_raster.nodata):
-            return to_push
-        e_prime_i = e_prime_raster.get(x, y)
-        if is_close(e_prime_i, e_prime_raster.nodata):
-            return to_push
-
-        # This condition reflects property A in the user's guide.
-        if downslope_sdr_weighted_sum < sdr_i:
-            # i think this happens because of our low resolution
-            # flow direction, it's okay to zero out.
-            downslope_sdr_weighted_sum = sdr_i
-
-        # these correspond to the full equations for
-        # dr_i, t_i, and f_i given in the docstring
-        if sdr_i == 1:
-            # This reflects property B in the user's guide and is
-            # an edge case to avoid division-by-zero.
-            dr_i = 1
-        else:
-            dr_i = (downslope_sdr_weighted_sum - sdr_i) / (1 - sdr_i)
-
-        # Lisa's modified equations
-        t_i = dr_i * f_j_weighted_sum  # deposition, a.k.a trapped sediment
-        f_i = (1 - dr_i) * f_j_weighted_sum + e_prime_i  # flux
-
-        # On large flow paths, it's possible for dr_i, f_i and t_i
-        # to have very small negative values that are numerically
-        # equivalent to 0. These negative values were raising
-        # questions on the forums and it's easier to clamp the
-        # values here than to explain IEEE 754.
-        if dr_i < 0:
-            dr_i = 0
-        if t_i < 0:
-            t_i = 0
-        if f_i < 0:
-            f_i = 0
-
-        sediment_deposition_raster.set(x, y, t_i)
-        f_raster.set(x, y, f_i)
-        return to_push
-
-    route(mfd_flow_direction_path, seed_fn, route_fn)
+    route(
+        flow_dir_path=mfd_flow_direction_path,
+        seed_fn=sed_dep_seed_fn,
+        route_fn=route_sed_dep,
+        seed_fn_args=[
+            mfd_flow_direction_raster,
+            sediment_deposition_raster],
+        route_fn_args=[
+            mfd_flow_direction_raster,
+            e_prime_raster, f_raster,
+            sdr_raster, sediment_deposition_raster])
     sediment_deposition_raster.close()

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -1,4 +1,4 @@
-# cython: profile=False
+# cython: profile=True
 # cython: language_level=3
 # distutils: language = c++
 import logging
@@ -17,7 +17,7 @@ from ..managed_raster.managed_raster cimport ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
 from ..managed_raster.managed_raster cimport INFLOW_OFFSETS
-from ..managed_raster.managed_raster cimport route
+# from ..managed_raster.managed_raster cimport route
 
 cdef extern from "time.h" nogil:
     ctypedef int time_t
@@ -26,149 +26,206 @@ cdef extern from "time.h" nogil:
 LOGGER = logging.getLogger(__name__)
 
 
-cdef bint sed_dep_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_raster,
-        ManagedRaster sediment_deposition_raster):
-    """Determine if a given pixel can be a seed pixel.
+cdef cppclass SeedFn:
 
-    To be a seed pixel, it must be a local high point and have data in
-    the sediment deposition raster.
+    SeedFn() except +
+    SeedFn(ManagedFlowDirRaster, ManagedRaster) except +
 
-    Args:
-        x (int): column index of the pixel in raster space
-        y (int): row index of the pixel in raster space
+    ManagedFlowDirRaster flow_dir_raster
+    ManagedRaster sed_dep_raster
 
-    Returns:
-        True if the pixel qualifies as a seed pixel, False otherwise
-    """
-    cdef bint is_local_high_point = flow_dir_raster.is_local_high_point(x, y)
-    cdef bint is_undefined = is_close(sediment_deposition_raster.get(x, y),
-                                      sediment_deposition_raster.nodata)
-    # if this can be a seed pixel and hasn't already been
-    # calculated, put it on the stack
-    return is_local_high_point and is_undefined
+    bint get "operator()"(int x, int y):
+        cdef bint is_local_high_point = flow_dir_raster.is_local_high_point(x, y)
+        cdef bint is_undefined = is_close(sed_dep_raster.get(x, y),
+                                          sed_dep_raster.nodata)
+        # if this can be a seed pixel and hasn't already been
+        # calculated, put it on the stack
+        return is_local_high_point and is_undefined
 
 
-cdef route_sed_dep(int x, int y,
-        ManagedFlowDirRaster mfd_flow_direction_raster,
-        ManagedRaster e_prime_raster, ManagedRaster f_raster,
-        ManagedRaster sdr_raster, ManagedRaster sediment_deposition_raster):
-    """Perform routed operations for SDR.
+cdef cppclass RouteFn:
 
-    Args:
-        x (int): column index of the pixel in raster space
-        y (int): row index of the pixel in raster space
+    RouteFn() except +
+    RouteFn(
+        ManagedFlowDirRaster,
+        ManagedRaster, ManagedRaster,
+        ManagedRaster, ManagedRaster) except +
 
-    Returns:
-        list of integer indexes of pixels to push onto the stack.
-        Flat indexes are used.
-    """
-    cdef float f_j_weighted_sum = 0
-    cdef float downslope_sdr_weighted_sum = 0
-    cdef float sdr_i, sdr_j, f_j
-    cdef bint upslope_neighbors_processed
-    cdef vector[long] next_pixels
-    # (sum over j ∈ J of f_j * p(i,j) in the equation for t_i)
-    # calculate the upslope f_j contribution to this pixel,
-    # the weighted sum of flux flowing onto this pixel from
-    # all neighbors
-    for neighbor in (
-            mfd_flow_direction_raster.get_upslope_neighbors(
-                x, y)):
+    ManagedFlowDirRaster mfd_flow_direction_raster
+    ManagedRaster e_prime_raster
+    ManagedRaster f_raster
+    ManagedRaster sdr_raster
+    ManagedRaster sediment_deposition_raster
 
-        f_j = f_raster.get(neighbor.x, neighbor.y)
-        if is_close(f_j, f_raster.nodata):
-            continue
 
-        # add the neighbor's flux value, weighted by the
-        # flow proportion
-        f_j_weighted_sum += neighbor.flow_proportion * f_j
+    vector[long] get "operator()"(int x, int y):
+        """Perform routed operations for SDR.
 
-    # calculate sum of SDR values of immediate downslope
-    # neighbors, weighted by proportion of flow into each
-    # neighbor
-    # (sum over k ∈ K of SDR_k * p(i,k) in the equation above)
-    for neighbor in (
-            mfd_flow_direction_raster.get_downslope_neighbors(
-                x, y)):
-        sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
-        if is_close(sdr_j, sdr_raster.nodata):
-            continue
-        if sdr_j == 0:
-            # this means it's a stream, for SDR deposition
-            # purposes, we set sdr to 1 to indicate this
-            # is the last step on which to retain sediment
-            sdr_j = 1
+        Args:
+            x (int): column index of the pixel in raster space
+            y (int): row index of the pixel in raster space
 
-        downslope_sdr_weighted_sum += (
-            sdr_j * neighbor.flow_proportion)
-
-        # check if we can add neighbor j to the stack yet
-        #
-        # if there is a downslope neighbor it
-        # couldn't have been pushed on the processing
-        # stack yet, because the upslope was just
-        # completed
-        upslope_neighbors_processed = True
-        # iterate over each neighbor-of-neighbor
-        for neighbor_of_neighbor in (
+        Returns:
+            list of integer indexes of pixels to push onto the stack.
+            Flat indexes are used.
+        """
+        cdef float f_j_weighted_sum = 0
+        cdef float downslope_sdr_weighted_sum = 0
+        cdef float sdr_i, sdr_j, f_j
+        cdef bint upslope_neighbors_processed
+        cdef vector[long] next_pixels
+        # (sum over j ∈ J of f_j * p(i,j) in the equation for t_i)
+        # calculate the upslope f_j contribution to this pixel,
+        # the weighted sum of flux flowing onto this pixel from
+        # all neighbors
+        for neighbor in (
                 mfd_flow_direction_raster.get_upslope_neighbors(
-                    neighbor.x, neighbor.y)):
-            # no need to push the one we're currently
-            # calculating back onto the stack
-            if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
-                    neighbor.direction):
+                    x, y)):
+
+            f_j = f_raster.get(neighbor.x, neighbor.y)
+            if is_close(f_j, f_raster.nodata):
                 continue
-            if is_close(
-                    sediment_deposition_raster.get(
-                        neighbor_of_neighbor.x, neighbor_of_neighbor.y
-                    ), sediment_deposition_raster.nodata):
-                upslope_neighbors_processed = False
-                break
-        # if all upslope neighbors of neighbor j are
-        # processed, we can push j onto the stack.
-        if upslope_neighbors_processed:
-            next_pixels.push_back(
-                neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
 
-    # nodata pixels should propagate to the results
-    sdr_i = sdr_raster.get(x, y)
-    e_prime_i = e_prime_raster.get(x, y)
-    if not (is_close(sdr_i, sdr_raster.nodata) or
-            is_close(e_prime_i, e_prime_raster.nodata)):
-        # This condition reflects property A in the user's guide.
-        if downslope_sdr_weighted_sum < sdr_i:
-            # i think this happens because of our low resolution
-            # flow direction, it's okay to zero out.
-            downslope_sdr_weighted_sum = sdr_i
+            # add the neighbor's flux value, weighted by the
+            # flow proportion
+            f_j_weighted_sum += neighbor.flow_proportion * f_j
 
-        # these correspond to the full equations for
-        # dr_i, t_i, and f_i given in the docstring
-        if sdr_i == 1:
-            # This reflects property B in the user's guide and is
-            # an edge case to avoid division-by-zero.
-            dr_i = 1
-        else:
-            dr_i = (downslope_sdr_weighted_sum - sdr_i) / (1 - sdr_i)
+        # calculate sum of SDR values of immediate downslope
+        # neighbors, weighted by proportion of flow into each
+        # neighbor
+        # (sum over k ∈ K of SDR_k * p(i,k) in the equation above)
+        for neighbor in (
+                mfd_flow_direction_raster.get_downslope_neighbors(
+                    x, y)):
+            sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
+            if is_close(sdr_j, sdr_raster.nodata):
+                continue
+            if sdr_j == 0:
+                # this means it's a stream, for SDR deposition
+                # purposes, we set sdr to 1 to indicate this
+                # is the last step on which to retain sediment
+                sdr_j = 1
 
-        # Lisa's modified equations
-        t_i = dr_i * f_j_weighted_sum  # deposition, a.k.a trapped sediment
-        f_i = (1 - dr_i) * f_j_weighted_sum + e_prime_i  # flux
+            downslope_sdr_weighted_sum += (
+                sdr_j * neighbor.flow_proportion)
 
-        # On large flow paths, it's possible for dr_i, f_i and t_i
-        # to have very small negative values that are numerically
-        # equivalent to 0. These negative values were raising
-        # questions on the forums and it's easier to clamp the
-        # values here than to explain IEEE 754.
-        if dr_i < 0:
-            dr_i = 0
-        if t_i < 0:
-            t_i = 0
-        if f_i < 0:
-            f_i = 0
-        sediment_deposition_raster.set(x, y, t_i)
-        f_raster.set(x, y, f_i)
+            # check if we can add neighbor j to the stack yet
+            #
+            # if there is a downslope neighbor it
+            # couldn't have been pushed on the processing
+            # stack yet, because the upslope was just
+            # completed
+            upslope_neighbors_processed = True
+            # iterate over each neighbor-of-neighbor
+            for neighbor_of_neighbor in (
+                    mfd_flow_direction_raster.get_upslope_neighbors(
+                        neighbor.x, neighbor.y)):
+                # no need to push the one we're currently
+                # calculating back onto the stack
+                if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
+                        neighbor.direction):
+                    continue
+                if is_close(
+                        sediment_deposition_raster.get(
+                            neighbor_of_neighbor.x, neighbor_of_neighbor.y
+                        ), sediment_deposition_raster.nodata):
+                    upslope_neighbors_processed = False
+                    break
+            # if all upslope neighbors of neighbor j are
+            # processed, we can push j onto the stack.
+            if upslope_neighbors_processed:
+                next_pixels.push_back(
+                    neighbor.y * mfd_flow_direction_raster.raster_x_size + neighbor.x)
 
-    return next_pixels
+        # nodata pixels should propagate to the results
+        sdr_i = sdr_raster.get(x, y)
+        e_prime_i = e_prime_raster.get(x, y)
+        if not (is_close(sdr_i, sdr_raster.nodata) or
+                is_close(e_prime_i, e_prime_raster.nodata)):
+            # This condition reflects property A in the user's guide.
+            if downslope_sdr_weighted_sum < sdr_i:
+                # i think this happens because of our low resolution
+                # flow direction, it's okay to zero out.
+                downslope_sdr_weighted_sum = sdr_i
+
+            # these correspond to the full equations for
+            # dr_i, t_i, and f_i given in the docstring
+            if sdr_i == 1:
+                # This reflects property B in the user's guide and is
+                # an edge case to avoid division-by-zero.
+                dr_i = 1
+            else:
+                dr_i = (downslope_sdr_weighted_sum - sdr_i) / (1 - sdr_i)
+
+            # Lisa's modified equations
+            t_i = dr_i * f_j_weighted_sum  # deposition, a.k.a trapped sediment
+            f_i = (1 - dr_i) * f_j_weighted_sum + e_prime_i  # flux
+
+            # On large flow paths, it's possible for dr_i, f_i and t_i
+            # to have very small negative values that are numerically
+            # equivalent to 0. These negative values were raising
+            # questions on the forums and it's easier to clamp the
+            # values here than to explain IEEE 754.
+            if dr_i < 0:
+                dr_i = 0
+            if t_i < 0:
+                t_i = 0
+            if f_i < 0:
+                f_i = 0
+            sediment_deposition_raster.set(x, y, t_i)
+            f_raster.set(x, y, f_i)
+
+        return next_pixels
+
+cdef route(flow_dir_path, SeedFn seed_fn, RouteFn route_fn):
+    """
+    Args:
+        seed_fn (callable): function that accepts an (x, y) coordinate
+            and returns a bool indicating if the pixel is a seed
+        route_fn (callable): function that accepts an (x, y) coordinate
+            and performs whatever routing operation is needed on that pixel.
+
+    Returns:
+        None
+    """
+
+    cdef long win_xsize, win_ysize, xoff, yoff, flat_index
+    cdef int col_index, row_index, global_col, global_row
+    cdef stack[long] processing_stack
+    cdef long n_cols, n_rows
+    cdef vector[long] next_pixels
+
+    flow_dir_info = pygeoprocessing.get_raster_info(flow_dir_path)
+    n_cols, n_rows = flow_dir_info['raster_size']
+
+    for offset_dict in pygeoprocessing.iterblocks(
+            (flow_dir_path, 1), offset_only=True, largest_block=0):
+        # use cython variables to avoid python overhead of dict values
+        win_xsize = offset_dict['win_xsize']
+        win_ysize = offset_dict['win_ysize']
+        xoff = offset_dict['xoff']
+        yoff = offset_dict['yoff']
+        for row_index in range(win_ysize):
+            global_row = yoff + row_index
+            for col_index in range(win_xsize):
+
+                global_col = xoff + col_index
+
+                if seed_fn.get(global_col, global_row):
+                    processing_stack.push(global_row * n_cols + global_col)
+
+        while processing_stack.size() > 0:
+            # loop invariant, we don't push a cell on the stack that
+            # hasn't already been set for processing.
+            flat_index = processing_stack.top()
+            processing_stack.pop()
+            global_row = flat_index // n_cols
+            global_col = flat_index % n_cols
+
+            next_pixels = route_fn.get(global_col, global_row)
+            for index in next_pixels:
+                processing_stack.push(index)
+
 
 def calculate_sediment_deposition(
         mfd_flow_direction_path, e_prime_path, f_path, sdr_path,
@@ -242,15 +299,22 @@ def calculate_sediment_deposition(
     cdef ManagedRaster sediment_deposition_raster = ManagedRaster(
         target_sediment_deposition_path, 1, True)
 
+    cdef SeedFn seed_fn
+    seed_fn.flow_dir_raster = mfd_flow_direction_raster
+    seed_fn.sed_dep_raster = sediment_deposition_raster
+
+    cdef RouteFn route_fn
+    route_fn.mfd_flow_direction_raster = mfd_flow_direction_raster
+    route_fn.e_prime_raster = e_prime_raster
+    route_fn.f_raster = f_raster
+    route_fn.sdr_raster = sdr_raster
+    route_fn.sediment_deposition_raster = sediment_deposition_raster
+
     route(
         flow_dir_path=mfd_flow_direction_path,
-        seed_fn=sed_dep_seed_fn,
-        route_fn=route_sed_dep,
-        seed_fn_args=[
-            mfd_flow_direction_raster,
-            sediment_deposition_raster],
-        route_fn_args=[
-            mfd_flow_direction_raster,
-            e_prime_raster, f_raster,
-            sdr_raster, sediment_deposition_raster])
+        seed_fn=seed_fn,
+        route_fn=route_fn)
     sediment_deposition_raster.close()
+
+
+

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -40,11 +40,12 @@ cdef bint sed_dep_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_raster,
     Returns:
         True if the pixel qualifies as a seed pixel, False otherwise
     """
+    cdef bint is_local_high_point = flow_dir_raster.is_local_high_point(x, y)
+    cdef bint is_undefined = is_close(sediment_deposition_raster.get(x, y),
+                                      sediment_deposition_raster.nodata)
     # if this can be a seed pixel and hasn't already been
     # calculated, put it on the stack
-    return (flow_dir_raster.is_local_high_point(x, y) and
-            is_close(sediment_deposition_raster.get(x, y),
-                     sediment_deposition_raster.nodata))
+    return is_local_high_point and is_undefined
 
 
 cdef route_sed_dep(int x, int y,

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
@@ -30,6 +30,113 @@ cdef extern from "time.h" nogil:
 LOGGER = logging.getLogger(__name__)
 
 cdef int N_MONTHS = 12
+cdef float TARGET_NODATA = -1e32
+
+
+def local_recharge_seed_fn(x, y, ManagedFlowDirRaster flow_raster):
+    return flow_raster.is_local_high_point(x, y)
+
+
+def local_recharge_route_fn(x, y, ManagedFlowDirRaster flow_raster, alpha_month_map,
+        beta_i, gamma,
+        et0_m_raster_list, precip_m_raster_list, qf_m_raster_list, kc_m_raster_list,
+        _ManagedRaster target_li_raster, _ManagedRaster target_li_avail_raster,
+        _ManagedRaster target_l_sum_avail_raster, _ManagedRaster target_aet_raster,
+        _ManagedRaster target_pi_raster):
+    cdef double pet_m, p_m, qf_m, et0_m, aet_i, p_i, qf_i, l_i, l_avail_i
+    cdef _ManagedRaster et0_m_raster, qf_m_raster, kc_m_raster
+    cdef numpy.ndarray[numpy.npy_float32, ndim=1] alpha_month_array = (
+        numpy.array(
+            [alpha[1] for alpha in sorted(alpha_month_map.items())],
+            dtype=numpy.float32))
+
+    cdef bint upslope_defined = True
+    cdef float l_sum_avail_i = target_l_sum_avail_raster.get(x, y)
+
+    if not is_close(l_sum_avail_i, target_l_sum_avail_raster.nodata):
+        # already defined
+        return []
+
+    # Equation 7, calculate L_sum_avail_i if possible, skip
+    # otherwise
+    # initialize to 0 so we indicate we haven't tracked any
+    # mfd values yet
+    l_sum_avail_i = 0
+    for neighbor in flow_raster.get_upslope_neighbors(x, y):
+        # pixel flows inward, check upslope
+        l_sum_avail_j = target_l_sum_avail_raster.get(
+            neighbor.x, neighbor.y)
+        if is_close(l_sum_avail_j, target_l_sum_avail_raster.nodata):
+            upslope_defined = False
+            break
+        l_avail_j = target_li_avail_raster.get(
+            neighbor.x, neighbor.y)
+        # A step of Equation 7
+        l_sum_avail_i += (
+            l_sum_avail_j + l_avail_j) * neighbor.flow_proportion
+    # calculate l_sum_avail_i by summing all the valid
+    # directions then normalizing by the sum of the mfd
+    # direction weights (Equation 8)
+    if upslope_defined:
+        # Equation 7
+        target_l_sum_avail_raster.set(x, y, l_sum_avail_i)
+    else:
+        # if not defined, we'll get it on another pass
+        return []
+
+    aet_i = 0
+    p_i = 0
+    qf_i = 0
+
+    for m_index in range(12):
+        precip_m_raster = (
+            <_ManagedRaster?>precip_m_raster_list[m_index])
+        qf_m_raster = (
+            <_ManagedRaster?>qf_m_raster_list[m_index])
+        et0_m_raster = (
+            <_ManagedRaster?>et0_m_raster_list[m_index])
+        kc_m_raster = (
+            <_ManagedRaster?>kc_m_raster_list[m_index])
+
+        p_m = precip_m_raster.get(x, y)
+        if not is_close(p_m, precip_m_raster.nodata):
+            p_i += p_m
+        else:
+            p_m = 0
+
+        qf_m = qf_m_raster.get(x, y)
+        if not is_close(qf_m, qf_m_raster.nodata):
+            qf_i += qf_m
+        else:
+            qf_m = 0
+
+        kc_m = kc_m_raster.get(x, y)
+        pet_m = 0
+        et0_m = et0_m_raster.get(x, y)
+        if not (
+                is_close(kc_m, kc_m_raster.nodata) or
+                is_close(et0_m, et0_m_raster.nodata)):
+            # Equation 6
+            pet_m = kc_m * et0_m
+
+        # Equation 4/5
+        aet_i += min(
+            pet_m,
+            p_m - qf_m +
+            alpha_month_array[m_index]*beta_i*l_sum_avail_i)
+
+    l_i = (p_i - qf_i - aet_i)
+    l_avail_i = min(gamma * l_i, l_i)
+
+    target_pi_raster.set(x, y, p_i)
+    target_aet_raster.set(x, y, aet_i)
+    target_li_raster.set(x, y, l_i)
+    target_li_avail_raster.set(x, y, l_avail_i)
+
+    next_pixels = []
+    for neighbor in flow_raster.get_downslope_neighbors(x, y):
+        next_pixels.append(neighbor.y * flow_raster.raster_x_size + neighbor.x)
+    return next_pixels
 
 
 def calculate_local_recharge(
@@ -105,136 +212,126 @@ def calculate_local_recharge(
     for kc_m_path in kc_path_list:
         kc_m_raster_list.append(_ManagedRaster(kc_m_path, 1, 0))
 
-    target_nodata = -1e32
+    TARGET_NODATA = -1e32
     pygeoprocessing.new_raster_from_base(
-        flow_dir_mfd_path, target_li_path, gdal.GDT_Float32, [target_nodata],
-        fill_value_list=[target_nodata])
+        flow_dir_mfd_path, target_li_path, gdal.GDT_Float32, [TARGET_NODATA],
+        fill_value_list=[TARGET_NODATA])
     cdef _ManagedRaster target_li_raster = _ManagedRaster(
         target_li_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_li_avail_path, gdal.GDT_Float32,
-        [target_nodata], fill_value_list=[target_nodata])
+        [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
     cdef _ManagedRaster target_li_avail_raster = _ManagedRaster(
         target_li_avail_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_l_sum_avail_path, gdal.GDT_Float32,
-        [target_nodata], fill_value_list=[target_nodata])
+        [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
     cdef _ManagedRaster target_l_sum_avail_raster = _ManagedRaster(
         target_l_sum_avail_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
-        flow_dir_mfd_path, target_aet_path, gdal.GDT_Float32, [target_nodata],
-        fill_value_list=[target_nodata])
+        flow_dir_mfd_path, target_aet_path, gdal.GDT_Float32, [TARGET_NODATA],
+        fill_value_list=[TARGET_NODATA])
     cdef _ManagedRaster target_aet_raster = _ManagedRaster(
         target_aet_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
-        flow_dir_mfd_path, target_pi_path, gdal.GDT_Float32, [target_nodata],
-        fill_value_list=[target_nodata])
+        flow_dir_mfd_path, target_pi_path, gdal.GDT_Float32, [TARGET_NODATA],
+        fill_value_list=[TARGET_NODATA])
     cdef _ManagedRaster target_pi_raster = _ManagedRaster(
         target_pi_path, 1, 1)
 
-    def seed_fn(x, y):
-        return flow_raster.is_local_high_point(x, y)
+    route(
+        flow_dir_path=flow_dir_mfd_path,
+        seed_fn=local_recharge_seed_fn,
+        route_fn=local_recharge_route_fn,
+        seed_fn_args=[flow_raster],
+        route_fn_args=[flow_raster, alpha_month_map, beta_i, gamma,
+            et0_m_raster_list, precip_m_raster_list, qf_m_raster_list, kc_m_raster_list,
+            target_li_raster, target_li_avail_raster,
+            target_l_sum_avail_raster, target_aet_raster,
+            target_pi_raster])
 
-    def route_fn(xi, yi):
-        cdef double pet_m, p_m, qf_m, et0_m, aet_i, p_i, qf_i, l_i, l_avail_i
-        cdef _ManagedRaster et0_m_raster, qf_m_raster, kc_m_raster
-        cdef numpy.ndarray[numpy.npy_float32, ndim=1] alpha_month_array = (
-            numpy.array(
-                [x[1] for x in sorted(alpha_month_map.items())],
-                dtype=numpy.float32))
-        l_sum_avail_i = target_l_sum_avail_raster.get(xi, yi)
-        if not is_close(l_sum_avail_i, target_l_sum_avail_raster.nodata):
-            # already defined
-            return []
 
-        # Equation 7, calculate L_sum_avail_i if possible, skip
-        # otherwise
-        upslope_defined = 1
-        # initialize to 0 so we indicate we haven't tracked any
-        # mfd values yet
-        l_sum_avail_i = 0
-        for neighbor in flow_raster.get_upslope_neighbors(xi, yi):
-            # pixel flows inward, check upslope
-            l_sum_avail_j = target_l_sum_avail_raster.get(
-                neighbor.x, neighbor.y)
-            if is_close(l_sum_avail_j, target_l_sum_avail_raster.nodata):
-                upslope_defined = 0
-                break
-            l_avail_j = target_li_avail_raster.get(
-                neighbor.x, neighbor.y)
-            # A step of Equation 7
-            l_sum_avail_i += (
-                l_sum_avail_j + l_avail_j) * neighbor.flow_proportion
-        # calculate l_sum_avail_i by summing all the valid
-        # directions then normalizing by the sum of the mfd
-        # direction weights (Equation 8)
-        if upslope_defined:
-            # Equation 7
-            target_l_sum_avail_raster.set(xi, yi, l_sum_avail_i)
+def baseflow_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_mfd_raster,
+        _ManagedRaster stream_raster):
+    """Determine whether the pixel at (x, y) is a seed pixel.
+
+    Args:
+        x (int): x coordinate of the pixel
+        y (int): y coordinate of the pixel
+
+    Returns:
+        True if the pixel qualifies as a seed pixel, False otherwise
+    """
+    cdef int stream_val
+    cdef int flow_dir_s = <int>flow_dir_mfd_raster.get(x, y)
+    if is_close(flow_dir_s, flow_dir_mfd_raster.nodata):
+        return False
+
+    # search for a pixel that has no downslope neighbors,
+    # or whose downslope neighbors all have nodata in the stream raster (?)
+    for neighbor in flow_dir_mfd_raster.get_downslope_neighbors(x, y):
+        stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
+        if stream_val != stream_raster.nodata:
+            return False
+    return True
+
+
+def baseflow_route_fn(x, y, ManagedFlowDirRaster flow_dir_mfd_raster,
+        _ManagedRaster l_raster, _ManagedRaster l_avail_raster,
+        _ManagedRaster l_sum_raster, _ManagedRaster stream_raster,
+        _ManagedRaster target_b_raster, _ManagedRaster target_b_sum_raster):
+    cdef int stream_val
+    cdef float b_i, l_j, l_avail_j, l_sum_j
+    cdef float b_sum_i = target_b_sum_raster.get(x, y)
+    cdef bint downslope_defined = True
+
+    next_pixels = []
+    if not is_close(b_sum_i, TARGET_NODATA):
+        return []
+
+    b_sum_i = 0.0
+    for neighbor in flow_dir_mfd_raster.get_downslope_neighbors(x, y):
+        stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
+        if stream_val:
+            b_sum_i += neighbor.flow_proportion
         else:
-            # if not defined, we'll get it on another pass
-            return []
+            b_sum_j = target_b_sum_raster.get(neighbor.x, neighbor.y)
+            if is_close(b_sum_j, TARGET_NODATA):
+                downslope_defined = False
+                break
+            l_j = l_raster.get(neighbor.x, neighbor.y)
+            l_avail_j = l_avail_raster.get(neighbor.x, neighbor.y)
+            l_sum_j = l_sum_raster.get(neighbor.x, neighbor.y)
 
-        aet_i = 0
-        p_i = 0
-        qf_i = 0
-
-        for m_index in range(12):
-            precip_m_raster = (
-                <_ManagedRaster?>precip_m_raster_list[m_index])
-            qf_m_raster = (
-                <_ManagedRaster?>qf_m_raster_list[m_index])
-            et0_m_raster = (
-                <_ManagedRaster?>et0_m_raster_list[m_index])
-            kc_m_raster = (
-                <_ManagedRaster?>kc_m_raster_list[m_index])
-
-            p_m = precip_m_raster.get(xi, yi)
-            if not is_close(p_m, precip_m_raster.nodata):
-                p_i += p_m
+            if l_sum_j != 0 and (l_sum_j - l_j) != 0:
+                b_sum_i += neighbor.flow_proportion * (
+                    (1 - l_avail_j / l_sum_j) * (
+                        b_sum_j / (l_sum_j - l_j)))
             else:
-                p_m = 0
+                b_sum_i += neighbor.flow_proportion
 
-            qf_m = qf_m_raster.get(xi, yi)
-            if not is_close(qf_m, qf_m_raster.nodata):
-                qf_i += qf_m
-            else:
-                qf_m = 0
+    if not downslope_defined:
+        return []
 
-            kc_m = kc_m_raster.get(xi, yi)
-            pet_m = 0
-            et0_m = et0_m_raster.get(xi, yi)
-            if not (
-                    is_close(kc_m, kc_m_raster.nodata) or
-                    is_close(et0_m, et0_m_raster.nodata)):
-                # Equation 6
-                pet_m = kc_m * et0_m
+    l_i = l_raster.get(x, y)
+    l_sum_i = l_sum_raster.get(x, y)
+    b_sum_i = l_sum_i * b_sum_i
 
-            # Equation 4/5
-            aet_i += min(
-                pet_m,
-                p_m - qf_m +
-                alpha_month_array[m_index]*beta_i*l_sum_avail_i)
+    if l_sum_i != 0:
+        b_i = max(b_sum_i * l_i / l_sum_i, 0.0)
+    else:
+        b_i = 0.0
 
-        l_i = (p_i - qf_i - aet_i)
-        l_avail_i = min(gamma * l_i, l_i)
+    target_b_raster.set(x, y, b_i)
+    target_b_sum_raster.set(x, y, b_sum_i)
 
-        target_pi_raster.set(xi, yi, p_i)
-        target_aet_raster.set(xi, yi, aet_i)
-        target_li_raster.set(xi, yi, l_i)
-        target_li_avail_raster.set(xi, yi, l_avail_i)
-
-        to_push = []
-        for neighbor in flow_raster.get_downslope_neighbors(xi, yi):
-            to_push.append(neighbor.y * flow_raster.raster_x_size + neighbor.x)
-        return to_push
-
-    route(flow_dir_mfd_path, seed_fn, route_fn)
-
+    for neighbor in flow_dir_mfd_raster.get_upslope_neighbors(x, y):
+        next_pixels.append(neighbor.y * flow_dir_mfd_raster.raster_x_size + neighbor.x)
+    return next_pixels
 
 def route_baseflow_sum(
         flow_dir_mfd_path, l_path, l_avail_path, l_sum_path,
@@ -257,14 +354,12 @@ def route_baseflow_sum(
     Returns:
         None.
     """
-    cdef float target_nodata = -1e32
-
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_b_sum_path, gdal.GDT_Float32,
-        [target_nodata], fill_value_list=[target_nodata])
+        [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_b_path, gdal.GDT_Float32,
-        [target_nodata], fill_value_list=[target_nodata])
+        [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
 
     cdef _ManagedRaster target_b_sum_raster = _ManagedRaster(
         target_b_sum_path, 1, 1)
@@ -277,81 +372,12 @@ def route_baseflow_sum(
         flow_dir_mfd_path, 1, 0)
     cdef _ManagedRaster stream_raster = _ManagedRaster(stream_path, 1, 0)
 
-
-    def seed_fn(int x, int y):
-        """Determine whether the pixel at (x, y) is a seed pixel.
-
-        Args:
-            x (int): x coordinate of the pixel
-            y (int): y coordinate of the pixel
-
-        Returns:
-            True if the pixel qualifies as a seed pixel, False otherwise
-        """
-        cdef int stream_val
-        cdef int flow_dir_s = <int>flow_dir_mfd_raster.get(x, y)
-        if is_close(flow_dir_s, flow_dir_mfd_raster.nodata):
-            return False
-
-        # search for a pixel that has no downslope neighbors,
-        # or whose downslope neighbors all have nodata in the stream raster (?)
-        for neighbor in flow_dir_mfd_raster.get_downslope_neighbors(x, y):
-            stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
-            if stream_val != stream_raster.nodata:
-                return False
-        return True
-
-
-    def route_fn(xi, yi):
-        cdef int stream_val
-        cdef float b_i, b_sum_i, l_j, l_avail_j, l_sum_j
-
-        to_push = []
-        b_sum_i = target_b_sum_raster.get(xi, yi)
-        if not is_close(b_sum_i, target_nodata):
-            return []
-
-        b_sum_i = 0.0
-        downslope_defined = 1
-        for neighbor in flow_dir_mfd_raster.get_downslope_neighbors(xi, yi):
-            stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
-            if stream_val:
-                b_sum_i += neighbor.flow_proportion
-            else:
-                b_sum_j = target_b_sum_raster.get(neighbor.x, neighbor.y)
-                if is_close(b_sum_j, target_nodata):
-                    downslope_defined = 0
-                    break
-                l_j = l_raster.get(neighbor.x, neighbor.y)
-                l_avail_j = l_avail_raster.get(neighbor.x, neighbor.y)
-                l_sum_j = l_sum_raster.get(neighbor.x, neighbor.y)
-
-                if l_sum_j != 0 and (l_sum_j - l_j) != 0:
-                    b_sum_i += neighbor.flow_proportion * (
-                        (1 - l_avail_j / l_sum_j) * (
-                            b_sum_j / (l_sum_j - l_j)))
-                else:
-                    b_sum_i += neighbor.flow_proportion
-
-        if not downslope_defined:
-            return []
-
-        l_i = l_raster.get(xi, yi)
-        l_sum_i = l_sum_raster.get(xi, yi)
-        b_sum_i = l_sum_i * b_sum_i
-
-        if l_sum_i != 0:
-            b_i = max(b_sum_i * l_i / l_sum_i, 0.0)
-        else:
-            b_i = 0.0
-
-        target_b_raster.set(xi, yi, b_i)
-        target_b_sum_raster.set(xi, yi, b_sum_i)
-
-        for neighbor in flow_dir_mfd_raster.get_upslope_neighbors(xi, yi):
-            to_push.append(neighbor.y * flow_dir_mfd_raster.raster_x_size + neighbor.x)
-
-        return to_push
-
-    route(flow_dir_mfd_path, seed_fn, route_fn)
+    route(
+        flow_dir_path=flow_dir_mfd_path,
+        seed_fn=baseflow_seed_fn,
+        route_fn=baseflow_route_fn,
+        seed_fn_args=[flow_dir_mfd_raster, stream_raster],
+        route_fn_args=[
+            flow_dir_mfd_raster, l_raster, l_avail_raster, l_sum_raster,
+            stream_raster, target_b_raster, target_b_sum_raster])
 

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
@@ -18,7 +18,7 @@ from libcpp.pair cimport pair
 from libcpp.stack cimport stack
 from libcpp.queue cimport queue
 from libc.time cimport time as ctime
-from ..managed_raster.managed_raster cimport _ManagedRaster
+from ..managed_raster.managed_raster cimport ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
 from ..managed_raster.managed_raster cimport route
@@ -40,11 +40,11 @@ def local_recharge_seed_fn(x, y, ManagedFlowDirRaster flow_raster):
 def local_recharge_route_fn(x, y, ManagedFlowDirRaster flow_raster, alpha_month_map,
         beta_i, gamma,
         et0_m_raster_list, precip_m_raster_list, qf_m_raster_list, kc_m_raster_list,
-        _ManagedRaster target_li_raster, _ManagedRaster target_li_avail_raster,
-        _ManagedRaster target_l_sum_avail_raster, _ManagedRaster target_aet_raster,
-        _ManagedRaster target_pi_raster):
+        ManagedRaster target_li_raster, ManagedRaster target_li_avail_raster,
+        ManagedRaster target_l_sum_avail_raster, ManagedRaster target_aet_raster,
+        ManagedRaster target_pi_raster):
     cdef double pet_m, p_m, qf_m, et0_m, aet_i, p_i, qf_i, l_i, l_avail_i
-    cdef _ManagedRaster et0_m_raster, qf_m_raster, kc_m_raster
+    cdef ManagedRaster et0_m_raster, qf_m_raster, kc_m_raster
     cdef numpy.ndarray[numpy.npy_float32, ndim=1] alpha_month_array = (
         numpy.array(
             [alpha[1] for alpha in sorted(alpha_month_map.items())],
@@ -90,13 +90,13 @@ def local_recharge_route_fn(x, y, ManagedFlowDirRaster flow_raster, alpha_month_
 
     for m_index in range(12):
         precip_m_raster = (
-            <_ManagedRaster?>precip_m_raster_list[m_index])
+            <ManagedRaster?>precip_m_raster_list[m_index])
         qf_m_raster = (
-            <_ManagedRaster?>qf_m_raster_list[m_index])
+            <ManagedRaster?>qf_m_raster_list[m_index])
         et0_m_raster = (
-            <_ManagedRaster?>et0_m_raster_list[m_index])
+            <ManagedRaster?>et0_m_raster_list[m_index])
         kc_m_raster = (
-            <_ManagedRaster?>kc_m_raster_list[m_index])
+            <ManagedRaster?>kc_m_raster_list[m_index])
 
         p_m = precip_m_raster.get(x, y)
         if not is_close(p_m, precip_m_raster.nodata):
@@ -192,55 +192,55 @@ def calculate_local_recharge(
     # always be non-negative
     et0_m_raster_list = []
     for et0_path in et0_path_list:
-        et0_m_raster = _ManagedRaster(et0_path, 1, 0)
+        et0_m_raster = ManagedRaster(et0_path, 1, 0)
         et0_m_raster_list.append(et0_m_raster)
         if et0_m_raster.nodata is None:
             et0_m_raster.nodata = -1
 
     precip_m_raster_list = []
     for precip_m_path in precip_path_list:
-        precip_m_raster = _ManagedRaster(precip_m_path, 1, 0)
+        precip_m_raster = ManagedRaster(precip_m_path, 1, 0)
         precip_m_raster_list.append(precip_m_raster)
         if precip_m_raster.nodata is None:
             precip_m_raster.nodata = -1
 
     qf_m_raster_list = []
     for qf_m_path in qf_m_path_list:
-        qf_m_raster_list.append(_ManagedRaster(qf_m_path, 1, 0))
+        qf_m_raster_list.append(ManagedRaster(qf_m_path, 1, 0))
 
     kc_m_raster_list = []
     for kc_m_path in kc_path_list:
-        kc_m_raster_list.append(_ManagedRaster(kc_m_path, 1, 0))
+        kc_m_raster_list.append(ManagedRaster(kc_m_path, 1, 0))
 
     TARGET_NODATA = -1e32
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_li_path, gdal.GDT_Float32, [TARGET_NODATA],
         fill_value_list=[TARGET_NODATA])
-    cdef _ManagedRaster target_li_raster = _ManagedRaster(
+    cdef ManagedRaster target_li_raster = ManagedRaster(
         target_li_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_li_avail_path, gdal.GDT_Float32,
         [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
-    cdef _ManagedRaster target_li_avail_raster = _ManagedRaster(
+    cdef ManagedRaster target_li_avail_raster = ManagedRaster(
         target_li_avail_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_l_sum_avail_path, gdal.GDT_Float32,
         [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
-    cdef _ManagedRaster target_l_sum_avail_raster = _ManagedRaster(
+    cdef ManagedRaster target_l_sum_avail_raster = ManagedRaster(
         target_l_sum_avail_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_aet_path, gdal.GDT_Float32, [TARGET_NODATA],
         fill_value_list=[TARGET_NODATA])
-    cdef _ManagedRaster target_aet_raster = _ManagedRaster(
+    cdef ManagedRaster target_aet_raster = ManagedRaster(
         target_aet_path, 1, 1)
 
     pygeoprocessing.new_raster_from_base(
         flow_dir_mfd_path, target_pi_path, gdal.GDT_Float32, [TARGET_NODATA],
         fill_value_list=[TARGET_NODATA])
-    cdef _ManagedRaster target_pi_raster = _ManagedRaster(
+    cdef ManagedRaster target_pi_raster = ManagedRaster(
         target_pi_path, 1, 1)
 
     route(
@@ -256,7 +256,7 @@ def calculate_local_recharge(
 
 
 def baseflow_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_mfd_raster,
-        _ManagedRaster stream_raster):
+        ManagedRaster stream_raster):
     """Determine whether the pixel at (x, y) is a seed pixel.
 
     Args:
@@ -281,9 +281,9 @@ def baseflow_seed_fn(int x, int y, ManagedFlowDirRaster flow_dir_mfd_raster,
 
 
 def baseflow_route_fn(x, y, ManagedFlowDirRaster flow_dir_mfd_raster,
-        _ManagedRaster l_raster, _ManagedRaster l_avail_raster,
-        _ManagedRaster l_sum_raster, _ManagedRaster stream_raster,
-        _ManagedRaster target_b_raster, _ManagedRaster target_b_sum_raster):
+        ManagedRaster l_raster, ManagedRaster l_avail_raster,
+        ManagedRaster l_sum_raster, ManagedRaster stream_raster,
+        ManagedRaster target_b_raster, ManagedRaster target_b_sum_raster):
     cdef int stream_val
     cdef float b_i, l_j, l_avail_j, l_sum_j
     cdef float b_sum_i = target_b_sum_raster.get(x, y)
@@ -361,16 +361,16 @@ def route_baseflow_sum(
         flow_dir_mfd_path, target_b_path, gdal.GDT_Float32,
         [TARGET_NODATA], fill_value_list=[TARGET_NODATA])
 
-    cdef _ManagedRaster target_b_sum_raster = _ManagedRaster(
+    cdef ManagedRaster target_b_sum_raster = ManagedRaster(
         target_b_sum_path, 1, 1)
-    cdef _ManagedRaster target_b_raster = _ManagedRaster(
+    cdef ManagedRaster target_b_raster = ManagedRaster(
         target_b_path, 1, 1)
-    cdef _ManagedRaster l_raster = _ManagedRaster(l_path, 1, 0)
-    cdef _ManagedRaster l_avail_raster = _ManagedRaster(l_avail_path, 1, 0)
-    cdef _ManagedRaster l_sum_raster = _ManagedRaster(l_sum_path, 1, 0)
+    cdef ManagedRaster l_raster = ManagedRaster(l_path, 1, 0)
+    cdef ManagedRaster l_avail_raster = ManagedRaster(l_avail_path, 1, 0)
+    cdef ManagedRaster l_sum_raster = ManagedRaster(l_sum_path, 1, 0)
     cdef ManagedFlowDirRaster flow_dir_mfd_raster = ManagedFlowDirRaster(
         flow_dir_mfd_path, 1, 0)
-    cdef _ManagedRaster stream_raster = _ManagedRaster(stream_path, 1, 0)
+    cdef ManagedRaster stream_raster = ManagedRaster(stream_path, 1, 0)
 
     route(
         flow_dir_path=flow_dir_mfd_path,


### PR DESCRIPTION
## Description
Add a function `route` that encapsulates the common structure of routed functions in invest.

All our routed functions use a stack or queue to track which pixels can be processed next. There is some logic specific to the routing algorithm that identifies "seed" pixels (pixels that routing can begin from). Seed pixels are pushed to the stack. 
There is a second chunk of logic that is applied to each pixel on the stack. This is the core of the routing algorithm. It calculates results and pushes neighboring pixels to the stack when possible. The `route` wrapper separates these chunks of logic into a `seed_fn` and a `route_fn`.

 The `seed_fn` must accept `x` and `y` parameters. Other arbitrary parameters are also allowed. It returns a boolean (`True` if the pixel at (x, y) meets the criteria for a seed pixel, `False` otherwise).

The `route_fn` must accept `x` and `y` parameters. Other arbitrary parameters are also allowed. It performs calculations and sets values in the target rasters for the pixel (x, y). It returns a list of pixels that can now be pushed to the stack (represented as flat indexes).

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
