### PR TITLE
Include pip packages in package_versions.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ $(INVEST_BINARIES_DIR): | $(DIST_DIR) $(BUILD_DIR)
 	-$(RMDIR) $(INVEST_BINARIES_DIR)
 	$(PYTHON) -m PyInstaller --workpath $(BUILD_DIR)/pyi-build --clean --distpath $(DIST_DIR) exe/invest.spec
 	$(CONDA) list > $(INVEST_BINARIES_DIR)/package_versions.txt
+	$(PYTHON) -m pip list >> $(INVEST_BINARIES_DIR)/package_versions.txt
 	$(INVEST_BINARIES_DIR)/invest list
 
 # Documentation.


### PR DESCRIPTION
`package_versions.txt` is meant to be a list of all packages & versions included in the binary builds. It's a convenient way to see which version of package was bundled with the workbench, after the workbench is installed.

We were building it with `micromamba list`, but that excludes pip installed packages (pygeoprocessing, taskgraph, among others). I did not find any way for `micromamba` to include these, so I appended the `pip list` to the `micromamba list`. There is some overlap, which I don't understand, but I think that's okay given the purpose of this file.

Fixes #1527 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
