### PR TITLE
Raise Exception for NA keys in reclassify_raster and test HQ missing lulc value

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,7 +83,7 @@ Unreleased Changes
       (https://github.com/natcap/invest/issues/1615).
     * Rarity values are now output in CSV format (as well as in raster format)
       (https://github.com/natcap/invest/issues/721).
-    * Improved error handling when there is a missing LULC value in the 
+    * Improved error handling when there is a missing LULC value in the
       sensitivity table (https://github.com/natcap/invest/issues/1671).
 * Pollination
     * Fixed an issue with nodata handling that was causing some outputs to be

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -54,6 +54,8 @@ Unreleased Changes
     * Fixed an issue on Windows where GDAL fails to find its DLLs due to
       an interfering GDAL installation on the PATH, such as from anaconda.
       https://github.com/natcap/invest/issues/1643
+    * Improved error handling of NA values in raster reclassification to provide
+      a more descriptive message.
 * Workbench
     * Several small updates to the model input form UI to improve usability
       and visual consistency (https://github.com/natcap/invest/issues/912).
@@ -81,6 +83,8 @@ Unreleased Changes
       (https://github.com/natcap/invest/issues/1615).
     * Rarity values are now output in CSV format (as well as in raster format)
       (https://github.com/natcap/invest/issues/721).
+    * Improved error handling when there is a missing LULC value in the 
+      sensitivity table (https://github.com/natcap/invest/issues/1671).
 * Pollination
     * Fixed an issue with nodata handling that was causing some outputs to be
       filled either with the float32 value for positive infinity, or else with

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -742,10 +742,10 @@ def reclassify_raster(
 
     Raises:
         ValueError:
-            - if ``values_required`` is ``True`` and a pixel value from 
+            - if ``values_required`` is ``True`` and a pixel value from
             ``raster_path_band`` is not a key in ``value_map``.
-            - if there is a missing or invalid key in ``value_map``, such
-            as `None`, `NA`, or other values representing missing data.
+        TypeError:
+            - if there is a ``None`` or ``NA`` key in ``value_map``.
     """
     # Error early if 'error_details' keys are invalid
     raster_name = error_details['raster_name']

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -754,7 +754,7 @@ def reclassify_raster(
 
     # check keys in value map to ensure none are NA or None
     if any((key is pandas.NA or key is None)
-           for key in value_map.keys()):
+           for key in value_map):
         error_message = (f"Missing or NA value in '{column_name}' column"
                          f" in {table_name} table.")
         raise TypeError(error_message)

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -741,13 +741,23 @@ def reclassify_raster(
         None
 
     Raises:
-        ValueError if ``values_required`` is ``True`` and a pixel value from
-        ``raster_path_band`` is not a key in ``value_map``.
+        ValueError:
+            - if ``values_required`` is ``True`` and a pixel value from 
+            ``raster_path_band`` is not a key in ``value_map``.
+            - if there is a missing or invalid key in ``value_map``, such
+            as `None`, `NA`, or other values representing missing data.
     """
     # Error early if 'error_details' keys are invalid
     raster_name = error_details['raster_name']
     column_name = error_details['column_name']
     table_name = error_details['table_name']
+
+    # check keys in value map to ensure none are NA or None
+    if any((key is pandas.NA or key is None)
+           for key in value_map.keys()):
+        error_message = (f"Missing or NA value in '{column_name}' column"
+                         f" in {table_name} table.")
+        raise TypeError(error_message)
 
     try:
         pygeoprocessing.reclassify_raster(

--- a/tests/test_habitat_quality.py
+++ b/tests/test_habitat_quality.py
@@ -2145,18 +2145,11 @@ class HabitatQualityTests(unittest.TestCase):
             'n_workers': -1,
         }
 
-        args['access_vector_path'] = os.path.join(
-            args['workspace_dir'], 'access_samp.shp')
-        make_access_shp(args['access_vector_path'])
-
-        scenarios = ['_bas_', '_cur_', '_fut_']
-        for lulc_val, scenario in enumerate(scenarios, start=1):
-            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
-            lulc_array[50:, :] = lulc_val
-            args['lulc' + scenario + 'path'] = os.path.join(
-                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
-            make_raster_from_array(
-                lulc_array, args['lulc' + scenario + 'path'])
+        lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
+        args['lulc_cur_path'] = os.path.join(
+            args['workspace_dir'], 'lc_samp_cur_b.tif')
+        make_raster_from_array(
+            lulc_array, args['lulc_cur_path'])
 
         args['sensitivity_table_path'] = os.path.join(
             args['workspace_dir'], 'sensitivity_samp.csv')


### PR DESCRIPTION
## Description
Raises exception in `reclassify_raster` function in utils when `value_map` contains NA key. Provides a more specific error message.

New test checks that specific error is raised if LULC value is missing.

This fixes the issue in HQ where an ambiguous error message was raised due to missing LULC value in sensitivity table 

Fixes #1671

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
