### PR TITLE
Update wheel filename pattern to support natcap_invest

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,7 +121,7 @@ jobs:
           python -m pip uninstall -y natcap.invest
           python -m build --wheel
           ls -la dist
-          pip install $(find dist -name "natcap.invest*.whl")
+          pip install $(find dist -name "natcap[._-]invest*.whl")
 
       - name: Run model tests
         run: make test


### PR DESCRIPTION
## Description
This PR updates the pip install command in our build process to account for the recent change in wheel naming conventions from `natcap.invest-*.whl` to `natcap_invest-*.whl`.

As discussed in #1679, Python’s build process has been progressively enforcing sanitization of distribution names, replacing dots (.) with underscores (_). Initially, this affected source distributions (sdist), and now we are seeing the same change applied to wheel (whl) files.

Specifically, this PR changes the install command from `pip install $(find dist -name "natcap.invest*.whl")` to `pip install $(find dist -name "natcap[._-]invest*.whl")` to accommodate both old and new naming conventions.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
