### PR TITLE
Avoid pyinstaller multiprocessing issues by capping `pyinstaller<6.10`

### DIFF
--- a/constraints_tests.txt
+++ b/constraints_tests.txt
@@ -8,3 +8,8 @@ GDAL!=3.6.*,!=3.7.*
 
 # https://github.com/natcap/pygeoprocessing/issues/387
 GDAL<3.8.5
+
+# Pyinstaller 6.10 breaks our windows builds.  Until we can figure out the
+root cause, let's cap the versions to those that work.
+# https://github.com/natcap/invest/issues/1622
+pyinstaller<6.10

--- a/constraints_tests.txt
+++ b/constraints_tests.txt
@@ -10,6 +10,6 @@ GDAL!=3.6.*,!=3.7.*
 GDAL<3.8.5
 
 # Pyinstaller 6.10 breaks our windows builds.  Until we can figure out the
-root cause, let's cap the versions to those that work.
+# root cause, let's cap the versions to those that work.
 # https://github.com/natcap/invest/issues/1622
 pyinstaller<6.10

--- a/exe/invest.spec
+++ b/exe/invest.spec
@@ -30,7 +30,8 @@ kwargs = {
         'pkg_resources.py2_warn',
         'cmath',
         'charset_normalizer',
-        'scipy.special._cdflib'
+        'scipy.special._cdflib',
+        'scipy.special._special_ufuncs',
     ],
     'datas': [proj_datas],
     'cipher': block_cipher,

--- a/exe/invest.spec
+++ b/exe/invest.spec
@@ -32,6 +32,7 @@ kwargs = {
         'charset_normalizer',
         'scipy.special._cdflib',
         'scipy.special._special_ufuncs',
+        'scipy._lib.array_api_compat.numpy.fft',
     ],
     'datas': [proj_datas],
     'cipher': block_cipher,


### PR DESCRIPTION
This doesn't fix the issue entirely, but it should at least help make our builds work again.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
