### PR TITLE
Halt auto-scrolling of log output on user-initiated scrolling

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -38,6 +38,10 @@
 
 Unreleased Changes
 ------------------
+* Workbench
+    * Auto-scrolling of log output is halted on user-initiated scrolling,
+      enabling easier inspection of log output while a model is running
+      (`InVEST #1533 <https://github.com/natcap/invest/issues/1533>`_).
 * Coastal Blue Carbon
     * The ``code`` column in the model's biophysical table input, as well as
       the ``code`` column in the preprocessor's LULC lookup table input and

--- a/workbench/src/renderer/components/LogTab/index.jsx
+++ b/workbench/src/renderer/components/LogTab/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 
@@ -13,15 +13,32 @@ const { ipcRenderer } = window.Workbench.electron;
 function LogDisplay(props) {
   const ref = useRef();
 
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [prevScrollTop, setPrevScrollTop] = useState(0);
+
   useEffect(() => {
-    ref.current.scrollTop = ref.current.scrollHeight;
+    if (autoScroll) {
+      ref.current.scrollTop = ref.current.scrollHeight;
+    }
   }, [props.logdata]);
+
+  // Listen for scroll events. If scroll direction is up,
+  // assume scrolling was user-initiated, and halt auto-scrolling.
+  const checkScrollDirection = () => {
+    const currentScrollTop = ref.current.scrollTop;
+    const scrollingUp = (currentScrollTop < prevScrollTop);
+    if (scrollingUp) {
+      setAutoScroll(false);
+    }
+    setPrevScrollTop(currentScrollTop);
+  };
 
   return (
     <Col
       className="text-break"
       id="log-display"
       ref={ref}
+      onScroll={checkScrollDirection}
     >
       {
         props.logdata.map(([line, cls], idx) => (

--- a/workbench/src/renderer/components/LogTab/index.jsx
+++ b/workbench/src/renderer/components/LogTab/index.jsx
@@ -15,7 +15,11 @@ function LogDisplay(props) {
 
   const [autoScroll, setAutoScroll] = useState(true);
   const [prevScrollTop, setPrevScrollTop] = useState(0);
+
+  // A scroll event doesn't tell us whether it was initiated by a user or by code,
+  // so we assume all scroll events are user-initiated unless otherwise specified.
   const [userInitiatedScroll, setUserInitiatedScroll] = useState(true);
+
   let scrollHandlerTimer;
 
   // `scrollOffsetThreshold` is used to determine when user has scrolled to bottom of window.
@@ -26,11 +30,16 @@ function LogDisplay(props) {
 
   useEffect(() => {
     if (autoScroll) {
+      // Setting `ref.current.scrollTop` will fire a scroll event, which will
+      // result in a call to `handleScroll`. To avoid unnecessary operations in
+      // `handleScroll`, we flag the next scroll event as _not_ user-initiated.
       setUserInitiatedScroll(false);
       ref.current.scrollTop = ref.current.scrollHeight;
     }
   }, [props.logdata]);
 
+  // Check scroll direction or position IFF scroll event was user-initiated.
+  // Always update `prevScrollTop` and reset `userInitiatedScroll` to `true`.
   const handleScroll = () => {
     if (scrollHandlerTimer) {
       clearTimeout(scrollHandlerTimer);


### PR DESCRIPTION
## Description
Fixes #1533. When a user-initiated scroll event is detected (based on scroll direction), auto-scrolling is halted.

Note this behavior will persist in a model tab as long as it is open. Once auto-scrolling has been halted in a given tab, it will not resume in that tab, even on subsequent model runs. This shouldn't cause any problems, but if it becomes annoying, we can implement a mechanism for resuming auto-scrolling.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
