### PR TITLE
Plugin install: use micromamba to make sure git is available

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -56,7 +56,7 @@ export function setupAddPlugin() {
       try {
         logger.info('adding plugin at', pluginURL);
         const micromamba = settingsStore.get('micromamba');
-        const rootPrefix = upath.join(process.resourcesPath, 'micromamba_envs')
+        const rootPrefix = upath.join(process.resourcesPath, 'micromamba_envs');
         const baseEnvPrefix = upath.join(rootPrefix, 'invest_base');
         // Create invest_base environment, if it doesn't already exist
         // The purpose of this environment is just to ensure that git is available
@@ -71,7 +71,7 @@ export function setupAddPlugin() {
         await spawnWithLogging(
           micromamba,
           ['run', '--prefix', `"${baseEnvPrefix}"`,
-           'git', 'clone', '--depth', '1', '--no-checkout', pluginURL, tmpPluginDir]
+            'git', 'clone', '--depth', '1', '--no-checkout', pluginURL, tmpPluginDir]
         );
         await spawnWithLogging(
           micromamba,
@@ -92,11 +92,13 @@ export function setupAddPlugin() {
 
         // Create a conda env containing the plugin and its dependencies
         const envName = `invest_plugin_${pluginID}`;
-        const pluginEnvPrefix = upath.join(rootPrefix, envName)
+        const pluginEnvPrefix = upath.join(rootPrefix, envName);
         const createCommand = [
           'create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
-          '-c', 'conda-forge']; // include dependencies read from pyproject.toml
-        condaDeps.forEach((dep) => createCommand.push(`"${dep}"`))
+          '-c', 'conda-forge', 'python'];
+        if (condaDeps) { // include dependencies read from pyproject.toml
+          condaDeps.forEach((dep) => createCommand.push(`"${dep}"`));
+        }
         await spawnWithLogging(micromamba, createCommand);
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -88,15 +88,16 @@ export function setupAddPlugin() {
         const pluginID = pyprojectTOML.tool.natcap.invest.model_id;
         const pluginName = pyprojectTOML.tool.natcap.invest.model_name;
         const pluginPyName = pyprojectTOML.tool.natcap.invest.pyname;
+        const condaDeps = pyprojectTOML.tool.natcap.invest.conda_dependencies;
 
         // Create a conda env containing the plugin and its dependencies
         const envName = `invest_plugin_${pluginID}`;
         const pluginEnvPrefix = upath.join(rootPrefix, envName)
-        await spawnWithLogging(
-          micromamba,
-          ['create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
-           '-c', 'conda-forge', '"python<3.12"', '"gdal<3.6"']
-        );
+        const createCommand = [
+          'create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
+          '-c', 'conda-forge']; // include dependencies read from pyproject.toml
+        condaDeps.forEach((dep) => createCommand.push(`"${dep}"`))
+        await spawnWithLogging(micromamba, createCommand);
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -56,15 +56,26 @@ export function setupAddPlugin() {
       try {
         logger.info('adding plugin at', pluginURL);
         const micromamba = settingsStore.get('micromamba');
+        const rootPrefix = upath.join(process.resourcesPath, 'micromamba_envs')
+        const baseEnvPrefix = upath.join(rootPrefix, 'invest_base');
+        // Create invest_base environment, if it doesn't already exist
+        // The purpose of this environment is just to ensure that git is available
+        if (!fs.existsSync(baseEnvPrefix)) {
+          await spawnWithLogging(
+            micromamba,
+            ['create', '--yes', '--prefix', `"${baseEnvPrefix}"`, '-c', 'conda-forge', 'git']
+          );
+        }
         // Create a temporary directory and check out the plugin's pyproject.toml
         const tmpPluginDir = fs.mkdtempSync(upath.join(tmpdir(), 'natcap-invest-'));
         await spawnWithLogging(
-          'git',
-          ['clone', '--depth', '1', '--no-checkout', pluginURL, tmpPluginDir]
+          micromamba,
+          ['run', '--prefix', `"${baseEnvPrefix}"`,
+           'git', 'clone', '--depth', '1', '--no-checkout', pluginURL, tmpPluginDir]
         );
         await spawnWithLogging(
-          'git',
-          ['checkout', 'HEAD', 'pyproject.toml'],
+          micromamba,
+          ['run', '--prefix', `"${baseEnvPrefix}"`, 'git', 'checkout', 'HEAD', 'pyproject.toml'],
           { cwd: tmpPluginDir }
         );
         // Read in the plugin's pyproject.toml, then delete it
@@ -80,22 +91,24 @@ export function setupAddPlugin() {
 
         // Create a conda env containing the plugin and its dependencies
         const envName = `invest_plugin_${pluginID}`;
+        const pluginEnvPrefix = upath.join(rootPrefix, envName)
         await spawnWithLogging(
           micromamba,
-          ['create', '--yes', '--name', envName, '-c', 'conda-forge', '"python<3.12"', '"gdal<3.6"']
+          ['create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
+           '-c', 'conda-forge', '"python<3.12"', '"gdal<3.6"']
         );
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,
-          ['run', '--name', envName, 'pip', 'install', `git+${pluginURL}`]
+          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'pip', 'install', `git+${pluginURL}`]
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json
-        const envInfo = execSync(`${micromamba} info --name ${envName}`, { windowsHide: true }).toString();
-        logger.info(`env info:\n${envInfo}`);
-        const regex = /env location : (.+)/;
-        const envPath = envInfo.match(regex)[1];
-        logger.info(`env path:\n${envPath}`);
+        // const envInfo = execSync(`${micromamba} info --name ${envName}`, { windowsHide: true }).toString();
+        // logger.info(`env info:\n${envInfo}`);
+        // const regex = /env location : (.+)/;
+        // const envPath = envInfo.match(regex)[1];
+        // logger.info(`env path:\n${envPath}`);
         logger.info('writing plugin info to settings store');
         settingsStore.set(
           `plugins.${pluginID}`,
@@ -104,7 +117,7 @@ export function setupAddPlugin() {
             pyname: pluginPyName,
             type: 'plugin',
             source: pluginURL,
-            env: envPath,
+            env: pluginEnvPrefix,
           }
         );
         logger.info('successfully added plugin');

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -104,11 +104,6 @@ export function setupAddPlugin() {
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json
-        // const envInfo = execSync(`${micromamba} info --name ${envName}`, { windowsHide: true }).toString();
-        // logger.info(`env info:\n${envInfo}`);
-        // const regex = /env location : (.+)/;
-        // const envPath = envInfo.match(regex)[1];
-        // logger.info(`env path:\n${envPath}`);
         logger.info('writing plugin info to settings store');
         settingsStore.set(
           `plugins.${pluginID}`,


### PR DESCRIPTION
## Description
Fixes #1713 
Creates an `invest_base` environment that contains git, and runs the subsequent git commands in that env, so we don't have to assume that git is available on the system.

Also specifies a prefix (path) for the base and plugin environments, rather than using the `--name`. This resolves a warning I was seeing about no root prefix specified - and keeps the invest-specific environments contained in the workbench resources directory, rather than mixing with other envs the user might have in the default location. Also removes the need to look up the env location in `mamba info`.

Also throwing in a fix for #1652, since it's so small - just read in the conda dependencies from a pyproject.toml configuration, rather than hard-coding.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
