### PR TITLE
Fix failed auto-PR from `main` into `release/*`

### DIFF
--- a/.github/workflows/auto-pr-from-main-into-releases.yml
+++ b/.github/workflows/auto-pr-from-main-into-releases.yml
@@ -76,6 +76,7 @@ jobs:
                   --reviewer "$PR_USERNAME" \
                   --assignee "$PR_USERNAME" \
                   --label "auto" \
+                  --title "auto merge main into release/*" \
                   --body-file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
           done
 


### PR DESCRIPTION
I think we just need to provide a `--title`. I tested a similar command locally with `--dry-run` and it worked.

Fixes #1751 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
