### PR TITLE
#1166 Add support for zero-padded months in SWY

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,6 +86,9 @@ Unreleased Changes
       updated the stated dtype of most pollination model outputs to be float32
       instead of the float64 dtype that was being assumed previously.  This
       will result in smaller output filesizes with minimal loss of precision.
+* Seasonal Water Yield
+    * Added support for zero padding in month numbers in ET and precipitation 
+      file names (i.e., users can now name their file Precip_01.tif).
 * Urban Flood Risk
     * Fields present on the input AOI vector are now retained in the output.
       (https://github.com/natcap/invest/issues/1600)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -87,7 +87,7 @@ Unreleased Changes
       instead of the float64 dtype that was being assumed previously.  This
       will result in smaller output filesizes with minimal loss of precision.
 * Seasonal Water Yield
-    * Added support for zero padding in month numbers in ET and precipitation 
+    * Added support for zero padding in month numbers in ET and precipitation
       file names (i.e., users can now name their file Precip_01.tif).
 * Urban Flood Risk
     * Fields present on the input AOI vector are now retained in the output.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -89,6 +89,7 @@ Unreleased Changes
 * Seasonal Water Yield
     * Added support for zero padding in month numbers in ET and precipitation
       file names (i.e., users can now name their file Precip_01.tif).
+      (https://github.com/natcap/invest/issues/1166)
 * Urban Flood Risk
     * Fields present on the input AOI vector are now retained in the output.
       (https://github.com/natcap/invest/issues/1600)

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -659,15 +659,8 @@ def execute(args):
     output_align_list = [
         file_registry['lulc_aligned_path'], file_registry['dem_aligned_path']]
     if not args['user_defined_local_recharge']:
-        et0_dir_list = [
-            os.path.join(args['et0_dir'], f) for f in os.listdir(
-                args['et0_dir'])]
-        precip_dir_list = [
-            os.path.join(args['precip_dir'], f) for f in os.listdir(
-                args['precip_dir'])]
-
-        et0_path_list, precip_path_list = _get_monthly_file_lists(
-            N_MONTHS, et0_dir_list, precip_dir_list)
+        precip_path_list = _get_monthly_file_lists(N_MONTHS, args['precip_dir'])
+        et0_path_list = _get_monthly_file_lists(N_MONTHS, args['et0_dir'])
 
         input_align_list = (
             precip_path_list + [args['soil_group_path']] + et0_path_list +
@@ -1362,44 +1355,40 @@ def _aggregate_recharge(
     aggregate_vector = None
 
 
-def _get_monthly_file_lists(n_months, et0_dir_list, precip_dir_list):
-    """Create lists of monthly files for precipitation and evapotranspiration.
+def _get_monthly_file_lists(n_months, in_dir):
+    """Create list of monthly files for data_type
 
     Parameters:
-        n_months (int): The number of months to iterate over (should be 12)
-        et0_dir_list (list): List of file paths in evapotranspiration directory
-        precip_dir_list (list): List of file paths in precipitation directory
+        n_months (int): Number of months to iterate over (should be 12)
+        in_dir (string): Path to directory of monthly files (for specific
+                         variable)
 
     Raises:
-        ValueError: If no file or multiple files are found for a month for
-                    precipitation or et data.
+        ValueError: If no file or multiple files are found for a month
 
     Returns:
-        tuple: Two lists containing the monthly file paths
-               for evapotranspiration and precipitation, respectively.
+        list: contains monthly file paths for specific variable
     """
-    et0_path_list = []
-    precip_path_list = []
-    
+    in_path_list = [os.path.join(in_dir, f) for f in os.listdir(in_dir)]
+    out_path_list = []
+
     for month_index in range(1, n_months + 1):
         month_file_pattern = re.compile(r'.*[^\d]0?%d\.[^.]+$' % month_index)
+        file_list = [
+            month_file_path for month_file_path in in_path_list
+            if month_file_pattern.match(month_file_path)]
+        if len(file_list) == 0:
+            raise ValueError(
+                "No files found in %s for month %d. Please ensure that \
+                filenames end in the month number (e.g., precip_1.tif)."
+                % (in_dir, month_index))
+        if len(file_list) > 1:
+            raise ValueError(
+                "Ambiguous set of files found for month %d: %s" %
+                (month_index, file_list))
+        out_path_list.append(file_list[0])
 
-        for data_type, dir_list, path_list in [
-                ('et0', et0_dir_list, et0_path_list),
-                ('Precip', precip_dir_list, precip_path_list)]:
-            file_list = [
-                month_file_path for month_file_path in dir_list
-                if month_file_pattern.match(month_file_path)]
-            if len(file_list) == 0:
-                raise ValueError(
-                    "No %s found for month %d" % (data_type, month_index))
-            if len(file_list) > 1:
-                raise ValueError(
-                    "Ambiguous set of files found for month %d: %s" %
-                    (month_index, file_list))
-            path_list.append(file_list[0])
-
-    return et0_path_list, precip_path_list
+    return out_path_list
 
 
 @validation.invest_validator

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -1356,18 +1356,18 @@ def _aggregate_recharge(
 
 
 def _get_monthly_file_lists(n_months, in_dir):
-    """Create list of monthly files for data_type
+    """Create list of monthly files for data type
 
     Parameters:
         n_months (int): Number of months to iterate over (should be 12)
         in_dir (string): Path to directory of monthly files (for specific
-                         variable)
+                         data type)
 
     Raises:
         ValueError: If no file or multiple files are found for a month
 
     Returns:
-        list: contains monthly file paths for specific variable
+        list: contains monthly file paths for data type
     """
     in_path_list = [os.path.join(in_dir, f) for f in os.listdir(in_dir)]
     out_path_list = []
@@ -1380,7 +1380,7 @@ def _get_monthly_file_lists(n_months, in_dir):
         if len(file_list) == 0:
             raise ValueError(
                 "No files found in %s for month %d. Please ensure that \
-                filenames end in the month number (e.g., precip_1.tif)."
+                    filenames end in the month number (e.g., precip_1.tif)."
                 % (in_dir, month_index))
         if len(file_list) > 1:
             raise ValueError(

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -319,17 +319,21 @@ class SeasonalWaterYieldUnusualDataTests(unittest.TestCase):
         shutil.rmtree(self.workspace_dir, ignore_errors=True)
 
     def test_zeropadded_monthly_filenames(self):
-        """test filenames with zero-padded months in 
+        """test filenames with zero-padded months in
         _get_monthly_file_lists function
         """
-        from natcap.invest.seasonal_water_yield.seasonal_water_yield import _get_monthly_file_lists
+        from natcap.invest.seasonal_water_yield.seasonal_water_yield import (
+            _get_monthly_file_lists)
+
         n_months = 12
-        
+
         # Make fake paths with file names with zero-padded months
-        padded_et0_dir_list = [os.path.join("/fake/path", 
-            "et0_" + str(mo).zfill(2) + ".tif") for mo in range(1, n_months+1)]
-        padded_precip_dir_list = [os.path.join("/fake/path", 
-                                               "Precip" + str(mo).zfill(2) + ".tif") for mo in range(1, n_months+1)]
+        padded_et0_dir_list = [
+            os.path.join("/fake/path", "et0_" + str(mo).zfill(2) + ".tif")
+            for mo in range(1, n_months+1)]
+        padded_precip_dir_list = [
+            os.path.join("/fake/path", "Precip" + str(mo).zfill(2) + ".tif")
+            for mo in range(1, n_months + 1)]
 
         et0_path_list, precip_path_list = _get_monthly_file_lists(
             n_months, padded_et0_dir_list, padded_precip_dir_list)

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -322,7 +322,7 @@ class SeasonalWaterYieldUnusualDataTests(unittest.TestCase):
         """test filenames with zero-padded months in 
         _get_monthly_file_lists function
         """
-        from natcap.invest.seasonal_water_yield import _get_monthly_file_lists
+        from natcap.invest.seasonal_water_yield.seasonal_water_yield import _get_monthly_file_lists
         n_months = 12
         
         # Make fake paths with file names with zero-padded months

--- a/tests/test_seasonal_water_yield_regression.py
+++ b/tests/test_seasonal_water_yield_regression.py
@@ -318,6 +318,26 @@ class SeasonalWaterYieldUnusualDataTests(unittest.TestCase):
         """Delete workspace after test is done."""
         shutil.rmtree(self.workspace_dir, ignore_errors=True)
 
+    def test_zeropadded_monthly_filenames(self):
+        """test filenames with zero-padded months in 
+        _get_monthly_file_lists function
+        """
+        from natcap.invest.seasonal_water_yield import _get_monthly_file_lists
+        n_months = 12
+        
+        # Make fake paths with file names with zero-padded months
+        padded_et0_dir_list = [os.path.join("/fake/path", 
+            "et0_" + str(mo).zfill(2) + ".tif") for mo in range(1, n_months+1)]
+        padded_precip_dir_list = [os.path.join("/fake/path", 
+                                               "Precip" + str(mo).zfill(2) + ".tif") for mo in range(1, n_months+1)]
+
+        et0_path_list, precip_path_list = _get_monthly_file_lists(
+            n_months, padded_et0_dir_list, padded_precip_dir_list)
+
+        # Verify that the returned lists match the input
+        self.assertEqual(et0_path_list, padded_et0_dir_list)
+        self.assertEqual(precip_path_list, padded_precip_dir_list)
+
     def test_ambiguous_precip_data(self):
         """SWY test case where there are more than 12 precipitation files."""
         from natcap.invest.seasonal_water_yield import seasonal_water_yield


### PR DESCRIPTION
## Description
Updated the regex to allow users to have zero-padded month numbers in the monthly precipitation and evapotranspiration files. Now, filenames like et0_01.tif and precip01.tif are permitted. 

Fixes #1166

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
