### PR TITLE
Restrict pygeoprocessing < 2.4.5 to avoid GHA failures.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpy>=1.11.0,!=1.16.0,<2.0
 Rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
 scipy>=1.9.0,!=1.12.*
-pygeoprocessing>=2.4.2  # pip-only
+pygeoprocessing>=2.4.2,<2.4.5  # pip-only
 taskgraph>=0.11.0
 psutil>=5.6.6
 chardet>=3.0.4


### PR DESCRIPTION
## Description
We've had some issue where it seems like the PGP 2.4.5 release is causing our tests to fail. It's very unclear why this would be the case as the 2.4.5 release doesn't have any real changes. This PR is a patch to get our tests passing why we look into it.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
