### PR TITLE
Plugins: update how investUsageLogger gets port information

### DIFF
--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -13,9 +13,9 @@ const PREFIX = 'api';
 export default function investUsageLogger() {
   const sessionId = crypto.randomUUID();
 
-  function start(modelPyName, args) {
+  function start(modelPyName, args, port) {
     logger.debug('logging model start');
-    fetch(`${HOSTNAME}:${process.env.PORT}/${PREFIX}/log_model_start`, {
+    fetch(`${HOSTNAME}:${port}/${PREFIX}/log_model_start`, {
       method: 'post',
       body: JSON.stringify({
         model_pyname: modelPyName,
@@ -31,9 +31,9 @@ export default function investUsageLogger() {
       .catch((error) => logger.error(error));
   }
 
-  function exit(status) {
+  function exit(status, port) {
     logger.debug('logging model exit');
-    fetch(`${HOSTNAME}:${process.env.PORT}/${PREFIX}/log_model_exit`, {
+    fetch(`${HOSTNAME}:${port}/${PREFIX}/log_model_exit`, {
       method: 'post',
       body: JSON.stringify({
         session_id: sessionId,

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -88,6 +88,7 @@ export function setupInvestRunHandlers() {
     await writeInvestParameters(payload);
     let cmd;
     let cmdArgs;
+    let port;
     const plugins = settingsStore.get('plugins');
     if (plugins && Object.keys(plugins).includes(modelRunName)) {
       cmd = settingsStore.get('mamba');
@@ -103,6 +104,7 @@ export function setupInvestRunHandlers() {
         modelRunName,
         `-d "${datastackPath}"`,
       ];
+      port = settingsStore.get(`plugins.${modelRunName}.port`);
     } else {
       cmd = settingsStore.get('investExe');
       cmdArgs = [
@@ -112,6 +114,7 @@ export function setupInvestRunHandlers() {
         'run',
         modelRunName,
         `-d "${datastackPath}"`];
+      port = settingsStore.get('core.port');
     }
 
     logger.debug(`about to run model with command: ${cmd} ${cmdArgs}`);
@@ -141,7 +144,7 @@ export function setupInvestRunHandlers() {
           );
           event.reply(`invest-logging-${tabID}`, path.resolve(investLogfile));
           if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
-            usageLogger.start(pyModuleName, args);
+            usageLogger.start(pyModuleName, args, port);
           }
         }
       }
@@ -176,7 +179,7 @@ export function setupInvestRunHandlers() {
         });
       });
       if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
-        usageLogger.exit(investStdErr);
+        usageLogger.exit(investStdErr, port);
       }
     });
   });

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -225,7 +225,8 @@ describe('createWindow', () => {
 });
 
 describe('investUsageLogger', () => {
-  const expectedURL = `http://127.0.0.1:${process.env.PORT}/api/log_model_start`;
+  const PORT = 3000;
+  const expectedURL = `http://127.0.0.1:${PORT}/api/log_model_start`;
   beforeEach(() => {
     // the expected response
     const response = {
@@ -244,12 +245,12 @@ describe('investUsageLogger', () => {
     const investStdErr = '';
     const usageLogger = investUsageLogger();
 
-    usageLogger.start(modelPyname, args);
+    usageLogger.start(modelPyname, args, PORT);
     expect(fetch.mock.calls).toHaveLength(1);
     expect(fetch.mock.calls[0][0]).toBe(expectedURL);
     const startPayload = JSON.parse(fetch.mock.calls[0][1].body);
 
-    usageLogger.exit(investStdErr);
+    usageLogger.exit(investStdErr, PORT);
     expect(fetch.mock.calls).toHaveLength(2);
     const exitPayload = JSON.parse(fetch.mock.calls[1][1].body);
 


### PR DESCRIPTION
## Description
Since we're now managing multiple invest servers on different ports, we're storing related port information in the `settingsStore` config. `investUsageLogger` was still using `process.env.PORT`. This PR attempts to transition that to the new setup.

I'd love some feedback and input on how to manage this. The solution I have here works, but feels a little tacked on. I couldn't think of a clean way for `investUsageLogger` to locally know if a plugin or core model was being run to get the port information there. So, I end up passing the port in to the `start` and `exit` functions from `setupInvestHandlers`. 
