### PR TITLE
pin sqlite<3.49.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
-          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} sqlite<3.49.1  # https://github.com/natcap/invest/issues/1797
 
       - name: Download previous conda environment.yml
         continue-on-error: true


### PR DESCRIPTION
## Description
See #1797 

The issue is resolved by avoiding the latest sqlite version. sqlite is a conda package and not a python package, so there is no change to `requirements.txt`, just to the github actions workflow. If we determine that there is a real issue with this version, we might update the invest conda-forge feedstock to reflect that. For now, just getting the builds working.
## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
