### PR TITLE
bump pytest-subtests requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@
 
 virtualenv>=12.0.1
 pytest
-pytest-subtests
+pytest-subtests>=0.14.1  # https://github.com/pytest-dev/pytest-subtests/issues/173
 wheel>=0.27.0
 pypiwin32; sys_platform == 'win32'  # pip-only
 


### PR DESCRIPTION
## Description
This should fix the invest test failures on python 3.9 and 3.10.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
