### PR TITLE
HQ: Use reprojected access vector in rasterization task

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -48,6 +48,9 @@ Unreleased Changes
     * Fixed a bug that, in certain scenarios, caused a datastack to be saved
       with relative paths when the Relative Paths checkbox was left unchecked
       (https://github.com/natcap/invest/issues/1609)
+* Habitat Quality
+    * Access raster is now generated from the reprojected access vector.
+      (https://github.com/natcap/invest/issues/1615)
 
 3.14.2 (2024-05-29)
 -------------------

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -555,7 +555,7 @@ def execute(args):
 
         rasterize_access_task = task_graph.add_task(
             func=pygeoprocessing.rasterize,
-            args=(args['access_vector_path'], access_raster_path),
+            args=(reprojected_access_path, access_raster_path),
             kwargs={
                 'option_list': ['ATTRIBUTE=ACCESS'],
                 'burn_values': None


### PR DESCRIPTION
## Description
Fixes #1615 by passing the reprojected access vector to the rasterize_access task

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- ~~[ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
