### PR TITLE
SWY: check for `numpy.nan` pixels in routing functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -90,6 +90,9 @@ Unreleased Changes
     * Added support for zero padding in month numbers in ET and precipitation
       file names (i.e., users can now name their file Precip_01.tif).
       (https://github.com/natcap/invest/issues/1166)
+    * Fixed a bug where ``numpy.nan`` pixel values would not be correctly
+      detected as nodata in local recharge and baseflow routing functions.
+      (https://github.com/natcap/invest/issues/1705)
 * Urban Flood Risk
     * Fields present on the input AOI vector are now retained in the output.
       (https://github.com/natcap/invest/issues/1600)

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -982,6 +982,7 @@ def _calculate_vri(l_path, target_vri_path):
         valid_mask = (
             ~pygeoprocessing.array_equals_nodata(block, l_nodata) &
             (~numpy.isinf(block)))
+        # TODO: should numpy.sum ignore numpy.nan?
         qb_sum += numpy.sum(block[valid_mask])
         qb_valid_count += numpy.count_nonzero(valid_mask)
     li_nodata = pygeoprocessing.get_raster_info(l_path)['nodata'][0]

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -982,7 +982,6 @@ def _calculate_vri(l_path, target_vri_path):
         valid_mask = (
             ~pygeoprocessing.array_equals_nodata(block, l_nodata) &
             (~numpy.isinf(block)))
-        # TODO: should numpy.sum ignore numpy.nan?
         qb_sum += numpy.sum(block[valid_mask])
         qb_valid_count += numpy.count_nonzero(valid_mask)
     li_nodata = pygeoprocessing.get_raster_info(l_path)['nodata'][0]

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield_core.pyx
@@ -16,6 +16,7 @@ from cython.operator cimport dereference as deref
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from cython.operator cimport dereference as deref
 from cython.operator cimport preincrement as inc
+from libc.math cimport isnan
 from libcpp.list cimport list as clist
 from libcpp.set cimport set as cset
 from libcpp.pair cimport pair
@@ -28,6 +29,8 @@ cdef extern from "time.h" nogil:
     time_t time(time_t*)
 
 cdef int is_close(double x, double y):
+    if isnan(x) and isnan(y):
+        return 1
     return abs(x-y) <= (1e-8+1e-05*abs(y))
 
 cdef extern from "LRUCache.h":


### PR DESCRIPTION
We have updated our `is_close` and `numpy.isclose` calls in most places to check for `numpy.nan`, but this is one place where we were not doing that. It's plausible for the rasters being processed by this module to have `numpy.nan` pixels.

Fixes #1705 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
