### PR TITLE
apply dependency test constraints to binary build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -313,7 +313,11 @@ jobs:
         uses: ./.github/actions/setup_env
         with:
           python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
-          requirements-files: requirements.txt requirements-dev.txt requirements-docs.txt
+          requirements-files: |
+            requirements.txt
+            requirements-dev.txt
+            requirements-docs.txt
+            constraints_tests.txt
           requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} pandoc
 
       - name: Make install


### PR DESCRIPTION
## Description
Apply dependency constraints for tests to the binary build job. This fixes another workflow failure that popped up this morning.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
