### PR TITLE
Update Scenario Generator Output CSV Columns

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -181,6 +181,14 @@ NDR
   different climate scenarios and watershed selections.
   https://github.com/natcap/invest/issues/1741
 
+Scenario Generator
+==================
+* Updated the output CSV columns: Renamed `lucode` column `original lucode`
+  to clarify that it contains the original, to-be-converted, value(s). Added
+  `replacement lucode` column, containing the LULC code to which habitat was
+  converted during the model run.
+  https://github.com/natcap/invest/issues/1295
+
 SDR
 ===
 * Raster outputs that previously contained per-pixel values (e.g., t/pixel)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := dc0146c31c7cdc4c252572586437b525ef6c9154
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 4eb5a2fac4818a37663780c4cbdff1b41e7019be
+GIT_TEST_DATA_REPO_REV      := 275a823bb8cf3f745a1601c8d55ea39c446ceb10
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ GIT_SAMPLE_DATA_REPO_REV    := dc0146c31c7cdc4c252572586437b525ef6c9154
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 275a823bb8cf3f745a1601c8d55ea39c446ceb10
+GIT_TEST_DATA_REPO_REV      := 073b5fb5d803b02525cf0faf2d93e51c56214d1f
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 4c2ab01589d991cc4c5aab88ab5b40333879da84
+GIT_UG_REPO_REV             := bbeb7937307370ee438481dc94046d5b9aed374f
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -70,7 +70,7 @@ MODEL_SPEC = {
             "regexp": "[0-9 ]+",
             "about": gettext(
                 "A space-separated list of LULC codes that can be "
-                "converted to be converted to agriculture."),
+                "converted to agriculture."),
             "name": gettext("convertible landcover codes")
         },
         "n_fragmentation_steps": {

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -123,11 +123,15 @@ MODEL_SPEC = {
         "nearest_to_edge.csv": {
             "about": gettext(
                 "Table of land cover classes and the amount of each that was converted for the nearest-to-edge conversion scenario."),
-            "index_col": "lucode",
+            "index_col": "original lucode",
             "columns": {
-                "lucode": {
+                "original lucode": {
                     "type": "integer",
-                    "about": "LULC code of the land cover class"
+                    "about": "Original LULC code of the land cover class"
+                },
+                "replacement lucode": {
+                    "type": "integer",
+                    "about": "LULC code to which habitat was converted"
                 },
                 "area converted (Ha)": {
                     "type": "number",
@@ -143,11 +147,15 @@ MODEL_SPEC = {
         "farthest_from_edge.csv": {
             "about": gettext(
                 "Table of land cover classes and the amount of each that was converted for the nearest-to-edge conversion scenario."),
-            "index_col": "lucode",
+            "index_col": "original lucode",
             "columns": {
-                "lucode": {
+                "original lucode": {
                     "type": "integer",
-                    "about": "LULC code of the land cover class"
+                    "about": "Original LULC code of the land cover class"
+                },
+                "replacement lucode": {
+                    "type": "integer",
+                    "about": "LULC code to which habitat was converted"
                 },
                 "area converted (Ha)": {
                     "type": "number",
@@ -556,7 +564,7 @@ def _convert_landscape(
             output_landscape_raster_path, replacement_lucode, stats_cache,
             score_weight)
 
-    _log_stats(stats_cache, pixel_area_ha, stats_path)
+    _log_stats(stats_cache, replacement_lucode, pixel_area_ha, stats_path)
     try:
         shutil.rmtree(temp_dir)
     except OSError:
@@ -564,12 +572,13 @@ def _convert_landscape(
             "Could not delete temporary working directory '%s'", temp_dir)
 
 
-def _log_stats(stats_cache, pixel_area, stats_path):
+def _log_stats(stats_cache, replacement_lucode, pixel_area, stats_path):
     """Write pixel change statistics to a file in tabular format.
 
     Args:
         stats_cache (dict): a dictionary mapping pixel lucodes to number of
             pixels changed
+        replacement_lucode (int): lucode to which habitat was converted
         pixel_area (float): size of pixels in hectares so an area column can
             be generated
         stats_path (string): path to a csv file that the table should be
@@ -580,11 +589,14 @@ def _log_stats(stats_cache, pixel_area, stats_path):
 
     """
     with open(stats_path, 'w') as csv_output_file:
-        csv_output_file.write('lucode,area converted (Ha),pixels converted\n')
+        csv_output_file.write(
+            'original lucode,replacement lucode,'
+            'area converted (Ha),pixels converted\n')
         for lucode in sorted(stats_cache):
             csv_output_file.write(
-                '%s,%s,%s\n' % (
-                    lucode, stats_cache[lucode] * pixel_area,
+                '%s,%s,%s,%s\n' % (
+                    lucode, replacement_lucode,
+                    stats_cache[lucode] * pixel_area,
                     stats_cache[lucode]))
 
 

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -146,7 +146,7 @@ MODEL_SPEC = {
         },
         "farthest_from_edge.csv": {
             "about": gettext(
-                "Table of land cover classes and the amount of each that was converted for the nearest-to-edge conversion scenario."),
+                "Table of land cover classes and the amount of each that was converted for the farthest-from-edge conversion scenario."),
             "index_col": "original lucode",
             "columns": {
                 "original lucode": {


### PR DESCRIPTION
## Description
Fixes #1295 

`lucode` as a column name in the output CSVs of the Scenario Generator model was a bit ambiguous. This PR:
- Renames the `lucode` column `original lucode`, to clarify that it contains the original, to-be-converted, LULC values
- Adds a second column, `replacement lucode`, representing the LULC code to which habitat was converted during the model run

The `replacement lucode` column will only ever contain one value, the value specified by the user as the "Replacement Landcover Code" in the model run setup. However, including it means the user will easily be able to reference both the input and output codes from within the CSV. 

User Guide PR: [#170](https://github.com/natcap/invest.users-guide/pull/170)
Test Data PR: [#33](https://bitbucket.org/natcap/invest-test-data/pull-requests/33)

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)