### PR TITLE
Upgrade `setup-micromamba` action version

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -71,10 +71,6 @@ runs:
         cache-environment: true
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
 
-    - name: test
-      shell: bash
-      run: echo ${{ hashFiles('environment.yml') }}
-
     - name: List conda environment
       shell: bash -l {0}
       run: micromamba list

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -60,7 +60,7 @@ runs:
         cat environment.yml
 
     - name: Setup conda environment
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: environment.yml
         environment-name: env
@@ -70,6 +70,9 @@ runs:
         init-shell: bash
         cache-environment: true
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
+
+    - name: test
+      run: echo ${{ hashFiles('environment.yml') }}
 
     - name: List conda environment
       shell: bash -l {0}

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -72,6 +72,7 @@ runs:
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
 
     - name: test
+      shell: bash
       run: echo ${{ hashFiles('environment.yml') }}
 
     - name: List conda environment


### PR DESCRIPTION
## Description
Fixes #1709 
Not sure why exactly, but updating to the latest major version of `setup-micromamba` appears to fix the cache key issue. You can see in the `Setup environment` step, the cache key no longer has the extra string containing `[object Promise]`.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
