### PR TITLE
Fix two issues from dependency updates

### DIFF
--- a/constraints_tests.txt
+++ b/constraints_tests.txt
@@ -5,3 +5,6 @@
 # A gdal bug caused our test suite to fail, but this issue is unlikely to
 # occur with regular use of invest. https://github.com/OSGeo/gdal/issues/8497
 GDAL!=3.6.*,!=3.7.*
+
+# https://github.com/natcap/pygeoprocessing/issues/387
+GDAL<3.8.5

--- a/exe/invest.spec
+++ b/exe/invest.spec
@@ -30,6 +30,7 @@ kwargs = {
         'pkg_resources.py2_warn',
         'cmath',
         'charset_normalizer',
+        'scipy.special._cdflib'
     ],
     'datas': [proj_datas],
     'cipher': block_cipher,


### PR DESCRIPTION
## Description
Fixes #1553 , fixes #1556 

A new scipy release (1.13.0) requires us to include a new hidden import for pyinstaller. The pyinstaller scipy hook will probably eventually be updated to include this for us.

GDAL 3.8.5 fixed a bug that we were relying on to get a list of warp algorithm names in pygeoprocessing. We'll need to update pygeoprocessing for that. In the mean time, I put a gdal<3.8.5 constraint in our new constraints file. (Not totally sure if this belongs in constraints or requirements, but we likely won't do a release before this issue is fixed).

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
