### PR TITLE
Habitat Quality: Improve validation for `MAX_DIST` and `WEIGHT`

### DIFF
--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -1266,16 +1266,12 @@ def validate(args, limit_to=None):
                 ['threats_table_path'],
                 MISSING_THREAT_RASTER_MSG.format(threat_list=bad_threat_paths)
             ))
-
-            if 'threats_table_path' not in invalid_keys:
-                invalid_keys.add('threats_table_path')
+            invalid_keys.add('threats_table_path')
 
         if duplicate_paths:
             validation_warnings.append((
                 ['threats_table_path'],
                 DUPLICATE_PATHS_MSG + str(duplicate_paths)))
-
-            if 'threats_table_path' not in invalid_keys:
-                invalid_keys.add('threats_table_path')
+            invalid_keys.add('threats_table_path')
 
     return validation_warnings

--- a/tests/test_habitat_quality.py
+++ b/tests/test_habitat_quality.py
@@ -802,104 +802,6 @@ class HabitatQualityTests(unittest.TestCase):
         self.assertIn("max distance for threat: 'threat_1' is less",
                       str(cm.exception))
 
-    def test_habitat_quality_missing_max_dist(self):
-        """Habitat Quality: expected ValueError on missing max_dist."""
-        from natcap.invest import habitat_quality
-
-        args = {
-            'half_saturation_constant': '0.5',
-            'results_suffix': 'regression',
-            'workspace_dir': self.workspace_dir,
-            'n_workers': -1,
-        }
-
-        args['access_vector_path'] = os.path.join(
-            args['workspace_dir'], 'access_samp.shp')
-        make_access_shp(args['access_vector_path'])
-
-        scenarios = ['_bas_', '_cur_', '_fut_']
-        for lulc_val, scenario in enumerate(scenarios, start=1):
-            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
-            lulc_array[50:, :] = lulc_val
-            args['lulc' + scenario + 'path'] = os.path.join(
-                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
-            make_raster_from_array(
-                lulc_array, args['lulc' + scenario + 'path'])
-
-        args['sensitivity_table_path'] = os.path.join(
-            args['workspace_dir'], 'sensitivity_samp.csv')
-        make_sensitivity_samp_csv(args['sensitivity_table_path'])
-
-        make_threats_raster(args['workspace_dir'])
-
-        args['threats_table_path'] = os.path.join(
-            args['workspace_dir'], 'threats_samp.csv')
-
-        # create the threat CSV table
-        with open(args['threats_table_path'], 'w') as open_table:
-            open_table.write(
-                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
-            open_table.write(
-                ',0.7,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
-            open_table.write(
-                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
-                'threat_2_f.tif\n')
-
-        with self.assertRaises(ValueError) as cm:
-            habitat_quality.execute(args)
-
-        self.assertIn("max distance for threat: 'threat_1' is less",
-                      str(cm.exception))
-
-    def test_habitat_quality_missing_weight(self):
-        """Habitat Quality: expected ValueError on missing weight."""
-        from natcap.invest import habitat_quality
-
-        args = {
-            'half_saturation_constant': '0.5',
-            'results_suffix': 'regression',
-            'workspace_dir': self.workspace_dir,
-            'n_workers': -1,
-        }
-
-        args['access_vector_path'] = os.path.join(
-            args['workspace_dir'], 'access_samp.shp')
-        make_access_shp(args['access_vector_path'])
-
-        scenarios = ['_bas_', '_cur_', '_fut_']
-        for lulc_val, scenario in enumerate(scenarios, start=1):
-            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
-            lulc_array[50:, :] = lulc_val
-            args['lulc' + scenario + 'path'] = os.path.join(
-                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
-            make_raster_from_array(
-                lulc_array, args['lulc' + scenario + 'path'])
-
-        args['sensitivity_table_path'] = os.path.join(
-            args['workspace_dir'], 'sensitivity_samp.csv')
-        make_sensitivity_samp_csv(args['sensitivity_table_path'])
-
-        make_threats_raster(args['workspace_dir'])
-
-        args['threats_table_path'] = os.path.join(
-            args['workspace_dir'], 'threats_samp.csv')
-
-        # create the threat CSV table
-        with open(args['threats_table_path'], 'w') as open_table:
-            open_table.write(
-                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
-            open_table.write(
-                '0.04,,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
-            open_table.write(
-                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
-                'threat_2_f.tif\n')
-
-        with self.assertRaises(ValueError) as cm:
-            habitat_quality.execute(args)
-
-        self.assertIn("Missing weight ratio for threat: 'threat_1'",
-                      str(cm.exception))
-
     def test_habitat_quality_invalid_decay_type(self):
         """Habitat Quality: expected ValueError on invalid decay type."""
         from natcap.invest import habitat_quality
@@ -1470,6 +1372,159 @@ class HabitatQualityTests(unittest.TestCase):
         self.assertTrue(utils.matches_format_string(
             validate_result[0][1],
             habitat_quality.MISSING_SENSITIVITY_TABLE_THREATS_MSG))
+
+    def test_habitat_quality_validation_invalid_max_dist(self):
+        """Habitat Quality: test validation for max_dist <= 0."""
+        from natcap.invest import habitat_quality
+        from natcap.invest import utils
+
+        args = {
+            'half_saturation_constant': '0.5',
+            'results_suffix': 'regression',
+            'workspace_dir': self.workspace_dir,
+            'n_workers': -1,
+        }
+
+        args['access_vector_path'] = os.path.join(
+            args['workspace_dir'], 'access_samp.shp')
+        make_access_shp(args['access_vector_path'])
+
+        scenarios = ['_bas_', '_cur_', '_fut_']
+        for lulc_val, scenario in enumerate(scenarios, start=1):
+            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
+            lulc_array[50:, :] = lulc_val
+            args['lulc' + scenario + 'path'] = os.path.join(
+                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
+            make_raster_from_array(
+                lulc_array, args['lulc' + scenario + 'path'])
+
+        args['sensitivity_table_path'] = os.path.join(
+            args['workspace_dir'], 'sensitivity_samp.csv')
+        make_sensitivity_samp_csv(args['sensitivity_table_path'])
+
+        make_threats_raster(args['workspace_dir'])
+
+        args['threats_table_path'] = os.path.join(
+            args['workspace_dir'], 'threats_samp.csv')
+
+        # create the threat CSV table
+        with open(args['threats_table_path'], 'w') as open_table:
+            open_table.write(
+                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
+            open_table.write(
+                '0,0.7,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
+            open_table.write(
+                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
+                'threat_2_f.tif\n')
+
+        validate_result = habitat_quality.validate(args, limit_to=None)
+        self.assertEqual(len(validate_result), 1)
+        self.assertEqual(validate_result[0][0], ['threats_table_path'])
+        self.assertTrue(utils.matches_format_string(
+            validate_result[0][1],
+            habitat_quality.INVALID_MAX_DIST_MSG))
+
+    def test_habitat_quality_validation_missing_max_dist(self):
+        """Habitat Quality: test validation for missing max_dist."""
+        from natcap.invest import habitat_quality
+        from natcap.invest import utils
+
+        args = {
+            'half_saturation_constant': '0.5',
+            'results_suffix': 'regression',
+            'workspace_dir': self.workspace_dir,
+            'n_workers': -1,
+        }
+
+        args['access_vector_path'] = os.path.join(
+            args['workspace_dir'], 'access_samp.shp')
+        make_access_shp(args['access_vector_path'])
+
+        scenarios = ['_bas_', '_cur_', '_fut_']
+        for lulc_val, scenario in enumerate(scenarios, start=1):
+            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
+            lulc_array[50:, :] = lulc_val
+            args['lulc' + scenario + 'path'] = os.path.join(
+                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
+            make_raster_from_array(
+                lulc_array, args['lulc' + scenario + 'path'])
+
+        args['sensitivity_table_path'] = os.path.join(
+            args['workspace_dir'], 'sensitivity_samp.csv')
+        make_sensitivity_samp_csv(args['sensitivity_table_path'])
+
+        make_threats_raster(args['workspace_dir'])
+
+        args['threats_table_path'] = os.path.join(
+            args['workspace_dir'], 'threats_samp.csv')
+
+        # create the threat CSV table
+        with open(args['threats_table_path'], 'w') as open_table:
+            open_table.write(
+                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
+            open_table.write(
+                ',0.7,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
+            open_table.write(
+                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
+                'threat_2_f.tif\n')
+
+        validate_result = habitat_quality.validate(args, limit_to=None)
+        self.assertEqual(len(validate_result), 1)
+        self.assertEqual(validate_result[0][0], ['threats_table_path'])
+        self.assertTrue(utils.matches_format_string(
+            validate_result[0][1],
+            habitat_quality.MISSING_MAX_DIST_MSG))
+
+    def test_habitat_quality_validation_missing_weight(self):
+        """Habitat Quality: test validation for missing weight."""
+        from natcap.invest import habitat_quality
+        from natcap.invest import utils
+
+        args = {
+            'half_saturation_constant': '0.5',
+            'results_suffix': 'regression',
+            'workspace_dir': self.workspace_dir,
+            'n_workers': -1,
+        }
+
+        args['access_vector_path'] = os.path.join(
+            args['workspace_dir'], 'access_samp.shp')
+        make_access_shp(args['access_vector_path'])
+
+        scenarios = ['_bas_', '_cur_', '_fut_']
+        for lulc_val, scenario in enumerate(scenarios, start=1):
+            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
+            lulc_array[50:, :] = lulc_val
+            args['lulc' + scenario + 'path'] = os.path.join(
+                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
+            make_raster_from_array(
+                lulc_array, args['lulc' + scenario + 'path'])
+
+        args['sensitivity_table_path'] = os.path.join(
+            args['workspace_dir'], 'sensitivity_samp.csv')
+        make_sensitivity_samp_csv(args['sensitivity_table_path'])
+
+        make_threats_raster(args['workspace_dir'])
+
+        args['threats_table_path'] = os.path.join(
+            args['workspace_dir'], 'threats_samp.csv')
+
+        # create the threat CSV table
+        with open(args['threats_table_path'], 'w') as open_table:
+            open_table.write(
+                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
+            open_table.write(
+                '0.04,,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
+            open_table.write(
+                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
+                'threat_2_f.tif\n')
+
+        validate_result = habitat_quality.validate(args, limit_to=None)
+        self.assertEqual(len(validate_result), 1)
+        self.assertEqual(validate_result[0][0], ['threats_table_path'])
+        self.assertTrue(utils.matches_format_string(
+            validate_result[0][1],
+            habitat_quality.MISSING_WEIGHT_MSG))
 
     def test_habitat_quality_validation_bad_threat_path(self):
         """Habitat Quality: test validation for bad threat paths."""

--- a/tests/test_habitat_quality.py
+++ b/tests/test_habitat_quality.py
@@ -851,6 +851,55 @@ class HabitatQualityTests(unittest.TestCase):
         self.assertIn("max distance for threat: 'threat_1' is less",
                       str(cm.exception))
 
+    def test_habitat_quality_missing_weight(self):
+        """Habitat Quality: expected ValueError on missing weight."""
+        from natcap.invest import habitat_quality
+
+        args = {
+            'half_saturation_constant': '0.5',
+            'results_suffix': 'regression',
+            'workspace_dir': self.workspace_dir,
+            'n_workers': -1,
+        }
+
+        args['access_vector_path'] = os.path.join(
+            args['workspace_dir'], 'access_samp.shp')
+        make_access_shp(args['access_vector_path'])
+
+        scenarios = ['_bas_', '_cur_', '_fut_']
+        for lulc_val, scenario in enumerate(scenarios, start=1):
+            lulc_array = numpy.ones((100, 100), dtype=numpy.int8)
+            lulc_array[50:, :] = lulc_val
+            args['lulc' + scenario + 'path'] = os.path.join(
+                args['workspace_dir'], 'lc_samp' + scenario + 'b.tif')
+            make_raster_from_array(
+                lulc_array, args['lulc' + scenario + 'path'])
+
+        args['sensitivity_table_path'] = os.path.join(
+            args['workspace_dir'], 'sensitivity_samp.csv')
+        make_sensitivity_samp_csv(args['sensitivity_table_path'])
+
+        make_threats_raster(args['workspace_dir'])
+
+        args['threats_table_path'] = os.path.join(
+            args['workspace_dir'], 'threats_samp.csv')
+
+        # create the threat CSV table
+        with open(args['threats_table_path'], 'w') as open_table:
+            open_table.write(
+                'MAX_DIST,WEIGHT,THREAT,DECAY,BASE_PATH,CUR_PATH,FUT_PATH\n')
+            open_table.write(
+                '0.04,,threat_1,linear,,threat_1_c.tif,threat_1_f.tif\n')
+            open_table.write(
+                '0.07,1.0,threat_2,exponential,,threat_2_c.tif,'
+                'threat_2_f.tif\n')
+
+        with self.assertRaises(ValueError) as cm:
+            habitat_quality.execute(args)
+
+        self.assertIn("Missing weight ratio for threat: 'threat_1'",
+                      str(cm.exception))
+
     def test_habitat_quality_invalid_decay_type(self):
         """Habitat Quality: expected ValueError on invalid decay type."""
         from natcap.invest import habitat_quality


### PR DESCRIPTION
## Description

Fixes #1052 

While looking into Issue #1052, I found that, in most cases, our error handling related to empty fields in the Threats Table and Sensitivity Table CSVs has been addressed by improvements to validation since the time the issue was opened. However, in cases where a `NaN` value exists in the `MAX_DIST` or `WEIGHT` columns of the Threats Table, validation passes but the model eventually throws one of the following errors:

- In the case of missing `MAX_DIST`:
```
    if row['max_dist'] <= 0:
       ^^^^^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'str' and 'int'
```
- In the case of missing `WEIGHT`:
```
weight_sum = threat_df['weight'].sum()
             ^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
TypeError: can only concatenate str (not "float") to str
```

In order to give the user more helpful feedback, I've added checks to both `execute` (for the benefit of CLI users) and `validate` (for the benefit of Workbench users). 

We _did_ have an existing `if row['max_dist'] <= 0` check in `execute`; in the interest of catching errors as early as possible, I've moved this check up and combined it with the checks for missing `MAX_DIST` and `WEIGHT`. 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
