### PR TITLE
Update units of SWY precip input rasters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -95,6 +95,10 @@ Unreleased Changes
       to negative dimensions. https://github.com/natcap/invest/issues/1431
     * Optimized the creation of the summary vector by minimizing the number of
       times the target vector needs to be rasterized.
+* Seasonal Water Yield
+    * Fixed an issue with the precip directory units. Units for these input
+      rasters are now correctly stated as mm/month.
+      https://github.com/natcap/invest/issues/1571
 * Wind Energy
     * Fixed a bug where some number inputs were not being properly cast to
       ``float`` or ``int`` types. If the inputs happened to be passed as

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -70,7 +70,14 @@ MODEL_SPEC = {
             "contents": {
                 # monthly precipitation maps, each file ending in a number 1-12
                 "[MONTH]": {
-                    **spec_utils.PRECIP,
+                    "type": "raster",
+                    "bands": {
+                        1: {
+                            "type": "number",
+                            "units": u.millimeter/u.month,
+                        },
+                    },
+                    "name": gettext("precipitation"),
                     "about": gettext(
                         "Twelve files, one for each month. File names must "
                         "end with the month number (1-12). For example, "


### PR DESCRIPTION
This PR fixes #1571, which corrects the units for SWY's precip inputs to be mm/month instead of mm/year.

Thanks to @nadinetrahan for pointing this out!

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
