### PR TITLE
Updates directory permissions validation to use an EAFP approach

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -39,6 +39,7 @@ Unreleased Changes
 ------------------
 * Workbench
   * Several small updates to the model input form UI to improve usability and visual consistency (https://github.com/natcap/invest/issues/912)
+  * Fixed a bug that was allowing readonly workspace directories on Windows (https://github.com/natcap/invest/issues/1599)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -204,13 +204,15 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
     # Check for x access before checking for w, since w operations to a dir are dependent on x access
     if 'x' in permissions:
         try:
+            cwd = os.getcwd()
             os.chdir(dirpath)
+            os.chdir(cwd)
         except:
             return MESSAGES[MESSAGE_KEY].format(permission='execute')
 
     if 'w' in permissions:
         try:
-            tempfile.TemporaryFile(dir=dirpath)
+            tempfile.TemporaryFile(dir=dirpath).close()
         except:
             return MESSAGES[MESSAGE_KEY].format(permission='write')
 

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -166,8 +166,8 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
         must_exist=True (bool): If ``True``, the directory at ``dirpath``
             must already exist on the filesystem.
         permissions='rx' (string): A string that includes the lowercase
-            characters ``r``, ``w`` and/or ``x``, indicating read, write, and execute
-            permissions (respectively) required for this directory.
+            characters ``r``, ``w`` and/or ``x``, indicating read, write, and
+            execute permissions (respectively) required for this directory.
 
     Returns:
         A string error message if an error was found.  ``None`` otherwise.
@@ -197,25 +197,27 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
     if 'r' in permissions:
         try:
             os.scandir(dirpath).close()
-        except:
+        except OSError:
             return MESSAGES[MESSAGE_KEY].format(permission='read')
 
-    # Check for x access before checking for w, since w operations to a dir are dependent on x access
+    # Check for x access before checking for w,
+    # since w operations to a dir are dependent on x access
     if 'x' in permissions:
         try:
             cwd = os.getcwd()
             os.chdir(dirpath)
-            os.chdir(cwd)
-        except:
+        except OSError:
             return MESSAGES[MESSAGE_KEY].format(permission='execute')
+        finally:
+            os.chdir(cwd)
 
     if 'w' in permissions:
         try:
-            temp_path = os.path.join(dirpath, '__temp__workspace_validation_check.txt')
+            temp_path = os.path.join(dirpath, 'temp__workspace_validation.txt')
             with open(temp_path, 'w') as temp:
                 temp.close()
                 os.remove(temp_path)
-        except:
+        except OSError:
             return MESSAGES[MESSAGE_KEY].format(permission='write')
 
 
@@ -225,8 +227,8 @@ def check_file(filepath, permissions='r', **kwargs):
     Args:
         filepath (string): The filepath to validate.
         permissions='r' (string): A string that includes the lowercase
-            characters ``r``, ``w`` and/or ``x``, indicating read, write, and execute
-            permissions (respectively) required for this file.
+            characters ``r``, ``w`` and/or ``x``, indicating read, write, and
+            execute permissions (respectively) required for this file.
 
     Returns:
         A string error message if an error was found.  ``None`` otherwise.

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -9,7 +9,6 @@ import os
 import pprint
 import queue
 import re
-import tempfile
 import threading
 import warnings
 
@@ -212,7 +211,10 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
 
     if 'w' in permissions:
         try:
-            tempfile.TemporaryFile(dir=dirpath).close()
+            temp_path = os.path.join(dirpath, '__temp__workspace_validation_check.txt')
+            with open(temp_path, 'w') as temp:
+                temp.close()
+                os.remove(temp_path)
         except:
             return MESSAGES[MESSAGE_KEY].format(permission='write')
 

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -9,6 +9,7 @@ import os
 import pprint
 import queue
 import re
+import tempfile
 import threading
 import warnings
 
@@ -166,9 +167,8 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
         must_exist=True (bool): If ``True``, the directory at ``dirpath``
             must already exist on the filesystem.
         permissions='rx' (string): A string that includes the lowercase
-            characters ``r``, ``w`` and/or ``x`` indicating required
-            permissions for this folder .  See ``check_permissions`` for
-            details.
+            characters ``r``, ``w`` and/or ``x``, indicating read, write, and execute
+            permissions (respectively) required for this directory.
 
     Returns:
         A string error message if an error was found.  ``None`` otherwise.
@@ -193,9 +193,26 @@ def check_directory(dirpath, must_exist=True, permissions='rx', **kwargs):
                 dirpath = parent
                 break
 
-    permissions_warning = check_permissions(dirpath, permissions, True)
-    if permissions_warning:
-        return permissions_warning
+    MESSAGE_KEY = 'NEED_PERMISSION_DIRECTORY'
+
+    if 'r' in permissions:
+        try:
+            os.scandir(dirpath).close()
+        except:
+            return MESSAGES[MESSAGE_KEY].format(permission='read')
+
+    # Check for x access before checking for w, since w operations to a dir are dependent on x access
+    if 'x' in permissions:
+        try:
+            os.chdir(dirpath)
+        except:
+            return MESSAGES[MESSAGE_KEY].format(permission='execute')
+
+    if 'w' in permissions:
+        try:
+            tempfile.TemporaryFile(dir=dirpath)
+        except:
+            return MESSAGES[MESSAGE_KEY].format(permission='write')
 
 
 def check_file(filepath, permissions='r', **kwargs):
@@ -204,9 +221,8 @@ def check_file(filepath, permissions='r', **kwargs):
     Args:
         filepath (string): The filepath to validate.
         permissions='r' (string): A string that includes the lowercase
-            characters ``r``, ``w`` and/or ``x`` indicating required
-            permissions for this file.  See ``check_permissions`` for
-            details.
+            characters ``r``, ``w`` and/or ``x``, indicating read, write, and execute
+            permissions (respectively) required for this file.
 
     Returns:
         A string error message if an error was found.  ``None`` otherwise.
@@ -215,36 +231,12 @@ def check_file(filepath, permissions='r', **kwargs):
     if not os.path.exists(filepath):
         return MESSAGES['FILE_NOT_FOUND']
 
-    permissions_warning = check_permissions(filepath, permissions)
-    if permissions_warning:
-        return permissions_warning
-
-
-def check_permissions(path, permissions, is_directory=False):
-    """Validate permissions on a filesystem object.
-
-    This function uses ``os.access`` to determine permissions access.
-
-    Args:
-        path (string): The path to examine for permissions.
-        permissions (string): a string including the characters ``r``, ``w``
-            and/or ``x`` (lowercase), indicating read, write, and execute
-            permissions (respectively) that the filesystem object at ``path``
-            must have.
-        is_directory (boolean): Indicates whether the path refers to a directory
-            (True) or a file (False). Defaults to False.
-
-    Returns:
-        A string error message if an error was found.  ``None`` otherwise.
-
-    """
     for letter, mode, descriptor in (
             ('r', os.R_OK, 'read'),
             ('w', os.W_OK, 'write'),
             ('x', os.X_OK, 'execute')):
-        if letter in permissions and not os.access(path, mode):
-            message_key = 'NEED_PERMISSION_DIRECTORY' if is_directory else 'NEED_PERMISSION_FILE'
-            return MESSAGES[message_key].format(permission=descriptor)
+        if letter in permissions and not os.access(filepath, mode):
+            return MESSAGES['NEED_PERMISSION_FILE'].format(permission=descriptor)
 
 
 def _check_projection(srs, projected, projection_units):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,6 +5,7 @@ import functools
 import os
 import platform
 import shutil
+import stat
 import string
 import tempfile
 import textwrap
@@ -318,6 +319,60 @@ class DirectoryValidation(unittest.TestCase):
 
         self.assertEqual(None, validation.check_directory(
             self.workspace_dir, permissions='rwx'))
+
+    def test_invalid_permissions_r(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing write and execute permissions."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IREAD)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
+
+    def test_invalid_permissions_w(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing read and execute permissions."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IWRITE)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+
+    def test_invalid_permissions_x(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing read and write permissions."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IEXEC)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+
+    def test_invalid_permissions_rw(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing execute permission."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IREAD | stat.S_IWRITE)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
+
+    def test_invalid_permissions_rx(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing write permission."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IREAD | stat.S_IEXEC)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='write'))
+
+    def test_invalid_permissions_wx(self):
+        """Validation: when a folder must have read/write/execute permissions but is missing read permission."""
+        from natcap.invest import validation
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.chmod(tempdir, stat.S_IWRITE | stat.S_IEXEC)
+            validation_warning = validation.check_directory(tempdir, permissions='rwx')
+            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
 
     def test_workspace_not_exists(self):
         """Validation: when a folder's parent must exist with permissions."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,9 +1,6 @@
 """Testing module for validation."""
-import codecs
-import collections
 import functools
 import os
-import platform
 import shutil
 import stat
 import string
@@ -331,63 +328,91 @@ class DirectoryValidation(unittest.TestCase):
         self.assertEqual(None, validation.check_directory(
             new_dir, must_exist=False, permissions='rwx'))
 
-@unittest.skipIf(sys.platform.startswith('win'), 'requires support for os.chmod(), which is unreliable on Windows')
+
+@unittest.skipIf(
+    sys.platform.startswith('win'),
+    'requires support for os.chmod(), which is unreliable on Windows')
 class DirectoryValidationMacOnly(unittest.TestCase):
     """Test Directory Permissions Validation."""
 
     def test_invalid_permissions_r(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing write and execute permissions."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing write and execute permissions."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IREAD)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
 
     def test_invalid_permissions_w(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing read and execute permissions."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing read and execute permissions."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IWRITE)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
 
     def test_invalid_permissions_x(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing read and write permissions."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing read and write permissions."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IEXEC)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
 
     def test_invalid_permissions_rw(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing execute permission."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing execute permission."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IREAD | stat.S_IWRITE)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='execute'))
 
     def test_invalid_permissions_rx(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing write permission."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing write permission."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IREAD | stat.S_IEXEC)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='write'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='write'))
 
     def test_invalid_permissions_wx(self):
-        """Validation: when a folder must have read/write/execute permissions but is missing read permission."""
+        """Validation: when a folder must have read/write/execute
+        permissions but is missing read permission."""
         from natcap.invest import validation
 
         with tempfile.TemporaryDirectory() as tempdir:
             os.chmod(tempdir, stat.S_IWRITE | stat.S_IEXEC)
-            validation_warning = validation.check_directory(tempdir, permissions='rwx')
-            self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+            validation_warning = validation.check_directory(tempdir,
+                                                            permissions='rwx')
+            self.assertEqual(
+                validation_warning,
+                validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
+
 
 class FileValidation(unittest.TestCase):
     """Test File Validator."""
@@ -598,7 +623,6 @@ class VectorValidation(unittest.TestCase):
 
     def test_wrong_geom_type(self):
         """Validation: checks that the vector's geometry type is correct."""
-        from natcap.invest import spec_utils
         from natcap.invest import validation
         driver = gdal.GetDriverByName('GPKG')
         filepath = os.path.join(self.workspace_dir, 'vector.gpkg')
@@ -1427,7 +1451,6 @@ class TestGetValidatedDataframe(unittest.TestCase):
                     'col2': {'type': 'raster'}
                 })
         self.assertIn('File not found', str(cm.exception))
-
 
     def test_csv_raster_validation_not_projected(self):
         """validation: validate unprojected raster within csv column"""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import stat
 import string
+import sys
 import tempfile
 import textwrap
 import time
@@ -320,6 +321,20 @@ class DirectoryValidation(unittest.TestCase):
         self.assertEqual(None, validation.check_directory(
             self.workspace_dir, permissions='rwx'))
 
+    def test_workspace_not_exists(self):
+        """Validation: when a folder's parent must exist with permissions."""
+        from natcap.invest import validation
+
+        dirpath = 'foo'
+        new_dir = os.path.join(self.workspace_dir, dirpath)
+
+        self.assertEqual(None, validation.check_directory(
+            new_dir, must_exist=False, permissions='rwx'))
+
+@unittest.skipIf(sys.platform.startswith('win'), 'requires support for os.chmod(), which is unreliable on Windows')
+class DirectoryValidationMacOnly(unittest.TestCase):
+    """Test Directory Permissions Validation."""
+
     def test_invalid_permissions_r(self):
         """Validation: when a folder must have read/write/execute permissions but is missing write and execute permissions."""
         from natcap.invest import validation
@@ -373,17 +388,6 @@ class DirectoryValidation(unittest.TestCase):
             os.chmod(tempdir, stat.S_IWRITE | stat.S_IEXEC)
             validation_warning = validation.check_directory(tempdir, permissions='rwx')
             self.assertEqual(validation_warning, validation.MESSAGES['NEED_PERMISSION_DIRECTORY'].format(permission='read'))
-
-    def test_workspace_not_exists(self):
-        """Validation: when a folder's parent must exist with permissions."""
-        from natcap.invest import validation
-
-        dirpath = 'foo'
-        new_dir = os.path.join(self.workspace_dir, dirpath)
-
-        self.assertEqual(None, validation.check_directory(
-            new_dir, must_exist=False, permissions='rwx'))
-
 
 class FileValidation(unittest.TestCase):
     """Test File Validator."""


### PR DESCRIPTION
## Description
_Should_ fix #1599 by shifting to an [EAFP](https://docs.python.org/3/glossary.html#term-EAFP) approach to validating directory access.

File permissions validation still relies on [os.access()](https://docs.python.org/3/library/os.html#os.access), for now.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [n/a] Updated the user's guide (if needed)
- [x] Tested the Workbench UI on macOS
- [x] Tested the Workbench UI on Windows

## macOS screenshots
Tested the Workbench UI on macOS with the following eight user permissions scenarios (some more likely to exist IRL than others): `---`, `r--`, `-w-`, `--x`, `rw-`, `r-x`, `-wx`, `rwx`. Here are just a few examples:

### No access (missing r, w, and x)
<img width="925" alt="workspace-permissions_no-access_2024-08-27" src="https://github.com/user-attachments/assets/9faa1e72-59ec-4a56-acbd-053c8fcd9586">

### Strictly readonly (has r, missing w and x)
<img width="925" alt="permissions_r_2024-08-27" src="https://github.com/user-attachments/assets/e93511d8-18e9-4c19-8922-f9cba5b63057">

### "Readonly" in the colloquial sense (has r and x, missing w)
<img width="922" alt="permissions_rx_2024-08-27" src="https://github.com/user-attachments/assets/3cb825f3-86e3-4205-8953-09d87e64d329">

### Full access (has r, w, and x)
<img width="923" alt="permissions_rwx_2024-08-27" src="https://github.com/user-attachments/assets/36e31358-fa5c-4a47-bf16-3f2e9b93e5ef">
