### PR TITLE
Update release/3.15.0 with latest from main

### DIFF
--- a/.github/workflows/auto-pr-from-main-into-releases.yml
+++ b/.github/workflows/auto-pr-from-main-into-releases.yml
@@ -60,16 +60,26 @@ jobs:
               cat .github/auto-main-into-release-pr-body.md | envsubst > $PR_BODY_FILE
               cat $PR_BODY_FILE  # for debugging
 
+              PR_TITLE="[Auto-generated] Merge main into $BRANCH"
+
+              # Skip this branch if a PR from main into $BRANCH already exists.
+              EXISTING_PR=$(gh pr list --search "$PR_TITLE in:title" || echo '')
+              if ! [ -z "$EXISTING_PR" ]
+              then
+                  echo "PR into $BRANCH already exists; skipping."
+                  continue
+              fi
+
               # This PR will be assigned to $GITHUB_ACTOR, which should be
               # the person who merged the PR that caused this commit to be
-              # created.  Others could of course be assigned later.
+              # created. Others could of course be assigned later.
               gh pr create \
                   --head $SOURCE_BRANCH \
                   --base $RELEASE_BRANCH \
                   --reviewer "$PR_USERNAME" \
                   --assignee "$PR_USERNAME" \
                   --label "auto" \
-                  --title "[Auto-generated] Merge main into release/$BRANCH" \
+                  --title "$PR_TITLE" \
                   --body-file $PR_BODY_FILE || ERRORSPRESENT=$(($ERRORSPRESENT | $?))
           done
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ env:
   # build: dependency of make install
   # nomkl: make sure numpy w/out mkl
   # setuptools_scm: needed for versioning to work
-  CONDA_DEFAULT_DEPENDENCIES: python-build nomkl setuptools_scm
+  CONDA_DEFAULT_DEPENDENCIES: python-build nomkl setuptools_scm sqlite<3.49.1 # https://github.com/natcap/invest/issues/1797
   LATEST_SUPPORTED_PYTHON_VERSION: "3.13"
 
 jobs:
@@ -94,7 +94,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
-          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }} sqlite<3.49.1  # https://github.com/natcap/invest/issues/1797
+          requirements: ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
 
       - name: Download previous conda environment.yml
         continue-on-error: true


### PR DESCRIPTION
## Description
Updates `release/3.15.0` with the latest from `main`.

This PR had to be created manually because, in testing the results of PR #1818, I managed to successfully fool the GHA runner into _not_ creating a PR from `main` into `release/3.15.0`. 🙃 



