### PR TITLE
Log stdout and stderr from plugin installation and removal

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -11,6 +11,20 @@ import { settingsStore } from './settingsStore';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
+/**
+ * Spawn a child process and log its stdout, stderr, and any error in spawning.
+ *
+ * child_process.spawn is called with the provided cmd, args, and options,
+ * and the windowsHide option set to true.
+ *
+ * Required properties missing from the store are initialized with defaults.
+ * Invalid properties are reset to defaults.
+ * @param  {string} cmd - command to pass to spawn
+ * @param  {Array} args - command arguments to pass to spawn
+ * @param  {object} options - options to pass to spawn.
+ * @returns {Promise} resolves when the command finishes with exit code 0.
+ *                    Rejects with error otherwise.
+ */
 function spawnWithLogging(cmd, args, options) {
   logger.info(cmd, args);
   const cmdProcess = spawn(cmd, args, { ...options, windowsHide: true });

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -2,7 +2,7 @@ import upath from 'upath';
 import fs from 'fs';
 import { tmpdir } from 'os';
 import toml from 'toml';
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import { ipcMain } from 'electron';
 
 import { getLogger } from './logger';
@@ -11,59 +11,93 @@ import { settingsStore } from './settingsStore';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 
+function customSpawn(cmd, args, options) {
+  logger.info(cmd, args);
+  const cmdProcess = spawn(cmd, args, options);
+  if (cmdProcess.stdout) {
+    cmdProcess.stderr.on('data', (data) => logger.info(data.toString()));
+    cmdProcess.stdout.on('data', (data) => logger.info(data.toString()));
+  }
+  return new Promise((resolve, reject) => {
+    cmdProcess.on('close', (code) => { resolve(code); });
+  });
+}
+
 export function setupAddPlugin() {
   ipcMain.handle(
     ipcMainChannels.ADD_PLUGIN,
     (e, pluginURL) => {
       logger.info('adding plugin at', pluginURL);
 
+      const mamba = settingsStore.get('mamba');
+      let envName;
+      let pluginID;
+      let pluginName;
+      let pluginPyName;
+
       try {
         // Create a temporary directory and check out the plugin's pyproject.toml
         const tmpPluginDir = fs.mkdtempSync(upath.join(tmpdir(), 'natcap-invest-'));
-        execSync(
-          `git clone --depth 1 --no-checkout ${pluginURL} "${tmpPluginDir}"`,
-          { stdio: 'inherit', windowsHide: true }
-        );
-        execSync('git checkout HEAD pyproject.toml', { cwd: tmpPluginDir, stdio: 'inherit', windowsHide: true });
+        customSpawn(
+          'git',
+          ['clone', '--depth', '1', '--no-checkout', pluginURL, tmpPluginDir],
+          { windowsHide: true }
+        ).then(async () => {
+          await customSpawn(
+            'git',
+            ['checkout', 'HEAD', 'pyproject.toml'],
+            { cwd: tmpPluginDir, windowsHide: true }
+          );
+        }).then(async () => {
+          // Read in the plugin's pyproject.toml, then delete it
+          const pyprojectTOML = toml.parse(fs.readFileSync(
+            upath.join(tmpPluginDir, 'pyproject.toml')
+          ).toString());
+          fs.rmSync(tmpPluginDir, { recursive: true, force: true });
 
-        // Read in the plugin's pyproject.toml, then delete it
-        const pyprojectTOML = toml.parse(fs.readFileSync(
-          upath.join(tmpPluginDir, 'pyproject.toml')
-        ).toString());
-        fs.rmSync(tmpPluginDir, { recursive: true, force: true });
+          // Access plugin metadata from the pyproject.toml
+          pluginID = pyprojectTOML.tool.natcap.invest.model_id;
+          pluginName = pyprojectTOML.tool.natcap.invest.model_name;
+          pluginPyName = pyprojectTOML.tool.natcap.invest.pyname;
 
-        // Access plugin metadata from the pyproject.toml
-        const pluginID = pyprojectTOML.tool.natcap.invest.model_id;
-        const pluginName = pyprojectTOML.tool.natcap.invest.model_name;
-        const pluginPyName = pyprojectTOML.tool.natcap.invest.pyname;
+          // Create a conda env containing the plugin and its dependencies
+          envName = `invest_plugin_${pluginID}`;
+          await customSpawn(
+            mamba,
+            ['create', '--yes', '--name', envName, '-c', 'conda-forge', '"python<3.12"', '"gdal<3.6"'],
+            { windowsHide: true }
+          );
+          logger.info('created mamba env for plugin');
+        }).then(async () => {
+          await customSpawn(
+            mamba,
+            ['run', '--verbose', '--no-capture-output', '--name', envName, 'pip', 'install', `git+${pluginURL}`],
+            { windowsHide: true }
+          );
+          logger.info('installed plugin into its env');
+        })
+          .then(() => {
+            // Write plugin metadata to the workbench's config.json
+            const envInfo = execSync(`${mamba} info --envs`, { windowsHide: true }).toString();
+            logger.info(`env info:\n${envInfo}`);
 
-        // Create a conda env containing the plugin and its dependencies
-        const envName = `invest_plugin_${pluginID}`;
-        const mamba = settingsStore.get('mamba');
-        execSync(`${mamba} create --yes --name ${envName} -c conda-forge "python<3.12" "gdal<3.6"`,
-          { stdio: 'inherit', windowsHide: true });
-        logger.info('created mamba env for plugin');
-        execSync(`${mamba} run --name ${envName} pip install "git+${pluginURL}"`,
-          { stdio: 'inherit', windowsHide: true });
-        logger.info('installed plugin into its env');
+            const regex = new RegExp(String.raw`^${envName} +(.+)$`, 'm');
+            const envPath = envInfo.match(regex)[1];
 
-        // Write plugin metadata to the workbench's config.json
-        const envInfo = execSync(`${mamba} info --envs`, { windowsHide: true }).toString();
-        logger.info(`env info:\n${envInfo}`);
-        const envPath = envInfo.match(`${envName}\\s+(.+)$`)[1];
-        logger.info(`env path:\n${envPath}`);
-        logger.info('writing plugin info to settings store');
-        settingsStore.set(
-          `plugins.${pluginID}`,
-          {
-            model_name: pluginName,
-            pyname: pluginPyName,
-            type: 'plugin',
-            source: pluginURL,
-            env: envPath,
-          }
-        );
-        logger.info('successfully added plugin');
+            logger.info(`env path:\n${envPath}`);
+            logger.info('writing plugin info to settings store');
+            settingsStore.set(
+              `plugins.${pluginID}`,
+              {
+                model_name: pluginName,
+                pyname: pluginPyName,
+                type: 'plugin',
+                source: pluginURL,
+                env: envPath,
+              }
+            );
+            logger.info('successfully added plugin');
+          });
       } catch (error) {
         return error;
       }

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -19,6 +19,10 @@ function spawnWithLogging(cmd, args, options) {
     cmdProcess.stdout.on('data', (data) => logger.info(data.toString()));
   }
   return new Promise((resolve, reject) => {
+    cmdProcess.on('error', (err) => {
+      logger.error(err);
+      reject(err);
+    });
     cmdProcess.on('close', (code) => {
       if (code === 0) {
         resolve(code);

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -32,7 +32,7 @@ export default function PluginModal(props) {
       setLoading(false);
       updateInvestList();
       if (addPluginErr) {
-        setErr(addPluginErr);
+        setErr(true);
       } else {
         setShowPluginModal(false);
       }
@@ -119,10 +119,7 @@ export default function PluginModal(props) {
   if (err) {
     modalBody = (
       <Modal.Body>
-        <span>{t('Plugin installation failed')}</span>
-        <br />
-        <br />
-        <span>{err.toString()}</span>
+        {t('Plugin installation failed. Check the workbench log for details.')}
       </Modal.Body>
     );
   }


### PR DESCRIPTION
## Description
Fixes #1673 
Fixes #1665 

Stdout and stderr from subprocesses involved in plugin install/uninstall are now logged. They continue to show up in the terminal in dev mode, and now also appear in the workbench log in dev and production mode. Plugin installation errors are no longer displayed in the UI, but a message is shown pointing to the workbench log.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
