### PR TITLE
Add twine check and add README_PYTHON.rst to doc8 linting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,8 +46,8 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           python -m flake8 src --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-  check-history-rst-syntax:
-    name: Check HISTORY RST syntax
+  check-rst-syntax:
+    name: Check RST syntax
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
       - name: Lint with doc8
         run: |
             # Skip line-too-long errors (D001)
-            python -m doc8 --ignore D001 HISTORY.rst
+            python -m doc8 --ignore D001 HISTORY.rst README_PYTHON.rst
 
   run-model-tests:
     name: Run model tests
@@ -192,6 +192,12 @@ jobs:
           # The point here is to make sure that we can build
           # natcap.invest from source and that it imports.
           python -c "from natcap.invest import *"
+
+      - name: Set up environment
+        run: pip install twine
+
+      - name: Check long description with twine
+        run: twine check $(find dist -name "natcap[._-]invest*")
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           requirements-files: requirements.txt
-          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} twine
 
       - name: Build source distribution
         run: |
@@ -192,9 +192,6 @@ jobs:
           # The point here is to make sure that we can build
           # natcap.invest from source and that it imports.
           python -c "from natcap.invest import *"
-
-      - name: Set up environment
-        run: pip install twine
 
       - name: Check long description with twine
         run: twine check $(find dist -name "natcap[._-]invest*")


### PR DESCRIPTION
## Description
Resolves #1582.

1. Added `twine check` task, which validates the source distribution and raises an error if there are problems in the long description that will prevent proper rendering on PyPI. (See [twine check example output](https://github.com/emilyanndavis/invest/actions/runs/10782853636/job/29903637756#step:7:22) from an intentionally failed run.)
2. Also updated the `check-history-rst-syntax` so that it also lints README_PYTHON.rst. While `twine check` seems to bail after the first syntax error it encounters, doc8 reports all issues, which would be helpful in the (albeit unlikely) scenario in which README_PYTHON.rst is updated and ends up with multiple syntax issues. (See [doc8 example output](https://github.com/emilyanndavis/invest/actions/runs/10782853636/job/29903628924) from an intentionally failed run.)

I realize there's a lot of overlap between these two tasks, so I'm open to other options if folks think it's not worthwhile to include both.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
