### PR TITLE
Wrap mamba commands in quotes

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -82,7 +82,7 @@ export function setupRemovePlugin() {
         const mamba = settingsStore.get('mamba');
         execSync(
           `"${mamba}" remove --yes --prefix ${env} --all`,
-          { stdio: 'inherit' }
+          { stdio: 'inherit', windowsHide: true }
         );
         // Delete the plugin's data from storage
         settingsStore.delete(`plugins.${pluginID}`);

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -40,15 +40,15 @@ export function setupAddPlugin() {
         // Create a conda env containing the plugin and its dependencies
         const envName = `invest_plugin_${pluginID}`;
         const mamba = settingsStore.get('mamba');
-        execSync(`${mamba} create --yes --name ${envName} -c conda-forge "python<3.12" "gdal<3.6"`,
+        execSync(`"${mamba}" create --yes --name ${envName} -c conda-forge "python<3.12" "gdal<3.6"`,
           { stdio: 'inherit', windowsHide: true });
         logger.info('created mamba env for plugin');
-        execSync(`${mamba} run --name ${envName} pip install "git+${pluginURL}"`,
+        execSync(`"${mamba}" run --name ${envName} pip install "git+${pluginURL}"`,
           { stdio: 'inherit', windowsHide: true });
         logger.info('installed plugin into its env');
 
         // Write plugin metadata to the workbench's config.json
-        const envInfo = execSync(`${mamba} info --envs`, { windowsHide: true }).toString();
+        const envInfo = execSync(`"${mamba}" info --envs`, { windowsHide: true }).toString();
         logger.info(`env info:\n${envInfo}`);
         const envPath = envInfo.match(`${envName}\\s+(.+)$`)[1];
         logger.info(`env path:\n${envPath}`);
@@ -81,7 +81,7 @@ export function setupRemovePlugin() {
         const env = settingsStore.get(`plugins.${pluginID}.env`);
         const mamba = settingsStore.get('mamba');
         execSync(
-          `${mamba} remove --yes --prefix ${env} --all`,
+          `"${mamba}" remove --yes --prefix ${env} --all`,
           { stdio: 'inherit' }
         );
         // Delete the plugin's data from storage


### PR DESCRIPTION
## Description
During installation on Windows there is a space in the path of where InVEST is installed. The space then breaks the path for running the mamba command. Wrapping that mamba command in quotes.

Also, adding `windowsHide:true` so a windows cmd shell doesn't pop open during plugin removal.

Fixes #1675
Fixes #1665

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
