### PR TITLE
Schedule release workflow to run first tuesday of the month

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -1,6 +1,12 @@
 name: Release (Part 1 of 2)
 
 on:
+  schedule:
+    # every tuesday at 10:20am PST (6:20pm UTC)
+    # cron doesn't support "first tuesday of the month", so we will use github
+    # actions syntax below to skip tuesdays that aren't in the first week.
+    # it is recommended not to start on the hour to avoid peak traffic
+    - cron: "20 18 1-7 * 2"
   workflow_dispatch:
     inputs:
       version:
@@ -18,11 +24,22 @@ jobs:
   start-release:
     runs-on: ubuntu-latest
     steps:
+      # skip scheduled runs that aren't the first tuesday of the month
+      - name: Check day of month
+        run: |
+          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 7 ]]; then
+            echo "RUN=true" >> $GITHUB_ENV
+          else
+            echo "RUN=false" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
+        if: ${{ env.RUN }}
         with:
           token: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
       - name: Configure git
+        if: ${{ env.RUN }}
         run: |
           git config user.name "GitHub Actions"
           git config user.email "<>"
@@ -30,6 +47,7 @@ jobs:
       # Members of the natcap software team can push to the autorelease branch on
       # natcap/invest; this branch is a special case for our release process.
       - name: Create autorelease branch
+        if: ${{ env.RUN }}
         run: git checkout -b "$AUTORELEASE_BRANCH"
 
       # Replace
@@ -46,6 +64,7 @@ jobs:
       # X.X.X (XXXX-XX-XX)
       # ------------------
       - name: Update HISTORY.rst
+        if: ${{ env.RUN }}
         run: |
           HEADER="$VERSION ($(date '+%Y-%m-%d'))"
           HEADER_LENGTH=${#HEADER}
@@ -55,18 +74,22 @@ jobs:
               HISTORY.rst
 
       - name: Install dependencies
+        if: ${{ env.RUN }}
         run: pip install rst2html5
 
       - name: Generate changelog.html
+        if: ${{ env.RUN }}
         run: rst2html5 HISTORY.rst workbench/changelog.html
 
       - name: Update package.json version
+        if: ${{ env.RUN }}
         uses: BellCubeDev/update-package-version-by-release-tag@v2
         with:
           version: ${{ inputs.version }}
           package-json-path: workbench/package.json
 
       - name: Commit updated HISTORY.rst, changelog.html, and package.json
+        if: ${{ env.RUN }}
         run: |
           git add HISTORY.rst
           git add workbench/changelog.html
@@ -74,11 +97,13 @@ jobs:
           git commit -m "Committing the $VERSION release."
 
       - name: Tag and push
+        if: ${{ env.RUN }}
         run: |
           git tag $VERSION
           git push --atomic origin $AUTORELEASE_BRANCH $VERSION
 
       - name: Find actions run for the version tag
+        if: ${{ env.RUN }}
         run: |
           # wait a few seconds to make sure the actions run exists before querying it
           sleep 5
@@ -90,6 +115,7 @@ jobs:
               --jq .[].url)" >> $GITHUB_ENV
 
       - name: Create a PR from the autorelease branch into main
+        if: ${{ env.RUN }}
         run: |
           gh pr create \
             --base main \

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -38,6 +38,23 @@ jobs:
         with:
           token: ${{ secrets.AUTORELEASE_BOT_PAT }}
 
+      - name: Install dependencies
+        if: ${{ env.RUN }}
+        run: pip install rst2html5 setuptools_scm
+
+      - name: Get current version number (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: echo "CURRENT_VERSION=$(python -m setuptools_scm)" > $GITHUB_ENV
+
+      - name: Get next bugfix version number (scheduled runs only)
+        if: github.event_name == 'schedule'
+        shell: python
+        run: |
+          import os
+          major, minor, bugfix, *_ = os.environ['CURRENT_VERSION'].split('.')
+          with open(os.environ['GITHUB_ENV']) as env_file:
+            env_file.write(f'VERSION={major}.{minor}.{bugfix + 1}')
+
       - name: Configure git
         if: ${{ env.RUN }}
         run: |
@@ -72,10 +89,6 @@ jobs:
           perl -0777 -i -pe \
               "s/Unreleased Changes\n------------------/..\n  Unreleased Changes\n  ------------------\n\n${HEADER}\n${UNDERLINE}/g" \
               HISTORY.rst
-
-      - name: Install dependencies
-        if: ${{ env.RUN }}
-        run: pip install rst2html5
 
       - name: Generate changelog.html
         if: ${{ env.RUN }}

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 18 1-7 * 2"
+    - cron: "20 18 * * 2"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Description
Fixes #1736 
I tested the bash if/else expression, but not the whole workflow since it can't be run on a branch other than `main`. There's a good chance that some part of this won't work perfectly, but it might be easy enough to fix on the first scheduled release day, rather than trying to set up a test.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
