### PR TITLE
Spawn call was missing shell true option

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -15,7 +15,8 @@ const logger = getLogger(__filename.split('/').slice(-1)[0]);
  * Spawn a child process and log its stdout, stderr, and any error in spawning.
  *
  * child_process.spawn is called with the provided cmd, args, and options,
- * and the windowsHide option set to true.
+ * and the windowsHide option set to true. The shell option is set to true
+ * because spawn by default sets shell to false.
  *
  * Required properties missing from the store are initialized with defaults.
  * Invalid properties are reset to defaults.

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -27,7 +27,8 @@ const logger = getLogger(__filename.split('/').slice(-1)[0]);
  */
 function spawnWithLogging(cmd, args, options) {
   logger.info(cmd, args);
-  const cmdProcess = spawn(cmd, args, { ...options, windowsHide: true });
+  const cmdProcess = spawn(
+    cmd, args, { ...options, shell: true, windowsHide: true });
   if (cmdProcess.stdout) {
     cmdProcess.stderr.on('data', (data) => logger.info(data.toString()));
     cmdProcess.stdout.on('data', (data) => logger.info(data.toString()));


### PR DESCRIPTION
A spawn call was missing the `shell: true` option, and is set to `false` by default. This was causing an error on Windows.