### PR TITLE
Close any open plugin tabs before removing it

### DIFF
--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -379,6 +379,8 @@ export default class App extends React.Component {
                 }
                 <PluginModal
                   updateInvestList={this.updateInvestList}
+                  closeInvestModel={this.closeInvestModel}
+                  openJobs={openJobs}
                 />
                 <SettingsModal
                   className="mx-3"

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -13,7 +13,7 @@ import { ipcMainChannels } from '../../../main/ipcMainChannels';
 const { ipcRenderer } = window.Workbench.electron;
 
 export default function PluginModal(props) {
-  const { updateInvestList } = props;
+  const { updateInvestList, closeInvestModel, openJobs } = props;
   const [showPluginModal, setShowPluginModal] = useState(false);
   const [url, setURL] = useState(undefined);
   const [revision, setRevision] = useState(undefined);
@@ -52,6 +52,11 @@ export default function PluginModal(props) {
 
   const removePlugin = () => {
     setLoading(true);
+    Object.keys(openJobs).forEach((tabID) => {
+      if (openJobs[tabID].modelRunName === pluginToRemove) {
+        closeInvestModel(tabID);
+      }
+    });
     ipcRenderer.invoke(ipcMainChannels.REMOVE_PLUGIN, pluginToRemove).then(() => {
       updateInvestList();
       setLoading(false);
@@ -212,4 +217,8 @@ export default function PluginModal(props) {
 
 PluginModal.propTypes = {
   updateInvestList: PropTypes.func.isRequired,
+  closeInvestModel: PropTypes.func.isRequired,
+  openJobs: PropTypes.shape({
+    modelRunName: PropTypes.string,
+  }).isRequired,
 };

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -142,9 +142,14 @@ describe('Add plugin modal', () => {
       return Promise.resolve();
     });
     const {
-      findByText, getByRole, findByLabelText, queryByRole,
+      findByText, findByRole, getByRole, findByLabelText, queryByRole,
     } = render(<App />);
 
+    // open the plugin first, to make sure it doesn't cause a crash when removing
+    const pluginButton = await findByRole('button', { name: /Foo/ });
+    await act(async () => {
+      userEvent.click(pluginButton);
+    });
     const managePluginsButton = await findByText('Manage plugins');
     userEvent.click(managePluginsButton);
 


### PR DESCRIPTION
## Description
Fixes #1692 
Prevent the renderer crash when removing a plugin, by first closing any open tabs running that plugin.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
