### PR TITLE
UFRM: preserve source AOI fields in output vector

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,9 @@ Unreleased Changes
       (https://github.com/natcap/invest/issues/1598)
     * Fixed a bug that was allowing readonly workspace directories on Windows
       (https://github.com/natcap/invest/issues/1599)
+* Urban Flood Risk
+    * Fields present on the input AOI vector are now retained in the output.
+      (https://github.com/natcap/invest/issues/1600)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -554,6 +554,7 @@ def _write_summary_vector(
     """
     source_aoi_vector = gdal.OpenEx(source_aoi_vector_path, gdal.OF_VECTOR)
     source_aoi_layer = source_aoi_vector.GetLayer()
+    source_aoi_field_defns = source_aoi_layer.schema
     source_geom_type = source_aoi_layer.GetGeomType()
     source_srs_wkt = pygeoprocessing.get_vector_info(
         source_aoi_vector_path)['projection_wkt']
@@ -612,6 +613,10 @@ def _write_summary_vector(
             'flood_vol', float(flood_volume_stats[feature_id]['sum']))
 
         target_watershed_layer.CreateFeature(target_feature)
+
+    for field_defn in source_aoi_field_defns:
+        target_watershed_layer.CreateField(field_defn)
+
     target_watershed_layer.SyncToDisk()
     target_watershed_layer = None
     target_watershed_vector = None

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -173,14 +173,14 @@ MODEL_SPEC = {
                     "about": "Map of runoff volume.",
                     "bands": {1: {"type": "number", "units": u.meter**3}}
                 },
-                "reprojected_aoi.gpkg": {
+                "reprojected_aoi.shp": {
                     "about": (
                         "Copy of AOI vector reprojected to the same spatial "
                         "reference as the LULC."),
                     "geometries": spec_utils.POLYGONS,
                     "fields": {}
                 },
-                "structures_reprojected.gpkg": {
+                "structures_reprojected.shp": {
                     "about": (
                         "Copy of built infrastructure vector reprojected to "
                         "the same spatial reference as the LULC."),
@@ -408,14 +408,14 @@ def execute(args):
         task_name='calculate service built raster')
 
     reprojected_aoi_path = os.path.join(
-        intermediate_dir, 'reprojected_aoi.gpkg')
+        intermediate_dir, 'reprojected_aoi')
     reprojected_aoi_task = task_graph.add_task(
         func=pygeoprocessing.reproject_vector,
         args=(
             args['aoi_watersheds_path'],
             target_sr_wkt,
             reprojected_aoi_path),
-        kwargs={'driver_name': 'GPKG'},
+        kwargs={'driver_name': 'ESRI Shapefile'},
         target_path_list=[reprojected_aoi_path],
         task_name='reproject aoi/watersheds')
 
@@ -435,7 +435,7 @@ def execute(args):
             (runoff_retention_raster_path, 1),
             reprojected_aoi_path),
         store_result=True,
-        dependent_task_list=[runoff_retention_task],
+        dependent_task_list=[runoff_retention_task, reprojected_aoi_task],
         task_name='zonal_statistics over runoff_retention raster')
 
     runoff_retention_volume_stats_task = task_graph.add_task(
@@ -444,7 +444,7 @@ def execute(args):
             (runoff_retention_vol_raster_path, 1),
             reprojected_aoi_path),
         store_result=True,
-        dependent_task_list=[runoff_retention_vol_task],
+        dependent_task_list=[runoff_retention_vol_task, reprojected_aoi_task],
         task_name='zonal_statistics over runoff_retention_volume raster')
 
     damage_per_aoi_stats = None
@@ -457,13 +457,13 @@ def execute(args):
             args['built_infrastructure_vector_path'] not in ('', None)):
         # Reproject the built infrastructure vector to the target SRS.
         reprojected_structures_path = os.path.join(
-            intermediate_dir, 'structures_reprojected.gpkg')
+            intermediate_dir, 'structures_reprojected')
         reproject_built_infrastructure_task = task_graph.add_task(
             func=pygeoprocessing.reproject_vector,
             args=(args['built_infrastructure_vector_path'],
                   target_sr_wkt,
                   reprojected_structures_path),
-            kwargs={'driver_name': 'GPKG'},
+            kwargs={'driver_name': 'ESRI Shapefile'},
             target_path_list=[reprojected_structures_path],
             task_name='reproject built infrastructure to target SRS')
 
@@ -512,7 +512,7 @@ def _write_summary_vector(
         runoff_ret_vol_stats, flood_volume_stats, damage_per_aoi_stats=None):
     """Write a vector with summary statistics.
 
-    This vector will always contain two fields::
+    This vector will always contain three fields::
 
         * ``'flood_vol'``: The volume of flood (runoff), in m3, per watershed.
         * ``'rnf_rt_idx'``: Average of runoff retention values per watershed
@@ -571,34 +571,31 @@ def _write_summary_vector(
 
     target_watershed_layer.ResetReading()
     for target_feature in target_watershed_layer:
-        # Target vector is SHP, where FIDs start at 0, but stats were
-        # generated based on GPKG reprojection, where FIDs start at 1.
-        # Therefore, we need to reference stats at SHP FID + 1.
-        stat_key = target_feature.GetFID() + 1
+        feature_id = target_feature.GetFID()
 
-        pixel_count = runoff_ret_stats[stat_key]['count']
+        pixel_count = runoff_ret_stats[feature_id]['count']
         if pixel_count > 0:
             mean_value = (
-                runoff_ret_stats[stat_key]['sum'] / float(pixel_count))
+                runoff_ret_stats[feature_id]['sum'] / float(pixel_count))
             target_feature.SetField('rnf_rt_idx', float(mean_value))
 
         target_feature.SetField(
             'rnf_rt_m3', float(
-                runoff_ret_vol_stats[stat_key]['sum']))
+                runoff_ret_vol_stats[feature_id]['sum']))
 
         if damage_per_aoi_stats is not None:
-            pixel_count = runoff_ret_vol_stats[stat_key]['count']
+            pixel_count = runoff_ret_vol_stats[feature_id]['count']
             if pixel_count > 0:
-                damage_sum = damage_per_aoi_stats[stat_key]
+                damage_sum = damage_per_aoi_stats[feature_id]
                 target_feature.SetField('aff_bld', damage_sum)
 
                 # This is the service_built equation.
                 target_feature.SetField(
                     'serv_blt', (
-                        damage_sum * runoff_ret_vol_stats[stat_key]['sum']))
+                        damage_sum * runoff_ret_vol_stats[feature_id]['sum']))
 
         target_feature.SetField(
-            'flood_vol', float(flood_volume_stats[stat_key]['sum']))
+            'flood_vol', float(flood_volume_stats[feature_id]['sum']))
 
         target_watershed_layer.SetFeature(target_feature)
 

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -79,7 +79,7 @@ class UFRMTests(unittest.TestCase):
             set(output_fields),
             set(field.GetName() for field in result_layer.schema))
 
