### PR TITLE
Redesign plugin interface and support removing plugins

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,6 +89,13 @@ jobs:
           path: data/invest-test-data
           key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
+      - name: debug
+        run: |
+          ls data/invest-test-data
+          ls data/invest-test-data/wind_energy/smoke
+          ls /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke
+          gdalinfo /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke/landpoly_smoke.shp
+
       - name: Set up python environment
         uses: ./.github/actions/setup_env
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,13 +89,6 @@ jobs:
           path: data/invest-test-data
           key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
-      - name: debug
-        run: |
-          ls data/invest-test-data
-          ls data/invest-test-data/wind_energy/smoke
-          ls /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke
-          gdalinfo /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke/landpoly_smoke.shp
-
       - name: Set up python environment
         uses: ./.github/actions/setup_env
         with:
@@ -129,6 +122,13 @@ jobs:
           python -m build --wheel
           ls -la dist
           pip install $(find dist -name "natcap.invest*.whl")
+
+      - name: debug
+        run: |
+          ls data/invest-test-data
+          ls data/invest-test-data/wind_energy/smoke
+          ls /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke
+          gdalinfo /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke/landpoly_smoke.shp
 
       - name: Run model tests
         run: make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,13 +123,6 @@ jobs:
           ls -la dist
           pip install $(find dist -name "natcap.invest*.whl")
 
-      - name: debug
-        run: |
-          ls data/invest-test-data
-          ls data/invest-test-data/wind_energy/smoke
-          ls /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke
-          gdalinfo /Users/runner/work/invest/invest/tests/../data/invest-test-data/wind_energy/smoke/landpoly_smoke.shp
-
       - name: Run model tests
         run: make test
 

