### PR TITLE
Bugfix: saving datastack with absolute paths

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -45,6 +45,9 @@ Unreleased Changes
       (https://github.com/natcap/invest/issues/1598)
     * Fixed a bug that was allowing readonly workspace directories on Windows
       (https://github.com/natcap/invest/issues/1599)
+    * Fixed a bug that, in certain scenarios, caused a datastack to be saved
+      with relative paths when the Relative Paths checkbox was left unchecked
+      (https://github.com/natcap/invest/issues/1609)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/workbench/src/renderer/components/SaveAsModal/index.jsx
+++ b/workbench/src/renderer/components/SaveAsModal/index.jsx
@@ -67,7 +67,10 @@ class SaveAsModal extends React.Component {
   }
 
   handleShow() {
-    this.setState({ show: true });
+    this.setState({
+      relativePaths: false,
+      show: true,
+    });
   }
 
   handleChange(event) {


### PR DESCRIPTION
## Description
Fixes #1609 by resetting `relativePaths` to false each time the modal opens.

Confirmed this works by saving a datastack with Relative Paths checked (paths are indeed relative), then, in the same tab, saving the datastack with Relative Paths left unchecked (paths are indeed absolute).

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
