### PR TITLE
Update conf.py to fix Read the Docs build

### DIFF
--- a/doc/api-docs/conf.py
+++ b/doc/api-docs/conf.py
@@ -89,9 +89,6 @@ if os.environ.get('READTHEDOCS', '') == 'True':
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
 
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 html_logo = "_static/invest-logo.png"

--- a/doc/api-docs/conf.py
+++ b/doc/api-docs/conf.py
@@ -79,12 +79,6 @@ keep_warnings = False
 
 import sphinx_rtd_theme
 
-# Tell Jinja2 templates the build is running on Read the Docs
-if os.environ.get('READTHEDOCS', '') == 'True':
-    if 'html_context' not in globals():
-        html_context = {}
-    html_context['READTHEDOCS'] = True
-
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'

--- a/doc/api-docs/conf.py
+++ b/doc/api-docs/conf.py
@@ -78,6 +78,13 @@ keep_warnings = False
 # -- Options for HTML output ----------------------------------------------
 
 import sphinx_rtd_theme
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get('READTHEDOCS', '') == 'True':
+    if 'html_context' not in globals():
+        html_context = {}
+    html_context['READTHEDOCS'] = True
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
@@ -130,7 +137,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'InVEST', 'InVEST Documentation',
-   'The Natural Capital Project', 'InVEST', 
+   'The Natural Capital Project', 'InVEST',
    'Integrated Valuation of Ecosystem Services and Tradeoffs',
    'Scientific Software'),
 ]
@@ -138,8 +145,8 @@ texinfo_documents = [
 
 # -- Prepare for sphinx build ---------------------------------------------
 
-# Use sphinx apidoc tool to generate documentation for invest. Generated rst 
-# files go into the api/ directory. Note that some apidoc options may not work 
+# Use sphinx apidoc tool to generate documentation for invest. Generated rst
+# files go into the api/ directory. Note that some apidoc options may not work
 # the same because we aren't using their values in the custom templates
 apidoc.main([
     '--force',  # overwrite any files from previous run
@@ -164,7 +171,7 @@ InVEST Model Entry Points
 
 All InVEST models share a consistent python API:
 
-    - Every InVEST model has a corresponding module or subpackage in the 
+    - Every InVEST model has a corresponding module or subpackage in the
       ``natcap.invest`` package
     - The model modules contain a function called ``execute``
     - The ``execute`` function takes a single argument (``args``), a dictionary


### PR DESCRIPTION
## Description
Fixes #1639 by removing a call to `get_html_theme_path()`, which has been deprecated and is no longer needed, per this message from the RTD build logs:

`WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.`

## Checklist
- ~~[ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
- ~~[ ] Updated the user's guide (if needed)~~
- ~~[ ] Tested the Workbench UI (if relevant)~~
