### PR TITLE
Fixes failing workbench modal test

### DIFF
--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -11,7 +11,7 @@ channels:
 - nodefaults
 dependencies:
 - python=3.11
-- gdal>=3.4.2
+- gdal>=3.4.2,<3.8.5
 - pip
 - pip:
   - -r requirements.txt

--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -11,7 +11,7 @@ channels:
 - nodefaults
 dependencies:
 - python=3.11
-- gdal>=3.4.2,<3.8.5
+- gdal>=3.4.2
 - pip
 - pip:
   - -r requirements.txt

--- a/workbench/tests/renderer/downloadmodal.test.js
+++ b/workbench/tests/renderer/downloadmodal.test.js
@@ -41,7 +41,7 @@ describe('Sample Data Download Form', () => {
   });
 
   test('Modal does not display when app has been run before', async () => {
-    const { findByText, queryByText } = render(<App isFirstRun />);
+    const { findByText, queryByText } = render(<App />);
     await findByText('InVEST'); // wait for page to load before querying
     const modalTitle = queryByText('Download InVEST sample data');
     expect(modalTitle).toBeNull();


### PR DESCRIPTION
We are testing behavior when it is _not_ the first time the app has run, but we were passing a prop indicating that it is the first run.

It's unfortunate that this test was passing sometimes, it should have always failed. Probably it's a race condition where we were doing the `queryByText` too soon. But there's not an obvious thing to wait for before doing that query. 

Fixes #1569 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
