### PR TITLE
update to latest download links for mamba

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -369,20 +369,20 @@ jobs:
 
       - name: Download mamba installer for distribution (MacOS)
         if: matrix.os == 'macos-13'
-        run: curl -fsSLo Miniforge-pypy3-MacOSX-x86_64.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-MacOSX-x86_64.sh"
+        run: curl -fsSLo Miniforge3-MacOSX-x86_64.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh"
 
       - name: Install mamba for MacOS
         if: matrix.os == 'macos-13'
-        run: bash Miniforge-pypy3-MacOSX-x86_64.sh -b -p dist/miniforge3
+        run: bash Miniforge3-MacOSX-x86_64.sh -b -p dist/miniforge3
 
       - name: Download mamba installer for distribution (Windows)
         if: matrix.os == 'windows-latest'
-        run: curl -fsSLo Miniforge-pypy3-Windows-x86_64.exe "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge-pypy3-Windows-x86_64.exe"
+        run: curl -fsSLo Miniforge3-Windows-x86_64.exe "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe"
 
       - name: Install mamba for Windows
         if: matrix.os == 'windows-latest'
         shell: cmd
-        run: Miniforge-pypy3-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%cd%\dist\miniforge3
+        run: Miniforge3-Windows-x86_64.exe /InstallationType=JustMe /RegisterPython=0 /S /D=%cd%\dist\miniforge3
 
       - name: Authenticate GCP
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Description
Not sure if this will fix any issues we've seen with the mamba distribution, but it could be related and it's necessary anyway. Apparently the installer download links, at the time I copied them, pointed to PyPy-specific installers. I noticed a warning that the installer is deprecated. The [miniforge page](https://github.com/conda-forge/miniforge) says

> We are planning to remove PyPy from conda-forge feedstock recipes in a few weeks (and thus to stop building new releases of packages for PyPy), unless there is substantial enough interest to justify the continued maintenance effort.
To help with this transition, the latest installers will:
    The installer will refuse to proceed every two weeks in October
    The installer will refuse to proceed every ten days in November
    The installer will refuse to proceed every five days in December
    The installer will refuse to proceed in 2025+

We never intended to use PyPy anyway. This PR updates to point to the correct download links.


## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
