### PR TITLE
Fixes for Mac M1 issues on Github Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: workbench/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('workbench/yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
 
       - name: Install workbench dependencies
         if: steps.nodemodules-cache.outputs.cache-hit != 'true'
@@ -347,7 +347,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: workbench/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('workbench/yarn.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
 
       - name: Install Workbench Dependencies
         if: steps.nodemodules-cache.outputs.cache-hit != 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,11 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 # raise warnings to errors, except for deprecation warnings
-filterwarnings = ["error", "default::DeprecationWarning", "default::FutureWarning"]
+filterwarnings = [
+    "error",
+    "default::DeprecationWarning",
+    "default::FutureWarning",
+    # don't error on a specific runtime warning coming from a shapely
+    # issue on M1: https://github.com/natcap/invest/issues/1562
+    "default:invalid value encountered in intersection:RuntimeWarning",
+]

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -380,7 +380,7 @@ class NDRTests(unittest.TestCase):
         # bowtie geometry is invalid; verify we can still create a mask.
         coordinates = []
         for pixel_x_offset, pixel_y_offset in [
-                (0, 0), (0, 1), (1, 0), (1, 1), (0, 0)]:
+                (0, 0), (0, 1), (1, 0.25), (1, 0.75), (0, 0)]:
             coordinates.append((
                 default_origin[0] + default_pixel_size[0] * pixel_x_offset,
                 default_origin[1] + default_pixel_size[1] * pixel_y_offset

--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -38,7 +38,7 @@ const TMP_AOI_PATH = path.join(TMP_DIR, 'aoi.geojson');
 
 if (process.platform === 'darwin') {
   // https://github.com/electron-userland/electron-builder/issues/2724#issuecomment-375850150
-  [BINARY_PATH] = glob.sync('./dist/mac/*.app/Contents/MacOS/InVEST*');
+  [BINARY_PATH] = glob.sync('./dist/mac*/*.app/Contents/MacOS/InVEST*');
   SCREENSHOT_PREFIX = path.join(
     os.homedir(), 'Library/Logs', pkg.name, 'invest-workbench-'
   );


### PR DESCRIPTION
## Description
Fixes #1562
This PR fixes 3 issues that resulted from the `macos-latest` runner moving from `macos-13` (Intel) to `macos-14` (M1). 
- Updates the node_modules cache key to include the runner architecture. This triggered the cache to refresh so we're not using the old x86 packages.
- Add a pytest exception for a specific warning
- Update an NDR test to avoid an edge case

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