-        result_feature = result_layer.GetFeature(0)
+        result_feature = result_layer.GetNextFeature()
         for fieldname, expected_value in (
                 ('aff_bld', 187010830.32202843),
                 ('serv_blt', 13253546667257.65),
@@ -91,6 +91,11 @@ class UFRMTests(unittest.TestCase):
                 int(round(numpy.log(expected_value)/numpy.log(10)))-6)
             self.assertAlmostEqual(
                 result_val, expected_value, places=-places_to_round)
+
+        input_feature = input_layer.GetNextFeature()
+        for fieldname in input_fields:
+            self.assertEqual(result_feature.GetField(fieldname),
+                             input_feature.GetField(fieldname))
 
         result_feature = None
         result_layer = None

--- a/tests/test_ufrm.py
+++ b/tests/test_ufrm.py
@@ -59,6 +59,11 @@ class UFRMTests(unittest.TestCase):
         """UFRM: regression test."""
         from natcap.invest import urban_flood_risk_mitigation
         args = self._make_args()
+        input_vector = gdal.OpenEx(args['aoi_watersheds_path'],
+                                   gdal.OF_VECTOR)
+        input_layer = input_vector.GetLayer()
+        input_fields = [field.GetName() for field in input_layer.schema]
+
         urban_flood_risk_mitigation.execute(args)
 
         result_vector = gdal.OpenEx(os.path.join(
@@ -66,10 +71,12 @@ class UFRMTests(unittest.TestCase):
             gdal.OF_VECTOR)
         result_layer = result_vector.GetLayer()
 
-        # Check that all four expected fields are there.
+        # Check that all expected fields are there.
+        output_fields = ['aff_bld', 'serv_blt', 'rnf_rt_idx',
+                         'rnf_rt_m3', 'flood_vol']
+        output_fields += input_fields
         self.assertEqual(
-            set(('aff_bld', 'serv_blt', 'rnf_rt_idx', 'rnf_rt_m3',
-                 'flood_vol')),
+            set(output_fields),
             set(field.GetName() for field in result_layer.schema))
 
         result_feature = result_layer.GetFeature(0)
@@ -94,6 +101,11 @@ class UFRMTests(unittest.TestCase):
         from natcap.invest import urban_flood_risk_mitigation
         args = self._make_args()
         del args['built_infrastructure_vector_path']
+        input_vector = gdal.OpenEx(args['aoi_watersheds_path'],
+                                   gdal.OF_VECTOR)
+        input_layer = input_vector.GetLayer()
+        input_fields = [field.GetName() for field in input_layer.schema]
+
         urban_flood_risk_mitigation.execute(args)
 
         result_raster = gdal.OpenEx(os.path.join(
@@ -115,9 +127,11 @@ class UFRMTests(unittest.TestCase):
         result_layer = result_vector.GetLayer()
         result_feature = result_layer.GetFeature(0)
 
-        # Check that only the two expected fields are there.
+        # Check that only the expected fields are there.
+        output_fields = ['rnf_rt_idx', 'rnf_rt_m3', 'flood_vol']
+        output_fields += input_fields
         self.assertEqual(
-            set(('rnf_rt_idx', 'rnf_rt_m3', 'flood_vol')),
+            set(output_fields),
             set(field.GetName() for field in result_layer.schema))
 
         for fieldname, expected_value in (
@@ -217,7 +231,6 @@ class UFRMTests(unittest.TestCase):
             urban_flood_risk_mitigation.execute(args)
         except ValueError:
             self.fail('unexpected ValueError when testing curve number row with all zeros')
-
 
     def test_ufrm_string_damage_to_infrastructure(self):
         """UFRM: handle str(int) structure indices.


### PR DESCRIPTION
## Description
Fixes #1600 by using [CreateCopy](https://gdal.org/en/latest/api/python/raster_api.html#osgeo.gdal.Driver.CreateCopy) to generate target vector based on input vector.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
