### PR TITLE
Update validation.py to avoid SyntaxError

### DIFF
--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -642,7 +642,7 @@ def get_validated_dataframe(
             patterns.append(f'{groups[0]}(.+){groups[2]}')
         else:
             # for regular column names, use the exact name as the pattern
-            patterns.append(column.replace('(', '\\(').replace(')', '\\)'))
+            patterns.append(column.replace('(', r'\(').replace(')', r'\)'))
 
     # select only the columns that match a pattern
     df = df[[col for col in df.columns if any(

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -642,7 +642,7 @@ def get_validated_dataframe(
             patterns.append(f'{groups[0]}(.+){groups[2]}')
         else:
             # for regular column names, use the exact name as the pattern
-            patterns.append(column.replace('(', '\(').replace(')', '\)'))
+            patterns.append(column.replace('(', '\\(').replace(')', '\\)'))
 
     # select only the columns that match a pattern
     df = df[[col for col in df.columns if any(


### PR DESCRIPTION
## Description
Fixes #1663 with Python raw string notation, as recommended by the [Python `re` module docs](https://docs.python.org/3.12/library/re.html):

> Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a `SyntaxWarning` and in the future this will become a `SyntaxError`. This behaviour will happen even if it is a valid escape sequence for a regular expression.
> 
> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'.

I still don't know what triggered the switch to `SyntaxError`, since even the Python 3.13 docs still describe this as "future" behavior, but in any case the raw string notation appears to solve the problem.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
