### PR TITLE
Hide 'Open Workspace' button when logfile does not exist

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,9 +36,11 @@
 .. :changelog:
 
 
-..
-  Unreleased Changes
-  ------------------
+
+Unreleased Changes
+------------------
+* Workbench
+  * Fixed a bug that caused the application to crash when attempting to open a workspace without a valid logfile (https://github.com/natcap/invest/issues/1598)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/ModelStatusAlert/index.jsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 /* Render different Alert contents depending on an InVEST run status */
 export default function ModelStatusAlert(props) {
-  const { status } = props;
+  const { status, hideOpenWorkspace } = props;
   const { t, i18n } = useTranslation();
 
   const WorkspaceButton = (
@@ -56,7 +56,7 @@ export default function ModelStatusAlert(props) {
       variant={alertVariant}
     >
       {alertMessage}
-      {WorkspaceButton}
+      {!hideOpenWorkspace && WorkspaceButton}
     </Alert>
   );
 }
@@ -67,4 +67,5 @@ ModelStatusAlert.propTypes = {
   ).isRequired,
   terminateInvestProcess: PropTypes.func.isRequired,
   handleOpenWorkspace: PropTypes.func.isRequired,
+  hideOpenWorkspace: PropTypes.bool,
 };

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -208,7 +208,7 @@ class InvestTab extends React.Component {
       return (<div />);
     }
 
-    const logDisabled = !logfile;
+    const logDoesNotExist = !logfile;
     const sidebarSetupElementId = `sidebar-setup-${tabID}`;
     const sidebarFooterElementId = `sidebar-footer-${tabID}`;
 
@@ -229,7 +229,7 @@ class InvestTab extends React.Component {
                 {t('Setup')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
-              <Nav.Link eventKey="log" disabled={logDisabled}>
+              <Nav.Link eventKey="log" disabled={logDoesNotExist}>
                 {t('Log')}
                 <MdKeyboardArrowRight />
               </Nav.Link>
@@ -254,6 +254,7 @@ class InvestTab extends React.Component {
                     <ModelStatusAlert
                       status={status}
                       handleOpenWorkspace={() => handleOpenWorkspace(logfile)}
+                      hideOpenWorkspace={logDoesNotExist}
                       terminateInvestProcess={this.terminateInvestProcess}
                     />
                   )

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -122,6 +122,20 @@ describe('Run status Alert renders with status from a recent run', () => {
     openWorkspace.click();
     expect(shell.showItemInFolder).toHaveBeenCalledTimes(1);
   });
+
+  test('Open Workspace button is NOT available when logfile does not exist', async () => {
+    const job = new InvestJob({
+      modelRunName: 'carbon',
+      modelHumanName: 'Carbon Model',
+      status: 'error',
+      argsValues: {},
+      logfile: undefined,
+    });
+
+    const { queryByRole } = renderInvestTab(job);
+    const openWorkspaceBtn = queryByRole('button', { name: 'Open Workspace' });
+    expect(openWorkspaceBtn).toBe(null);
+  });
 });
 
 describe('Sidebar Buttons', () => {


### PR DESCRIPTION
## Description
Fixes #1598 by hiding the 'Open Workspace' button when there is no logfile

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [n/a] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
