### PR TITLE
Fix RTD builds; pip install gdal failures

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,5 +18,9 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
+    post_create_environment:
+      - pip install --upgrade-strategy=only-if-needed -r requirements.txt
+      - pip install --upgrade-strategy=only-if-needed -r requirements-dev.txt
+      - pip install --upgrade-strategy=only-if-needed -r requirements-docs.txt
     post_install:
       - make install

--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -13,7 +13,3 @@ dependencies:
 - python=3.11
 - gdal>=3.4.2
 - pip
-- pip:
-  - --upgrade-strategy=only-if-needed -r requirements.txt
-  - --upgrade-strategy=only-if-needed -r requirements-dev.txt
-  - --upgrade-strategy=only-if-needed -r requirements-docs.txt

--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -14,6 +14,6 @@ dependencies:
 - gdal>=3.4.2
 - pip
 - pip:
-  - -r --upgrade-strategy=only-if-needed requirements.txt
-  - -r --upgrade-strategy=only-if-needed requirements-dev.txt
-  - -r --upgrade-strategy=only-if-needed requirements-docs.txt
+  - --upgrade-strategy=only-if-needed -r requirements.txt
+  - --upgrade-strategy=only-if-needed -r requirements-dev.txt
+  - --upgrade-strategy=only-if-needed -r requirements-docs.txt

--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -14,6 +14,6 @@ dependencies:
 - gdal>=3.4.2
 - pip
 - pip:
-  - -r requirements.txt
-  - -r requirements-dev.txt
-  - -r requirements-docs.txt
+  - -r --upgrade-strategy=only-if-needed requirements.txt
+  - -r --upgrade-strategy=only-if-needed requirements-dev.txt
+  - -r --upgrade-strategy=only-if-needed requirements-docs.txt


### PR DESCRIPTION
Using RTD recommended `build.jobs` steps to more explicitly control how we use `pip`.

Fixes #1575 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
