### PR TITLE
Add git to plugin env creation

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -131,7 +131,7 @@ export function setupAddPlugin() {
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,
-          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'python -m pip', 'install', installString]
+          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'python', '-m', 'pip', 'install', installString]
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -131,7 +131,8 @@ export function setupAddPlugin() {
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,
-          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'pip', 'install', installString]
+          ['run', '--prefix', `"${pluginEnvPrefix}"`,
+           'python', '-m', 'pip', 'install', installString]
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -123,7 +123,7 @@ export function setupAddPlugin() {
         const pluginEnvPrefix = upath.join(rootPrefix, envName);
         const createCommand = [
           'create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
-          '-c', 'conda-forge', 'python'];
+          '-c', 'conda-forge', 'python', 'git'];
         if (condaDeps) { // include dependencies read from pyproject.toml
           condaDeps.forEach((dep) => createCommand.push(`"${dep}"`));
         }
@@ -131,7 +131,7 @@ export function setupAddPlugin() {
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,
-          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'pip', 'install', installString]
+          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'python -m pip', 'install', installString]
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -131,7 +131,7 @@ export function setupAddPlugin() {
         logger.info('created micromamba env for plugin');
         await spawnWithLogging(
           micromamba,
-          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'python', '-m', 'pip', 'install', installString]
+          ['run', '--prefix', `"${pluginEnvPrefix}"`, 'pip', 'install', installString]
         );
         logger.info('installed plugin into its env');
         // Write plugin metadata to the workbench's config.json


### PR DESCRIPTION
## Description
Adding `git` to the creation of the plugin env to help with dependencies that point to a git repository.

Also adding in `python -m` to call `pip`, since I was seeing some Windows specific issues where `pip` called from micromamba would return "failed to create process".  This [GH issue](https://github.com/mamba-org/mamba/issues/2702) mentions similar behavior in another instance, but I wasn't able to parse anything as a fix to what I was seeing.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
