### PR TITLE
Fix auto-PR GHA failure on attempt to create a duplicate PR

### DIFF
--- a/.github/workflows/auto-pr-from-main-into-releases.yml
+++ b/.github/workflows/auto-pr-from-main-into-releases.yml
@@ -60,16 +60,26 @@ jobs:
               cat .github/auto-main-into-release-pr-body.md | envsubst > $PR_BODY_FILE
               cat $PR_BODY_FILE  # for debugging
 
+              PR_TITLE="[Auto-generated] Merge main into $BRANCH"
+
+              # Skip this branch if a PR from main into $BRANCH already exists.
+              EXISTING_PR=$(gh pr list --search "$PR_TITLE in:title" || echo '')
+              if ! [ -z "$EXISTING_PR" ]
+              then
+                  echo "PR into $BRANCH already exists; skipping."
+                  continue
+              fi
+
               # This PR will be assigned to $GITHUB_ACTOR, which should be
               # the person who merged the PR that caused this commit to be
-              # created.  Others could of course be assigned later.
+              # created. Others could of course be assigned later.
               gh pr create \
                   --head $SOURCE_BRANCH \
                   --base $RELEASE_BRANCH \
                   --reviewer "$PR_USERNAME" \
                   --assignee "$PR_USERNAME" \
                   --label "auto" \
-                  --title "[Auto-generated] Merge main into release/$BRANCH" \
+                  --title "$PR_TITLE" \
                   --body-file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
           done
 


### PR DESCRIPTION
## Description
The `PR main into release/**` workflow fails if it attempts to create a PR that already exists.

This change should resolve the issue, specifically by implementing the following behavior:
- If a PR from `main` into a given release branch already exists, the workflow will not attempt to create another.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
