### PR TITLE
performance improvements to ManagedFlowDirRaster

### DIFF
--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -49,11 +49,11 @@ cdef class _ManagedRaster:
 
 cdef class ManagedFlowDirRaster(_ManagedRaster):
 
-    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi) noexcept
+    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi)
 
-    cdef NeighborTuple* get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi) noexcept
+    cdef NeighborTuple* get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi)
 
-    cdef NeighborTuple* get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*) noexcept
+    cdef NeighborTuple* get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*)
 
 
 # These offsets are for the neighbor rows and columns according to the

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -5,13 +5,17 @@ from libcpp.pair cimport pair
 from libcpp.set cimport set as cset
 from libc.math cimport isnan
 
-cdef struct s_neighborTuple:
+cdef struct NeighborTuple:
     int direction
     int x
     int y
     float flow_proportion
+    bint null
 
-ctypedef s_neighborTuple NeighborTuple
+cdef struct NeighborArray:
+    NeighborTuple* values
+    int length
+
 
 # this is a least recently used cache written in C++ in an external file,
 # exposing here so _ManagedRaster can use it
@@ -49,11 +53,22 @@ cdef class _ManagedRaster:
 
 cdef class ManagedFlowDirRaster(_ManagedRaster):
 
-    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi)
+    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi) noexcept
 
-    cdef NeighborTuple* get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi)
+    cdef NeighborArray get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi) noexcept
 
-    cdef NeighborTuple* get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*)
+    cdef NeighborArray get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*) noexcept
+
+
+cdef class UpslopeNeighborIterator:
+
+    cdef int n_dir
+    cdef int x
+    cdef int y
+    cdef ManagedFlowDirRaster flow_dir_raster
+
+    cdef void begin(UpslopeNeighborIterator self, int x, int y)
+    cdef NeighborTuple getNext(UpslopeNeighborIterator self)
 
 
 # These offsets are for the neighbor rows and columns according to the

--- a/src/natcap/invest/managed_raster/managed_raster.pxd
+++ b/src/natcap/invest/managed_raster/managed_raster.pxd
@@ -3,7 +3,6 @@
 from libcpp.list cimport list as clist
 from libcpp.pair cimport pair
 from libcpp.set cimport set as cset
-from libcpp.vector cimport vector
 from libc.math cimport isnan
 
 cdef struct s_neighborTuple:
@@ -50,11 +49,11 @@ cdef class _ManagedRaster:
 
 cdef class ManagedFlowDirRaster(_ManagedRaster):
 
-    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi)
+    cdef bint is_local_high_point(ManagedFlowDirRaster self, long xi, long yi) noexcept
 
-    cdef vector[NeighborTuple] get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi)
+    cdef NeighborTuple* get_upslope_neighbors(ManagedFlowDirRaster self, long xi, long yi) noexcept
 
-    cdef vector[NeighborTuple] get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*)
+    cdef NeighborTuple* get_downslope_neighbors(ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=*) noexcept
 
 
 # These offsets are for the neighbor rows and columns according to the

--- a/src/natcap/invest/managed_raster/managed_raster.pyx
+++ b/src/natcap/invest/managed_raster/managed_raster.pyx
@@ -317,7 +317,7 @@ cdef class _ManagedRaster:
 
 cdef class ManagedFlowDirRaster(_ManagedRaster):
 
-    cdef bint is_local_high_point(self, long xi, long yi) noexcept:
+    cdef bint is_local_high_point(self, long xi, long yi):
         """Check if a given pixel is a local high point.
 
         Args:
@@ -335,7 +335,7 @@ cdef class ManagedFlowDirRaster(_ManagedRaster):
 
     @cython.cdivision(True)
     cdef NeighborTuple* get_upslope_neighbors(
-            ManagedFlowDirRaster self, long xi, long yi) noexcept:
+            ManagedFlowDirRaster self, long xi, long yi):
         """Return upslope neighbors of a given pixel.
 
         Args:
