### PR TITLE
Fall back to x64 MacOS runners for GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -160,7 +160,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -203,17 +203,17 @@ jobs:
         # overwrite artifacts or have duplicates (mac/windows sdists have
         # different extensions)
       - name: Authenticate GCP
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-13' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         uses: google-github-actions/auth@v0
         with:
           credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
       - name: Set up GCP
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-13' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Deploy artifacts to GCS
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-13' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         run: make deploy
 
   validate-resources:
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-latest, macos-13]
 
     steps:
       - name: Check out repo
@@ -298,9 +298,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-13, windows-latest]
         include:
-          - os: macos-latest
+          - os: macos-13
             puppeteer-log: ~/Library/Logs/invest-workbench/
             workspace-path: InVEST-failed-mac-workspace.tar
             binary-extension: dmg
@@ -386,7 +386,7 @@ jobs:
           yarn run dist
 
       - name: Build Workbench (macOS)
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' # secrets not available in PR
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-13' # secrets not available in PR
         working-directory: workbench
         env:
           GH_TOKEN: env.GITHUB_TOKEN
@@ -416,7 +416,7 @@ jobs:
         run: npx cross-env CI=true yarn run test-electron-app
 
       - name: Sign binaries (macOS)
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-latest' # secrets not available in PR
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-13' # secrets not available in PR
         env:
           CERT_FILE: 2025-01-16-Expiry-AppStore-App.p12
           CERT_PASS: ${{ secrets.MACOS_CODESIGN_CERT_PASS }}
@@ -468,7 +468,7 @@ jobs:
         run: make invest_autotest
 
       - name: Tar the workspace to preserve permissions (macOS)
-        if: failure() && matrix.os == 'macos-latest'
+        if: failure() && matrix.os == 'macos-13'
         run: tar -cvf ${{ matrix.workspace-path}} ${{ github.workspace }}
 
       - name: Upload workspace on failure

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -65,7 +65,12 @@ const config = {
   mac: {
     category: 'public.app-category.business',
     icon: 'resources/InVEST-2-574x574.ico',
-    target: 'dmg',
+    target: [
+      {
+        target: 'dmg',
+        arch: ['x64'], // force build of x64 even on ARM macs
+      },
+    ],
   },
   win: {
     target: 'nsis',

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -1,14 +1,7 @@
 const { execFileSync } = require('child_process');
 
 const OS = process.platform;
-
-// github actions now defaults to ARM builds, so fall back to x64.
-let ARCH;
-if (OS === 'darwin') {
-  ARCH = 'x64';
-} else {
-  ARCH = process.arch;
-}
+const ARCH = process.arch;
 const EXT = OS === 'win32' ? 'exe' : 'dmg';
 
 // Uniquely identify the changeset we're building & packaging.
@@ -65,12 +58,7 @@ const config = {
   mac: {
     category: 'public.app-category.business',
     icon: 'resources/InVEST-2-574x574.ico',
-    target: [
-      {
-        target: 'dmg',
-        arch: ['x64'], // force build of x64 even on ARM macs
-      },
-    ],
+    target: 'dmg',
   },
   win: {
     target: 'nsis',

--- a/workbench/electron-builder-config.js
+++ b/workbench/electron-builder-config.js
@@ -1,7 +1,14 @@
 const { execFileSync } = require('child_process');
 
 const OS = process.platform;
-const ARCH = process.arch;
+
+// github actions now defaults to ARM builds, so fall back to x64.
+let ARCH;
+if (OS === 'darwin') {
+  ARCH = 'x64';
+} else {
+  ARCH = process.arch;
+}
 const EXT = OS === 'win32' ? 'exe' : 'dmg';
 
 // Uniquely identify the changeset we're building & packaging.


### PR DESCRIPTION
It turns out that mac binaries built on M1 chips won't run on intel chips.  This PR downgrades our mac runners so that our mac builds are building and testing on x64 until we determine the best approach to handle this (see #1586 ).  Related to the 3.14.2 release: #1581


## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
