### PR TITLE
Fix sdist version information in github actions sdist builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -178,7 +178,9 @@ jobs:
           # computer is guaranteed to have cython available at build
           # time.  Thus, it is no longer necessary to distribute the
           # .cpp files in addition to the .pyx files.
-          python -m build --sdist
+          #
+          # Elevating any python warnings to errors to catch build issues ASAP.
+          python -W error -m build --sdist
 
       - name: Install from source distribution
         run : |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -164,7 +164,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          - fetch-depth: 0  # Fetch complete history for accurate versioning
+          fetch-depth: 0  # Fetch complete history for accurate versioning
 
       - uses: ./.github/actions/setup_env
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,6 +163,8 @@ jobs:
         os: [windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+        with:
+          - fetch-depth: 0  # Fetch complete history for accurate versioning
 
       - uses: ./.github/actions/setup_env
         with:


### PR DESCRIPTION
Fixes an issue with our sdist builds where the version metadata were not included, leading to an incorrect version string (e.g. `natcap_invest-0.0.post1+g6bcb9e5`.  I also modified the sdist build process to upgrade python warnings to errors, so this shouldn't happen in the future without a very loud failure.

RE: #1581

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