@@ -388,7 +388,7 @@ cdef class ManagedFlowDirRaster(_ManagedRaster):
 
     @cython.cdivision(True)
     cdef NeighborTuple* get_downslope_neighbors(
-            ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=True) noexcept:
+            ManagedFlowDirRaster self, long xi, long yi, bint skip_oob=True):
         """Return downslope neighbors of a given pixel.
 
         Args:

--- a/src/natcap/invest/ndr/ndr_core.pyx
+++ b/src/natcap/invest/ndr/ndr_core.pyx
@@ -133,10 +133,9 @@ def ndr_eff_calculation(
                 downslope_neighbors_array = (
                     mfd_flow_direction_raster.get_downslope_neighbors(
                         global_col, global_row, skip_oob=False))
-                length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                for neighbor_idx in range(length):
+                for neighbor_idx in range(<int>(sizeof(downslope_neighbors_array) /
+                                                sizeof(NeighborTuple))):
                     neighbor = downslope_neighbors_array[neighbor_idx]
-
                     if (neighbor.x < 0 or neighbor.x >= n_cols or
                         neighbor.y < 0 or neighbor.y >= n_rows or
                         to_process_flow_directions_raster.get(
@@ -178,8 +177,8 @@ def ndr_eff_calculation(
                 downslope_neighbors_array = (
                     mfd_flow_direction_raster.get_downslope_neighbors(
                         global_col, global_row, skip_oob=False))
-                length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                for neighbor_idx in range(length):
+                for neighbor_idx in range(<int>(sizeof(downslope_neighbors_array) /
+                                                sizeof(NeighborTuple))):
                     neighbor = downslope_neighbors_array[neighbor_idx]
 
                     has_outflow = True
@@ -230,8 +229,8 @@ def ndr_eff_calculation(
             upslope_neighbors_array = (
                 mfd_flow_direction_raster.get_upslope_neighbors(
                     global_col, global_row))
-            length = sizeof(upslope_neighbors_array) /  sizeof(NeighborTuple)
-            for neighbor_idx in range(length):
+            for neighbor_idx in range(<int>(sizeof(upslope_neighbors_array) /
+                                            sizeof(NeighborTuple))):
                 neighbor = upslope_neighbors_array[neighbor_idx]
 
                 neighbor_outflow_dir = INFLOW_OFFSETS[neighbor.direction]

--- a/src/natcap/invest/sdr/sdr_core.pyx
+++ b/src/natcap/invest/sdr/sdr_core.pyx
@@ -11,13 +11,13 @@ from osgeo import gdal
 
 from libc.time cimport time as ctime
 from libcpp.stack cimport stack
-from libc.stdlib cimport free
+from libc.stdlib cimport malloc, free
 
 from ..managed_raster.managed_raster cimport _ManagedRaster
 from ..managed_raster.managed_raster cimport ManagedFlowDirRaster
 from ..managed_raster.managed_raster cimport is_close
-from ..managed_raster.managed_raster cimport INFLOW_OFFSETS
-from ..managed_raster.managed_raster cimport NeighborTuple
+from ..managed_raster.managed_raster cimport ROW_OFFSETS, COL_OFFSETS, INFLOW_OFFSETS, FLOW_DIR_REVERSE_DIRECTION
+from ..managed_raster.managed_raster cimport NeighborTuple, UpslopeNeighborIterator
 
 cdef extern from "time.h" nogil:
     ctypedef int time_t
@@ -25,8 +25,6 @@ cdef extern from "time.h" nogil:
 
 LOGGER = logging.getLogger(__name__)
 
-
-@cython.cdivision(True)
 def calculate_sediment_deposition(
         mfd_flow_direction_path, e_prime_path, f_path, sdr_path,
         target_sediment_deposition_path):
@@ -114,12 +112,27 @@ def calculate_sediment_deposition(
     cdef long neighbor_row, neighbor_col, xs, ys
     cdef int flow_val, neighbor_flow_val, ds_neighbor_flow_val
     cdef int flow_weight, neighbor_flow_weight
-    cdef float flow_sum, neighbor_flow_sum
     cdef float downslope_sdr_weighted_sum, sdr_i, sdr_j
     cdef float p_j, p_val
     cdef unsigned long n_pixels_processed = 0
     cdef time_t last_log_time = ctime(NULL)
     cdef float f_j_weighted_sum
+
+    cdef int n_dir
+    cdef long xj, yj
+    cdef float flow_ij
+
+    cdef NeighborTuple n
+    cdef NeighborTuple *downslope_neighbor_tuples
+    cdef int flow_dir
+    cdef float flow_sum
+
+    cdef int i
+
+    cdef int flow_dir_j, idx
+    cdef float flow_ji, flow_dir_j_sum
+    cdef UpslopeNeighborIterator upslope_neighbor_iterator = (
+        UpslopeNeighborIterator(mfd_flow_direction_raster))
 
     for offset_dict in pygeoprocessing.iterblocks(
             (mfd_flow_direction_path, 1), offset_only=True, largest_block=0):
@@ -138,10 +151,14 @@ def calculate_sediment_deposition(
             for col_index in range(win_xsize):
                 xs = xoff + col_index
 
+                # check if this is a good seed pixel ( a local high point)
+                if mfd_flow_direction_raster.get(xs, ys) == mfd_nodata:
+                    continue
+
                 # if this can be a seed pixel and hasn't already been
                 # calculated, put it on the stack
                 if (mfd_flow_direction_raster.is_local_high_point(xs, ys) and
-                        is_close(sediment_deposition_raster.get(xs, ys), target_nodata)):
+                        sediment_deposition_raster.get(xs, ys) == target_nodata):
                     processing_stack.push(ys * n_cols + xs)
 
                 while processing_stack.size() > 0:
@@ -158,81 +175,113 @@ def calculate_sediment_deposition(
                     # the weighted sum of flux flowing onto this pixel from
                     # all neighbors
                     f_j_weighted_sum = 0
-                    upslope_neighbors_array = mfd_flow_direction_raster.get_upslope_neighbors(
-                        global_col, global_row)
-                    length = sizeof(upslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
-                        neighbor = upslope_neighbors_array[neighbor_idx]
-                        f_j = f_raster.get(neighbor.x, neighbor.y)
-                        if is_close(f_j, target_nodata):
-                            continue
 
-                        # add the neighbor's flux value, weighted by the
-                        # flow proportion
-                        f_j_weighted_sum += neighbor.flow_proportion * f_j
-                    free(upslope_neighbors_array)
+
+
+                    upslope_neighbor_iterator.begin(global_col, global_row)
+                    neighbor = upslope_neighbor_iterator.getNext()
+                    while not neighbor.null:
+                        f_j = f_raster.get(neighbor.x, neighbor.y)
+                        if f_j != target_nodata:
+                            # add the neighbor's flux value, weighted by the
+                            # flow proportion
+                            f_j_weighted_sum += neighbor.flow_proportion * f_j
+                        neighbor = upslope_neighbor_iterator.getNext()
+
+
+                    # free(upslope_neighbors_array.values)
                     # calculate sum of SDR values of immediate downslope
                     # neighbors, weighted by proportion of flow into each
                     # neighbor
                     # (sum over k ∈ K of SDR_k * p(i,k) in the equation above)
                     downslope_sdr_weighted_sum = 0
-                    downslope_neighbors_array = (
-                        mfd_flow_direction_raster.get_downslope_neighbors(
-                            global_col, global_row))
-                    length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
-                        neighbor = downslope_neighbors_array[neighbor_idx]
+                    # downslope_neighbors_array = (
+                    #     mfd_flow_direction_raster.get_downslope_neighbors(
+                    #         global_col, global_row))
 
-                        sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
-                        if is_close(sdr_j, sdr_nodata):
+
+
+                    downslope_neighbor_tuples = <NeighborTuple *> malloc(8 * sizeof(NeighborTuple))
+                    flow_dir = <int>mfd_flow_direction_raster.get(global_col, global_row)
+                    flow_sum = 0
+                    i = 0
+                    for n_dir in range(8):
+                        # flows in this direction
+                        xj = global_col + COL_OFFSETS[n_dir]
+                        yj = global_row + ROW_OFFSETS[n_dir]
+                        if (xj < 0 or xj >= mfd_flow_direction_raster.raster_x_size or
+                                yj < 0 or yj >= mfd_flow_direction_raster.raster_y_size):
                             continue
-                        if sdr_j == 0:
-                            # this means it's a stream, for SDR deposition
-                            # purposes, we set sdr to 1 to indicate this
-                            # is the last step on which to retain sediment
-                            sdr_j = 1
+                        flow_ij = (flow_dir >> (n_dir * 4)) & 0xF
+                        flow_sum += flow_ij
+                        if flow_ij:
+                            n = NeighborTuple(
+                                direction=n_dir,
+                                x=xj,
+                                y=yj,
+                                flow_proportion=flow_ij,
+                                null=False)
+                            downslope_neighbor_tuples[i] = n
 
-                        downslope_sdr_weighted_sum += (
-                            sdr_j * neighbor.flow_proportion)
 
-                        # check if we can add neighbor j to the stack yet
-                        #
-                        # if there is a downslope neighbor it
-                        # couldn't have been pushed on the processing
-                        # stack yet, because the upslope was just
-                        # completed
-                        upslope_neighbors_processed = 1
-                        # iterate over each neighbor-of-neighbor
-                        upslope_neighbors_array = (
-                            mfd_flow_direction_raster.get_upslope_neighbors(
-                                neighbor.x, neighbor.y))
-                        length = sizeof(upslope_neighbors_array) /  sizeof(NeighborTuple)
-                        for neighbor_idx in range(length):
-                            neighbor_of_neighbor = upslope_neighbors_array[neighbor_idx]
-                            # no need to push the one we're currently
-                            # calculating back onto the stack
-                            if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
-                                    neighbor.direction):
+
+                            neighbor = downslope_neighbor_tuples[i]
+                            i += 1
+                            sdr_j = sdr_raster.get(neighbor.x, neighbor.y)
+                            if sdr_j == sdr_nodata:
                                 continue
-                            if is_close(
-                                    sediment_deposition_raster.get(
-                                        neighbor_of_neighbor.x, neighbor_of_neighbor.y
-                                    ), target_nodata):
-                                upslope_neighbors_processed = 0
-                                break
-                        free(upslope_neighbors_array)
-                        # if all upslope neighbors of neighbor j are
-                        # processed, we can push j onto the stack.
-                        if upslope_neighbors_processed:
-                            processing_stack.push(
-                                neighbor.y * n_cols + neighbor.x)
-                    free(downslope_neighbors_array)
+                            if sdr_j == 0:
+                                # this means it's a stream, for SDR deposition
+                                # purposes, we set sdr to 1 to indicate this
+                                # is the last step on which to retain sediment
+                                sdr_j = 1
+
+                            downslope_sdr_weighted_sum += (
+                                sdr_j * neighbor.flow_proportion)
+
+                            # check if we can add neighbor j to the stack yet
+                            #
+                            # if there is a downslope neighbor it
+                            # couldn't have been pushed on the processing
+                            # stack yet, because the upslope was just
+                            # completed
+                            upslope_neighbors_processed = 1
+
+
+                            i = 0
+
+                            upslope_neighbor_iterator.begin(neighbor.x, neighbor.y)
+                            neighbor_of_neighbor = upslope_neighbor_iterator.getNext()
+                            while not neighbor_of_neighbor.null:
+                                i += 1
+                                # no need to push the one we're currently
+                                # calculating back onto the stack
+                                if (INFLOW_OFFSETS[neighbor_of_neighbor.direction] ==
+                                        neighbor.direction):
+                                    neighbor_of_neighbor = upslope_neighbor_iterator.getNext()
+                                    continue
+                                if sediment_deposition_raster.get(
+                                            neighbor_of_neighbor.x, neighbor_of_neighbor.y
+                                        ) == target_nodata:
+                                    upslope_neighbors_processed = 0
+                                    break
+                                neighbor_of_neighbor = upslope_neighbor_iterator.getNext()
+
+                            # if all upslope neighbors of neighbor j are
+                            # processed, we can push j onto the stack.
+                            if upslope_neighbors_processed:
+                                processing_stack.push(
+                                    neighbor.y * n_cols + neighbor.x)
+
+                    if flow_sum > 0:
+                        downslope_sdr_weighted_sum /= flow_sum
+                    # free(downslope_neighbors_array.values)
                     # nodata pixels should propagate to the results
                     sdr_i = sdr_raster.get(global_col, global_row)
-                    if is_close(sdr_i, sdr_nodata):
+                    if sdr_i == sdr_nodata:
                         continue
                     e_prime_i = e_prime_raster.get(global_col, global_row)
-                    if is_close(e_prime_i, e_prime_nodata):
+                    if e_prime_i == e_prime_nodata:
                         continue
 
                     # This condition reflects property A in the user's guide.
@@ -269,6 +318,5 @@ def calculate_sediment_deposition(
                     sediment_deposition_raster.set(global_col, global_row, t_i)
                     f_raster.set(global_col, global_row, f_i)
         n_pixels_processed += win_xsize * win_ysize
-
     LOGGER.info('Sediment deposition 100% complete')
     sediment_deposition_raster.close()

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
@@ -219,8 +219,8 @@ cpdef calculate_local_recharge(
                     # mfd values yet
                     l_sum_avail_i = 0
                     upslope_neighbors_array = flow_raster.get_upslope_neighbors(xi, yi)
-                    length = sizeof(upslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
+                    for neighbor_idx in range(<int>(sizeof(upslope_neighbors_array) /
+                                                    sizeof(NeighborTuple))):
                         neighbor = upslope_neighbors_array[neighbor_idx]
 
                         # pixel flows inward, check upslope
@@ -301,8 +301,8 @@ cpdef calculate_local_recharge(
 
                     downslope_neighbors_array = (
                         flow_raster.get_downslope_neighbors(xi, yi))
-                    length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
+                    for neighbor_idx in range(<int>(sizeof(downslope_neighbors_array) /
+                                                    sizeof(NeighborTuple))):
                         neighbor = downslope_neighbors_array[neighbor_idx]
                         work_queue.push(pair[long, long](neighbor.x, neighbor.y))
                     free(downslope_neighbors_array)
@@ -393,10 +393,9 @@ def route_baseflow_sum(
                 outlet = 1
                 downslope_neighbors_array = (
                     flow_dir_mfd_raster.get_downslope_neighbors(xs_root, ys_root))
-                length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                for neighbor_idx in range(length):
+                for neighbor_idx in range(<int>(sizeof(downslope_neighbors_array) /
+                                                sizeof(NeighborTuple))):
                     neighbor = downslope_neighbors_array[neighbor_idx]
-
                     stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
                     if stream_val != stream_nodata:
                         outlet = 0
@@ -425,8 +424,8 @@ def route_baseflow_sum(
                     downslope_defined = 1
                     downslope_neighbors_array = (
                         flow_dir_mfd_raster.get_downslope_neighbors(xi, yi))
-                    length = sizeof(downslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
+                    for neighbor_idx in range(<int>(sizeof(downslope_neighbors_array) /
+                                                    sizeof(NeighborTuple))):
                         neighbor = downslope_neighbors_array[neighbor_idx]
                         stream_val = <int>stream_raster.get(neighbor.x, neighbor.y)
                         if stream_val:
@@ -466,8 +465,8 @@ def route_baseflow_sum(
                     current_pixel += 1
                     upslope_neighbors_array = (
                         flow_dir_mfd_raster.get_upslope_neighbors(xi, yi))
-                    length = sizeof(upslope_neighbors_array) /  sizeof(NeighborTuple)
-                    for neighbor_idx in range(length):
+                    for neighbor_idx in range(<int>(sizeof(upslope_neighbors_array) /
+                                                    sizeof(NeighborTuple))):
                         neighbor = upslope_neighbors_array[neighbor_idx]
                         work_stack.push(pair[long, long](neighbor.x, neighbor.y))
                     free(upslope_neighbors_array)


### PR DESCRIPTION
## Description
Fixes #

On `main`, `sdr_core.calculate_sediment_deposition` takes ~0.63 seconds to run on the sample data. On `feature/routing-refactor` it takes ~1.53 seconds (a bit less than 2.5x).

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
