### PR TITLE
Fix a quickflow summation bug in SWY

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -68,6 +68,11 @@ Unreleased Changes
       raster. ``nan`` pixels will now be propertly ignored before calculating
       mean depths along fetch rays.
       https://github.com/natcap/invest/issues/1528
+* Seasonal Water Yield
+    * Fixed an issue where the monthly quickflow values were being summed over
+      a block area and not summed pixelwise. This caused the quickflow 
+      output ``QF.tif`` to have malformed values.
+      https://github.com/natcap/invest/issues/1541
 * Urban Nature Access
     * Fixed a ``NameError`` that occurred when running the model using
       search radii defined per population group with an exponential search

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -100,7 +100,7 @@ Unreleased Changes
       rasters are now correctly stated as mm/month.
       https://github.com/natcap/invest/issues/1571
     * Fixed an issue where the monthly quickflow values were being summed over
-      a block area and not summed pixelwise. This caused the quickflow 
+      a block area and not summed pixelwise. This caused the quickflow
       output ``QF.tif`` to have malformed values.
       https://github.com/natcap/invest/issues/1541
 * Wind Energy

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -894,7 +894,7 @@ def execute(args):
             ],
             dependent_task_list=[
                 align_task, flow_dir_task, stream_threshold_task,
-                fill_pit_task, qf_task] + quick_flow_task_list,
+                fill_pit_task] + quick_flow_task_list,
             task_name='calculate local recharge')
 
     # calculate Qb as the sum of local_recharge_avail over the AOI, Eq [9]
@@ -966,7 +966,7 @@ def execute(args):
 
 
 # raster_map equation: sum the monthly qfis
-def qfi_sum_op(*qf_values): return numpy.sum(qf_values)
+def qfi_sum_op(*qf_values): return numpy.sum(qf_values, axis=0)
 
 
 def _calculate_l_avail(l_path, gamma, target_l_avail_path):


### PR DESCRIPTION
## Description
Fix a pixelwise sum op for QF. It was summing up whole blocks as opposed to doing a pixelwise sum. Remove unneeded task dependency.

I didn't add a test for this because SWY doesn't really have any regression testing for the raster outputs. It instead tests against the aggregated vector results. This seems like a larger issue which I created an issue for in #1549 .

Fixes #1541 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
