### PR TITLE
log the invest version string at the end of execution

### DIFF
--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 from datetime import datetime
 
+import natcap.invest
 import numpy
 import pandas
 import pygeoprocessing
@@ -169,7 +170,7 @@ def prepare_workspace(
                 LOGGER.info('Elapsed time: %s',
                             _format_time(round(time.time() - start_time, 2)))
                 logging.captureWarnings(False)
-                LOGGER.info('Execution finished')
+                LOGGER.info(f'Execution finished; version: {natcap.invest.__version__}')
 
 
 class ThreadFilter(logging.Filter):


### PR DESCRIPTION
Last lines of a logfile now look like:

```
05/10/2024 15:01:14  natcap.invest.utils INFO     Elapsed time: 2.79s
05/10/2024 15:01:14  natcap.invest.utils INFO     Execution finished; version: 3.14.1.post196+g1dbb45860.d20240501
```

Fixes #1529 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
