### PR TITLE
Allow 'Open Workspace' to open workspace whenever possible, even if logfile does not exist

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,13 +38,13 @@
 Unreleased Changes
 ------------------
 * Workbench
-  * Several small updates to the model input form UI to improve usability
-    and visual consistency (https://github.com/natcap/invest/issues/912)
-  * Fixed a bug that caused the application to crash when attempting to
-    open a workspace without a valid logfile
-    (https://github.com/natcap/invest/issues/1598)
-  * Fixed a bug that was allowing readonly workspace directories on Windows
-    (https://github.com/natcap/invest/issues/1599)
+    * Several small updates to the model input form UI to improve usability
+      and visual consistency (https://github.com/natcap/invest/issues/912)
+    * Fixed a bug that caused the application to crash when attempting to
+      open a workspace without a valid logfile
+      (https://github.com/natcap/invest/issues/1598)
+    * Fixed a bug that was allowing readonly workspace directories on Windows
+      (https://github.com/natcap/invest/issues/1599)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,7 @@ Unreleased Changes
 ------------------
 * Workbench
   * Several small updates to the model input form UI to improve usability and visual consistency (https://github.com/natcap/invest/issues/912)
+  * Fixed a bug that caused the application to crash when attempting to open a workspace without a valid logfile (https://github.com/natcap/invest/issues/1598)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/workbench/src/main/ipcMainChannels.js
+++ b/workbench/src/main/ipcMainChannels.js
@@ -14,6 +14,7 @@ export const ipcMainChannels = {
   IS_FIRST_RUN: 'is-first-run',
   LOGGER: 'logger',
   OPEN_EXTERNAL_URL: 'open-external-url',
+  OPEN_PATH: 'open-path',
   OPEN_LOCAL_HTML: 'open-local-html',
   SET_SETTING: 'set-setting',
   SHOW_ITEM_IN_FOLDER: 'show-item-in-folder',

--- a/workbench/src/main/setupDialogs.js
+++ b/workbench/src/main/setupDialogs.js
@@ -26,4 +26,10 @@ export default function setupDialogs() {
       shell.showItemInFolder(filepath);
     }
   );
+
+  ipcMain.handle(
+    ipcMainChannels.OPEN_PATH, async (event, dirpath) => {
+      return await shell.openPath(dirpath);
+    }
+  );
 }

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -50,10 +50,12 @@ function handleOpenWorkspace(logfile, workspace_dir) {
     logger.info(`Attempting to show logfile in workspace directory: ${logfile}`);
     ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
   }
-  // Always call shell.openPath.
-  // If shell.showItemInFolder failed, it will have failed silently;
-  // if it succeeded, the subsequent call to shell.openPath will not "undo" the result of shell.showItemInFolder.
-  openWorkspaceDir(workspace_dir);
+  if (workspace_dir) {
+    // Always call shell.openPath.
+    // If shell.showItemInFolder failed, it will have failed silently;
+    // if it succeeded, the subsequent call to shell.openPath will not "undo" the result of shell.showItemInFolder.
+    openWorkspaceDir(workspace_dir);
+  }
 }
 
 async function openWorkspaceDir(workspace_dir) {
@@ -220,7 +222,6 @@ class InvestTab extends React.Component {
       argsValues,
       logfile,
     } = this.props.job;
-    const {workspace_dir} = argsValues;
 
     const { tabID, t } = this.props;
 
@@ -274,7 +275,7 @@ class InvestTab extends React.Component {
                   ? (
                     <ModelStatusAlert
                       status={status}
-                      handleOpenWorkspace={() => handleOpenWorkspace(logfile, workspace_dir)}
+                      handleOpenWorkspace={() => handleOpenWorkspace(logfile, argsValues?.workspace_dir)}
                       terminateInvestProcess={this.terminateInvestProcess}
                     />
                   )

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -71,7 +71,6 @@ class InvestTab extends React.Component {
     this.investLogfileCallback = this.investLogfileCallback.bind(this);
     this.investExitCallback = this.investExitCallback.bind(this);
     this.handleOpenWorkspace = this.handleOpenWorkspace.bind(this);
-    this.openWorkspaceDir = this.openWorkspaceDir.bind(this);
     this.showErrorModal = this.showErrorModal.bind(this);
   }
 
@@ -189,17 +188,13 @@ class InvestTab extends React.Component {
     );
   }
 
-  handleOpenWorkspace(workspace_dir) {
+  async handleOpenWorkspace(workspace_dir) {
     if (workspace_dir) {
-      this.openWorkspaceDir(workspace_dir);
-    }
-  }
-
-  async openWorkspaceDir(workspace_dir) {
-    const error = await ipcRenderer.invoke(ipcMainChannels.OPEN_PATH, workspace_dir);
-    if (error) {
-      logger.error(`Error opening workspace (${workspace_dir}). ${error}`);
-      this.showErrorModal(true);
+      const error = await ipcRenderer.invoke(ipcMainChannels.OPEN_PATH, workspace_dir);
+      if (error) {
+        logger.error(`Error opening workspace (${workspace_dir}). ${error}`);
+        this.showErrorModal(true);
+      }
     }
   }
 

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -191,7 +191,6 @@ class InvestTab extends React.Component {
 
   handleOpenWorkspace(logfile, workspace_dir) {
     if (logfile) {
-      logger.info(`Attempting to show logfile in workspace directory: ${logfile}`);
       ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
     }
     if (workspace_dir) {
@@ -203,13 +202,10 @@ class InvestTab extends React.Component {
   }
 
   async openWorkspaceDir(workspace_dir) {
-    logger.info(`Attempting to open directory: ${workspace_dir}`);
     const error = await ipcRenderer.invoke(ipcMainChannels.OPEN_PATH, workspace_dir);
     if (error) {
-      logger.error(`Error opening directory: ${error}`);
+      logger.error(`Error opening workspace (${workspace_dir}). ${error}`);
       this.showErrorModal(true);
-    } else {
-      logger.info(`Directory should be open now`);
     }
   }
 

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -189,14 +189,8 @@ class InvestTab extends React.Component {
     );
   }
 
-  handleOpenWorkspace(logfile, workspace_dir) {
-    if (logfile) {
-      ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
-    }
+  handleOpenWorkspace(workspace_dir) {
     if (workspace_dir) {
-      // Always call shell.openPath.
-      // If shell.showItemInFolder failed, it will have failed silently;
-      // if it succeeded, the subsequent call to shell.openPath will not "undo" the result of shell.showItemInFolder.
       this.openWorkspaceDir(workspace_dir);
     }
   }
@@ -284,7 +278,7 @@ class InvestTab extends React.Component {
                     ? (
                       <ModelStatusAlert
                         status={status}
-                        handleOpenWorkspace={() => this.handleOpenWorkspace(logfile, argsValues?.workspace_dir)}
+                        handleOpenWorkspace={() => this.handleOpenWorkspace(argsValues?.workspace_dir)}
                         terminateInvestProcess={this.terminateInvestProcess}
                       />
                     )

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -7,6 +7,8 @@ import TabContainer from 'react-bootstrap/TabContainer';
 import Nav from 'react-bootstrap/Nav';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
 import {
   MdKeyboardArrowRight,
 } from 'react-icons/md';
@@ -45,31 +47,6 @@ async function investGetSpec(modelName) {
   return undefined;
 }
 
-function handleOpenWorkspace(logfile, workspace_dir) {
-  if (logfile) {
-    logger.info(`Attempting to show logfile in workspace directory: ${logfile}`);
-    ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
-  }
-  if (workspace_dir) {
-    // Always call shell.openPath.
-    // If shell.showItemInFolder failed, it will have failed silently;
-    // if it succeeded, the subsequent call to shell.openPath will not "undo" the result of shell.showItemInFolder.
-    openWorkspaceDir(workspace_dir);
-  }
-}
-
-async function openWorkspaceDir(workspace_dir) {
-  logger.info(`Attempting to open directory: ${workspace_dir}`);
-  const error = await ipcRenderer.invoke(ipcMainChannels.OPEN_PATH, workspace_dir);
-  if (error) {
-    logger.error(`Error opening directory: ${error}`);
-    // @TODO: render this error message in a modal
-    alert('Failed to open workspace directory. Make sure the directory exists and that you have write access to it.');
-  } else {
-    logger.info(`Directory should be open now`);
-  }
-}
-
 /**
  * Render an invest model setup form, log display, etc.
  * Manage launching of an invest model in a child process.
@@ -85,6 +62,7 @@ class InvestTab extends React.Component {
       uiSpec: null,
       userTerminated: false,
       executeClicked: false,
+      showErrorModal: false,
     };
 
     this.investExecute = this.investExecute.bind(this);
@@ -92,6 +70,9 @@ class InvestTab extends React.Component {
     this.terminateInvestProcess = this.terminateInvestProcess.bind(this);
     this.investLogfileCallback = this.investLogfileCallback.bind(this);
     this.investExitCallback = this.investExitCallback.bind(this);
+    this.handleOpenWorkspace = this.handleOpenWorkspace.bind(this);
+    this.openWorkspaceDir = this.openWorkspaceDir.bind(this);
+    this.showErrorModal = this.showErrorModal.bind(this);
   }
 
   async componentDidMount() {
@@ -208,6 +189,36 @@ class InvestTab extends React.Component {
     );
   }
 
+  handleOpenWorkspace(logfile, workspace_dir) {
+    if (logfile) {
+      logger.info(`Attempting to show logfile in workspace directory: ${logfile}`);
+      ipcRenderer.send(ipcMainChannels.SHOW_ITEM_IN_FOLDER, logfile);
+    }
+    if (workspace_dir) {
+      // Always call shell.openPath.
+      // If shell.showItemInFolder failed, it will have failed silently;
+      // if it succeeded, the subsequent call to shell.openPath will not "undo" the result of shell.showItemInFolder.
+      this.openWorkspaceDir(workspace_dir);
+    }
+  }
+
+  async openWorkspaceDir(workspace_dir) {
+    logger.info(`Attempting to open directory: ${workspace_dir}`);
+    const error = await ipcRenderer.invoke(ipcMainChannels.OPEN_PATH, workspace_dir);
+    if (error) {
+      logger.error(`Error opening directory: ${error}`);
+      this.showErrorModal(true);
+    } else {
+      logger.info(`Directory should be open now`);
+    }
+  }
+
+  showErrorModal(shouldShow) {
+    this.setState({
+      showErrorModal: shouldShow,
+    });
+  }
+
   render() {
     const {
       activeTab,
@@ -215,6 +226,7 @@ class InvestTab extends React.Component {
       argsSpec,
       uiSpec,
       executeClicked,
+      showErrorModal,
     } = this.state;
     const {
       status,
@@ -235,88 +247,99 @@ class InvestTab extends React.Component {
     const sidebarFooterElementId = `sidebar-footer-${tabID}`;
 
     return (
-      <TabContainer activeKey={activeTab} id="invest-tab">
-        <Row className="flex-nowrap">
-          <Col
-            className="invest-sidebar-col"
-          >
-            <Nav
-              className="flex-column"
-              id="vertical tabs"
-              variant="pills"
-              activeKey={activeTab}
-              onSelect={this.switchTabs}
+      <>
+        <TabContainer activeKey={activeTab} id="invest-tab">
+          <Row className="flex-nowrap">
+            <Col
+              className="invest-sidebar-col"
             >
-              <Nav.Link eventKey="setup">
-                {t('Setup')}
-                <MdKeyboardArrowRight />
-              </Nav.Link>
-              <Nav.Link eventKey="log" disabled={logDisabled}>
-                {t('Log')}
-                <MdKeyboardArrowRight />
-              </Nav.Link>
-            </Nav>
-            <div
-              className="sidebar-row sidebar-buttons"
-              id={sidebarSetupElementId}
-            />
-            <div className="sidebar-row sidebar-links">
-              <ResourcesLinks
-                moduleName={modelRunName}
-                docs={modelSpec.userguide}
+              <Nav
+                className="flex-column"
+                id="vertical tabs"
+                variant="pills"
+                activeKey={activeTab}
+                onSelect={this.switchTabs}
+              >
+                <Nav.Link eventKey="setup">
+                  {t('Setup')}
+                  <MdKeyboardArrowRight />
+                </Nav.Link>
+                <Nav.Link eventKey="log" disabled={logDisabled}>
+                  {t('Log')}
+                  <MdKeyboardArrowRight />
+                </Nav.Link>
+              </Nav>
+              <div
+                className="sidebar-row sidebar-buttons"
+                id={sidebarSetupElementId}
               />
-            </div>
-            <div
-              className="sidebar-row sidebar-footer"
-              id={sidebarFooterElementId}
-            >
-              {
-                status
-                  ? (
-                    <ModelStatusAlert
-                      status={status}
-                      handleOpenWorkspace={() => handleOpenWorkspace(logfile, argsValues?.workspace_dir)}
-                      terminateInvestProcess={this.terminateInvestProcess}
-                    />
-                  )
-                  : null
-              }
-            </div>
-          </Col>
-          <Col className="invest-main-col">
-            <TabContent>
-              <TabPane
-                eventKey="setup"
-                aria-label="model setup tab"
-              >
-                <SetupTab
-                  pyModuleName={modelSpec.pyname}
-                  userguide={modelSpec.userguide}
-                  modelName={modelRunName}
-                  argsSpec={argsSpec}
-                  uiSpec={uiSpec}
-                  argsInitValues={argsValues}
-                  investExecute={this.investExecute}
-                  sidebarSetupElementId={sidebarSetupElementId}
-                  sidebarFooterElementId={sidebarFooterElementId}
-                  executeClicked={executeClicked}
-                  switchTabs={this.switchTabs}
+              <div className="sidebar-row sidebar-links">
+                <ResourcesLinks
+                  moduleName={modelRunName}
+                  docs={modelSpec.userguide}
                 />
-              </TabPane>
-              <TabPane
-                eventKey="log"
-                aria-label="model log tab"
+              </div>
+              <div
+                className="sidebar-row sidebar-footer"
+                id={sidebarFooterElementId}
               >
-                <LogTab
-                  logfile={logfile}
-                  executeClicked={executeClicked}
-                  tabID={tabID}
-                />
-              </TabPane>
-            </TabContent>
-          </Col>
-        </Row>
-      </TabContainer>
+                {
+                  status
+                    ? (
+                      <ModelStatusAlert
+                        status={status}
+                        handleOpenWorkspace={() => this.handleOpenWorkspace(logfile, argsValues?.workspace_dir)}
+                        terminateInvestProcess={this.terminateInvestProcess}
+                      />
+                    )
+                    : null
+                }
+              </div>
+            </Col>
+            <Col className="invest-main-col">
+              <TabContent>
+                <TabPane
+                  eventKey="setup"
+                  aria-label="model setup tab"
+                >
+                  <SetupTab
+                    pyModuleName={modelSpec.pyname}
+                    userguide={modelSpec.userguide}
+                    modelName={modelRunName}
+                    argsSpec={argsSpec}
+                    uiSpec={uiSpec}
+                    argsInitValues={argsValues}
+                    investExecute={this.investExecute}
+                    sidebarSetupElementId={sidebarSetupElementId}
+                    sidebarFooterElementId={sidebarFooterElementId}
+                    executeClicked={executeClicked}
+                    switchTabs={this.switchTabs}
+                  />
+                </TabPane>
+                <TabPane
+                  eventKey="log"
+                  aria-label="model log tab"
+                >
+                  <LogTab
+                    logfile={logfile}
+                    executeClicked={executeClicked}
+                    tabID={tabID}
+                  />
+                </TabPane>
+              </TabContent>
+            </Col>
+          </Row>
+        </TabContainer>
+        <Modal show={showErrorModal} onHide={() => this.showErrorModal(false)} aria-labelledby="error-modal-title">
+          <Modal.Header closeButton>
+            <Modal.Title id="error-modal-title">{t('Error opening workspace')}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{t('Failed to open workspace directory. Make sure the directory exists and that you have write access to it.')}</Modal.Body>
+          <Modal.Footer>
+            <Button variant="primary" onClick={() => this.showErrorModal(false)}>{t('OK')}</Button>
+          </Modal.Footer>
+        </Modal>
+      </>
     );
   }
 }

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -187,6 +187,7 @@ describe('createWindow', () => {
       ipcMainChannels.GET_N_CPUS,
       ipcMainChannels.INVEST_VERSION,
       ipcMainChannels.IS_FIRST_RUN,
+      ipcMainChannels.OPEN_PATH,
       ipcMainChannels.SHOW_OPEN_DIALOG,
       ipcMainChannels.SHOW_SAVE_DIALOG,
     ];

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -117,13 +117,9 @@ describe('Run status Alert renders with status from a recent run', () => {
       logfile: 'foo.txt',
     });
 
-    jest.spyOn(shell, 'showItemInFolder');
-
     const { findByRole } = renderInvestTab(job);
     const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' });
     expect(openWorkspaceBtn).toBeTruthy();
-    openWorkspaceBtn.click();
-    expect(shell.showItemInFolder).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -148,42 +144,20 @@ describe('Open Workspace button', () => {
     removeIpcMainListeners();
   });
 
-  test('should open workspace with logfile selected, if logfile exists', async () => {
+  test('should open workspace', async () => {
     const job = {
       ...baseJob,
       argsValues: {
         workspace_dir: '/workspace',
       },
-      logfile: '/workspace/log.txt',
     };
 
-    jest.spyOn(shell, 'showItemInFolder');
-
-    const { findByRole } = renderInvestTab(job);
-    const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' });
-    openWorkspaceBtn.click();
-
-    expect(shell.showItemInFolder).toHaveBeenCalledTimes(1);
-    expect(shell.showItemInFolder).toHaveBeenCalledWith(job.logfile);
-  });
-
-  test('should open workspace (without logfile selected), if workspace exists but logfile does not', async () => {
-    const job = {
-      ...baseJob,
-      argsValues: {
-        workspace_dir: '/workspace',
-      },
-      logfile: undefined,
-    };
-
-    jest.spyOn(shell, 'showItemInFolder');
     jest.spyOn(ipcRenderer, 'invoke');
 
     const { findByRole } = renderInvestTab(job);
     const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' })
     openWorkspaceBtn.click();
 
-    expect(shell.showItemInFolder).not.toHaveBeenCalled();
     expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.invoke).toHaveBeenCalledWith(ipcMainChannels.OPEN_PATH, job.argsValues.workspace_dir);
   });
@@ -195,10 +169,8 @@ describe('Open Workspace button', () => {
       argsValues: {
         workspace_dir: '/nonexistent-workspace',
       },
-      logfile: undefined,
     };
 
-    jest.spyOn(shell, 'showItemInFolder');
     jest.spyOn(ipcRenderer, 'invoke');
     ipcRenderer.invoke.mockResolvedValue('Error opening workspace');
 
@@ -206,7 +178,6 @@ describe('Open Workspace button', () => {
     const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' });
     openWorkspaceBtn.click();
 
-    expect(shell.showItemInFolder).not.toHaveBeenCalled();
     expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.invoke).toHaveBeenCalledWith(ipcMainChannels.OPEN_PATH, job.argsValues.workspace_dir);
 

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -506,7 +506,7 @@ describe('InVEST Run Button', () => {
     uiConfig.UI_SPEC = mockUISpec(spec);
   });
 
-  xtest('Changing inputs trigger validation & enable/disable Run', async () => {
+  test('Changing inputs trigger validation & enable/disable Run', async () => {
     let invalidFeedback = 'is a required key';
     fetchValidation.mockResolvedValue([[['a', 'b'], invalidFeedback]]);
 

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -203,14 +203,15 @@ describe('Open Workspace button', () => {
     ipcRenderer.invoke.mockResolvedValue('Error opening workspace');
 
     const { findByRole } = renderInvestTab(job);
-    const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' })
+    const openWorkspaceBtn = await findByRole('button', { name: 'Open Workspace' });
     openWorkspaceBtn.click();
 
     expect(shell.showItemInFolder).not.toHaveBeenCalled();
     expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
     expect(ipcRenderer.invoke).toHaveBeenCalledWith(ipcMainChannels.OPEN_PATH, job.argsValues.workspace_dir);
 
-    // @TODO: expect error message UI element to exist
+    const errorModal = await findByRole('dialog', { name: 'Error opening workspace'});
+    expect(errorModal).toBeTruthy();
   });
 });
 
@@ -505,7 +506,7 @@ describe('InVEST Run Button', () => {
     uiConfig.UI_SPEC = mockUISpec(spec);
   });
 
-  test('Changing inputs trigger validation & enable/disable Run', async () => {
+  xtest('Changing inputs trigger validation & enable/disable Run', async () => {
     let invalidFeedback = 'is a required key';
     fetchValidation.mockResolvedValue([[['a', 'b'], invalidFeedback]]);
 


### PR DESCRIPTION
## Description
Fixes #1598, with a solution that is more forgiving (and perhaps more user-friendly) than the one in [PR #1617](https://github.com/natcap/invest/pull/1617).

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [n/a] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)

## Representative screenshots

### Open workspace with valid logfile (logfile is no longer selected, for the sake of simplicity)
<img width="905" alt="open-workspace_valid-logfile_not-highlighted_2024-08-29" src="https://github.com/user-attachments/assets/5139db7c-8e1f-414a-8bc4-223589cc9065">

### Open workspace with missing logfile (in this case, it was manually deleted after a successful run)
<img width="931" alt="open-workspace_missing-logfile_2024-08-23" src="https://github.com/user-attachments/assets/f855c9d0-dc11-4d29-b802-96f6c0b9ce19">

### Open empty workspace (this might happen if, for example, the workspace is readonly—see #1599)
<img width="940" alt="open-workspace_empty-workspace_2024-08-23" src="https://github.com/user-attachments/assets/04bf0e86-c48d-45b4-a55d-f4caea660e31">

### Error modal when workspace cannot be opened (for example, if it does not exist, as would be the case if the workspace path specified a not-yet-extant subdirectory of a readonly directory—see #1599)
<img width="1239" alt="open-workspace_nonexistent-workspace_2024-08-23" src="https://github.com/user-attachments/assets/260ff2ef-8ec4-48b6-b9e5-e78c4a735109">
