### PR TITLE
Also handling sanitized package names. RE:#1679

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -99,7 +99,7 @@ jobs:
           twine upload \
             --username="__token__" \
             --password=${{ secrets.PYPI_NATCAP_INVEST_TOKEN }} \
-            artifacts/natcap.invest*
+            artifacts/natcap.invest* artifacts/natcap_invest*
 
       - name: Roll back on failure
         if: failure()


### PR DESCRIPTION
This should be a simple fix, just adding the sanitized distribution names to the `twine upload` command.  Further context is described in #1679 

Fixes #1679 

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
