### PR TITLE
Wrap plugin env in quotes

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -60,7 +60,7 @@ export function setupAddPlugin() {
             pyname: pluginPyName,
             type: 'plugin',
             source: pluginURL,
-            env: envPath,
+            env: `\"{envPath}\"`,
           }
         );
         logger.info('successfully added plugin');

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -60,7 +60,7 @@ export function setupAddPlugin() {
             pyname: pluginPyName,
             type: 'plugin',
             source: pluginURL,
-            env: `\"{envPath}\"`,
+            env: envPath,
           }
         );
         logger.info('successfully added plugin');
@@ -81,7 +81,7 @@ export function setupRemovePlugin() {
         const env = settingsStore.get(`plugins.${pluginID}.env`);
         const mamba = settingsStore.get('mamba');
         execSync(
-          `${mamba} remove --yes --prefix ${env} --all`,
+          `${mamba} remove --yes --prefix "${env}" --all`,
           { stdio: 'inherit' }
         );
         // Delete the plugin's data from storage

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -93,7 +93,7 @@ export function setupInvestRunHandlers() {
       cmd = settingsStore.get('mamba');
       cmdArgs = [
         'run',
-        `--prefix ${settingsStore.get(`plugins.${modelRunName}.env`)}`,
+        `--prefix "${settingsStore.get(`plugins.${modelRunName}.env`)}"`,
         '--live-stream',
         'invest',
         LOGLEVELMAP[loggingLevel],


### PR DESCRIPTION
## Description
When testing a recent installation the plugin env path was being stored in the settings config without escaped quotes for path spacing. When running the plugin model I was seeing:
```sh

[11:57:18.970] [undefined] about to run model with command: "C:/Users/ddenu/AppData/Local/Programs/InVEST 3.14.2.post397+g9c664c177 Workbench/resources/miniforge3/condabin/mamba.bat" run,--prefix C:\Users\ddenu\AppData\Local\Programs\InVEST 3.14.2.post397+g9c664c177 Workbench\resources\Miniforge3\envs\invest_plugin_schistosomiasis,--live-stream,invest,-vv,--taskgraph-log-level=INFO,--language "en",run,schistosomiasis,-d "C:\Users\ddenu\AppData\Roaming\invest-workbench\tmp\data-Da2SMk\datastack.json"
[11:57:20.346] [undefined] Not a conda environment: C:\Users\ddenu\AppData\Local\Programs\InVEST
```

Wrapping the env path follows similar practices to how we store the invest and mamba paths.