### PR TITLE
update sample data commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 8f78a4873f1fa4253d3ab9a01d6e23f11499b975
+GIT_SAMPLE_DATA_REPO_REV    := ab8c74a62a93fd0019de2bca064abc0a5a07afab
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data


### PR DESCRIPTION
## Description
For the last CBC PR, I increased the analysis year in the sample data, but I forgot to also extend the price table through that new year, which caused the binary tests to fail on main. Didn't catch it earlier because we don't run invest-autotest on PRs. Here I'm updating the sample data again to correct that.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
