### PR TITLE
Addressing viewshed numerical error issue on M1 Macs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -76,6 +76,11 @@ Unreleased Changes
 * HRA
     * Fixed a bug where habitat and stressor vectors were not being rasterized
       with the `ALL_TOUCHED=TRUE` setting.
+* Scenic Quality
+    * Fixed an issue with viewshed calculations where some slight numerical
+      error was introduced on M1 Macs, but not on x86-based computers. This
+      numerical error was leading to slightly different visibility results.
+      https://github.com/natcap/invest/issues/1562
 * SDR
     * Fixed an issue encountered in the sediment deposition function where
       rasters with more than 2^32 pixels would raise a cryptic error relating

--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -824,6 +824,8 @@ def viewshed(dem_raster_path_band,
             # So, this calculation would introduce error:
             #   z = (((previous_height-r_v)/slope_distance) * target_distance) + r_v
             # while the formlation below does not.
+            # For the script used for testing, see
+            #  https://gist.github.com/phargogh/c4264b37e7f0beed31661eacce53d14a
             #
             # Some of this may be related to the fact that x86 chips have
             # extended precision for FPU-based calculations while M1 ARM chips

--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -815,8 +815,21 @@ def viewshed(dem_raster_path_band,
             if target_distance > max_visible_radius:
                 break
 
-            z = (((previous_height-r_v)/slope_distance) *
-                 target_distance + r_v)
+            # This is a weird platform-specific workaround addressing
+            # https://github.com/natcap/invest/issues/1562
+            # On M1 macs, the all-in-one-line addition of _product and r_v
+            # would create small but noticeable numerical error.  Breaking the
+            # calculation onto two lines eliminates the numerical error.  This
+            # behavior is reproducible in C, outside of Cython on an M1 mac.
+            # So, this calculation would introduce error:
+            #   z = (((previous_height-r_v)/slope_distance) * target_distance) + r_v
+            # while the formlation below does not.
+            #
+            # Some of this may be related to the fact that x86 chips have
+            # extended precision for FPU-based calculations while M1 ARM chips
+            # do not.  Still, that doesn't explain why the error is introduced.
+            _product = (((previous_height-r_v)/slope_distance) * target_distance)
+            z = _product + r_v
 
             # add on refractivity/curvature-of-earth calculations.
             adjustment = 0.0  # increase in required height due to curvature


### PR DESCRIPTION
This (strangely) fixes the viewshed issue on M1 macs.  See the inline comment for a rundown.

RE:#1562

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