--- a/workbench/src/main/ipcMainChannels.js
+++ b/workbench/src/main/ipcMainChannels.js
@@ -17,6 +17,7 @@ export const ipcMainChannels = {
   LOGGER: 'logger',
   OPEN_EXTERNAL_URL: 'open-external-url',
   OPEN_LOCAL_HTML: 'open-local-html',
+  REMOVE_PLUGIN: 'remove-plugin',
   SET_SETTING: 'set-setting',
   SHOW_ITEM_IN_FOLDER: 'show-item-in-folder',
   SHOW_OPEN_DIALOG: 'show-open-dialog',

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -25,7 +25,7 @@ import {
   setupLaunchPluginServerHandler,
   setupInvestLogReaderHandler
 } from './setupInvestHandlers';
-import setupAddPlugin from './setupAddPlugin';
+import { setupAddPlugin, setupRemovePlugin } from './setupAddRemovePlugin';
 import setupGetNCPUs from './setupGetNCPUs';
 import setupOpenExternalUrl from './setupOpenExternalUrl';
 import setupOpenLocalHtml from './setupOpenLocalHtml';
@@ -102,6 +102,7 @@ export const createWindow = async () => {
   setupOpenExternalUrl();
   setupRendererLogger();
   setupAddPlugin();
+  setupRemovePlugin();
 
   const devModeArg = ELECTRON_DEV_MODE ? '--devmode' : '';
   // Create the browser window.

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -11,7 +11,7 @@ import { settingsStore } from './settingsStore';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
-export default function setupAddPlugin() {
+export function setupAddPlugin() {
   ipcMain.handle(
     ipcMainChannels.ADD_PLUGIN,
     (e, pluginURL) => {
@@ -59,6 +59,29 @@ export default function setupAddPlugin() {
         logger.info('successfully added plugin');
       } catch (error) {
         return error;
+      }
+    }
+  );
+}
+
+export function setupRemovePlugin() {
+  ipcMain.handle(
+    ipcMainChannels.REMOVE_PLUGIN,
+    (e, pluginID) => {
+      logger.info('removing plugin', pluginID);
+      try {
+        // Delete the plugin's conda env
+        const env = settingsStore.get(`plugins.${pluginID}.env`);
+        execSync(
+          `micromamba remove --yes --prefix ${env} --all`,
+          { stdio: 'inherit' }
+        );
+        // Delete the plugin's data from storage
+        settingsStore.delete(`plugins.${pluginID}`);
+        logger.info('successfully removed plugin');
+      } catch (error) {
+        logger.info('Error removing plugin:');
+        logger.info(error);
       }
     }
   );

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -79,8 +79,9 @@ export function setupRemovePlugin() {
       try {
         // Delete the plugin's conda env
         const env = settingsStore.get(`plugins.${pluginID}.env`);
+        const mamba = settingsStore.get('mamba');
         execSync(
-          `micromamba remove --yes --prefix ${env} --all`,
+          `${mamba} remove --yes --prefix ${env} --all`,
           { stdio: 'inherit' }
         );
         // Delete the plugin's data from storage

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -25,11 +25,10 @@ import DownloadProgressBar from './components/DownloadProgressBar';
 import PluginModal from './components/PluginModal';
 import InvestJob from './InvestJob';
 import { dragOverHandlerNone } from './utils';
-
-const { ipcRenderer } = window.Workbench.electron;
 import { ipcMainChannels } from '../main/ipcMainChannels';
 import { getInvestModelNames } from './server_requests';
 
+const { ipcRenderer } = window.Workbench.electron;
 
 /** This component manages any application state that should persist
  * and be independent from properties of a single invest job.
@@ -357,7 +356,6 @@ export default class App extends React.Component {
                   clearJobsStorage={this.clearRecentJobs}
                   showDownloadModal={() => this.showDownloadModal(true)}
                   nCPU={this.props.nCPU}
-                  updateInvestList={this.updateInvestList}
                 />
               </Col>
             </Row>

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -22,12 +22,14 @@ import InvestTab from './components/InvestTab';
 import SettingsModal from './components/SettingsModal';
 import DataDownloadModal from './components/DataDownloadModal';
 import DownloadProgressBar from './components/DownloadProgressBar';
+import PluginModal from './components/PluginModal';
 import InvestJob from './InvestJob';
 import { dragOverHandlerNone } from './utils';
 
 const { ipcRenderer } = window.Workbench.electron;
 import { ipcMainChannels } from '../main/ipcMainChannels';
 import { getInvestModelNames } from './server_requests';
+
 
 /** This component manages any application state that should persist
  * and be independent from properties of a single invest job.
@@ -347,11 +349,15 @@ export default class App extends React.Component {
                     )
                     : <div />
                 }
+                <PluginModal
+                  updateInvestList={this.updateInvestList}
+                />
                 <SettingsModal
                   className="mx-3"
                   clearJobsStorage={this.clearRecentJobs}
                   showDownloadModal={() => this.showDownloadModal(true)}
                   nCPU={this.props.nCPU}
+                  updateInvestList={this.updateInvestList}
                 />
               </Col>
             </Row>
@@ -372,7 +378,6 @@ export default class App extends React.Component {
                     openInvestModel={this.openInvestModel}
                     recentJobs={recentJobs}
                     batchUpdateArgs={this.batchUpdateArgs}
-                    updateInvestList={this.updateInvestList}
                   />
                 )
                 : <div />}

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -11,7 +11,6 @@ import { useTranslation } from 'react-i18next';
 
 import OpenButton from '../OpenButton';
 import InvestJob from '../../InvestJob';
-import PluginModal from '../PluginModal';
 
 const { logger } = window.Workbench;
 
@@ -36,7 +35,7 @@ export default class HomeTab extends React.Component {
   }
 
   render() {
-    const { recentJobs, investList, openInvestModel, updateInvestList } = this.props;
+    const { recentJobs, investList, openInvestModel } = this.props;
 
     let sortedModelIds = {};
     if (investList) {
@@ -90,9 +89,6 @@ export default class HomeTab extends React.Component {
             {investButtons}
           </ListGroup>
         </Col>
-        <PluginModal
-          updateInvestList={updateInvestList}
-        />
         <Col className="recent-job-card-col">
           <RecentInvestJobs
             openInvestModel={openInvestModel}
@@ -111,7 +107,6 @@ HomeTab.propTypes = {
       type: PropTypes.string,
     })
   ).isRequired,
-  updateInvestList: PropTypes.func.isRequired,
   openInvestModel: PropTypes.func.isRequired,
   recentJobs: PropTypes.arrayOf(
     PropTypes.shape({

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -26,7 +26,7 @@ export default function PluginModal(props) {
     setShowPluginModal(false);
   };
   const handleModalOpen = () => setShowPluginModal(true);
-  const handleSubmit = () => {
+  const addPlugin = () => {
     setLoading(true);
     ipcRenderer.invoke(ipcMainChannels.ADD_PLUGIN, url).then((addPluginErr) => {
       setLoading(false);
@@ -63,11 +63,9 @@ export default function PluginModal(props) {
     <Modal.Body>
       <Form>
         <Form.Group className="mb-3">
-          <Form.Label htmlFor="url">Add a plugin</Form.Label>
+          <Form.Label htmlFor="url">{t('Add a plugin')}</Form.Label>
           <Form.Control
             id="url"
-            name="url"
-            type="text"
             placeholder={t('Enter Git URL')}
             onChange={(event) => setURL(event.currentTarget.value)}
           />
@@ -75,22 +73,19 @@ export default function PluginModal(props) {
             {t('This may take several minutes')}
           </Form.Text>
           <Button
-            name="submit"
             disabled={loading}
             className="mt-2"
-            onClick={handleSubmit}
+            onClick={addPlugin}
           >
             {t('Add')}
           </Button>
         </Form.Group>
         <hr />
         <Form.Group className="mb-3">
-          <Form.Label htmlFor="url">Remove a plugin</Form.Label>
+          <Form.Label htmlFor="plugin-select">{t('Remove a plugin')}</Form.Label>
           <Form.Control
             id="plugin-select"
             as="select"
-            name="plugin"
-            type="text"
             value={pluginToRemove}
             onChange={(event) => setPluginToRemove(event.currentTarget.value)}
           >
@@ -108,8 +103,7 @@ export default function PluginModal(props) {
             }
           </Form.Control>
           <Button
-            name="remove"
-            disabled={loading || !Object.keys(plugins).length }
+            disabled={loading || !Object.keys(plugins).length}
             className="mt-2"
             onClick={removePlugin}
           >

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -51,8 +51,10 @@ export default function PluginModal(props) {
   useEffect(() => {
     ipcRenderer.invoke(ipcMainChannels.GET_SETTING, 'plugins').then(
       (data) => {
-        setPlugins(data);
-        setPluginToRemove(Object.keys(data)[0]);
+        if (data) {
+          setPlugins(data);
+          setPluginToRemove(Object.keys(data)[0]);
+        }
       }
     );
   }, [loading]);

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -66,6 +66,7 @@ export default function PluginModal(props) {
           <Form.Label htmlFor="url">{t('Add a plugin')}</Form.Label>
           <Form.Control
             id="url"
+            type="text"
             placeholder={t('Enter Git URL')}
             onChange={(event) => setURL(event.currentTarget.value)}
           />

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -181,6 +181,7 @@ describe('createWindow', () => {
     await createWindow();
     const expectedHandleChannels = [
       ipcMainChannels.ADD_PLUGIN,
+      ipcMainChannels.REMOVE_PLUGIN,
       ipcMainChannels.CHANGE_LANGUAGE,
       ipcMainChannels.CHECK_STORAGE_TOKEN,
       ipcMainChannels.CHECK_FILE_PERMISSIONS,

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -48,9 +48,6 @@ describe('Add plugin modal', () => {
   });
 
   test('Interface to add a plugin', async () => {
-    const {
-      findByText, findByLabelText, findByRole, queryByRole,
-    } = render(<App />);
     const spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
@@ -64,11 +61,14 @@ describe('Add plugin modal', () => {
       }
       return Promise.resolve();
     });
+    const {
+      findByText, findByLabelText, findByRole, queryByRole,
+    } = render(<App />);
 
-    const addPluginButton = await findByText('Add a plugin');
-    userEvent.click(addPluginButton);
+    const managePluginsButton = await findByText('Manage plugins');
+    userEvent.click(managePluginsButton);
 
-    const urlField = await findByLabelText('Git URL');
+    const urlField = await findByLabelText('Add a plugin');
     await userEvent.type(urlField, 'fake url', { delay: 0 });
     const submitButton = await findByText('Add');
     userEvent.click(submitButton);


### PR DESCRIPTION
## Description
<img width="943" alt="image" src="https://github.com/user-attachments/assets/bb55dfcb-c68e-4671-b3bf-34e4aacf82e2">

- Create an interface to remove a plugin
- Move this, and the "add plugin" button, into a "Manage plugins" modal

Very little thought went into the design of the original "add plugin" button, it was just to get something working. This is a more intentional design.

I didn't add any tests yet, since we talked a while ago about possibly needing less UI tests, but I'm open to writing some if you think it would be helpful.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
