### PR TITLE
Workbench: Prevent Duplicate Element IDs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -105,6 +105,9 @@ Workbench
 * Auto-scrolling of log output is halted on user-initiated scrolling,
   enabling easier inspection of log output while a model is running
   (`InVEST #1533 <https://github.com/natcap/invest/issues/1533>`_).
+* Fixed a bug where toggle inputs would fail to respond if multiple tabs
+  of the same model were open.
+  https://github.com/natcap/invest/issues/1842
 
 Annual Water Yield
 ==================

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
@@ -41,7 +41,7 @@ function filterSpatialOverlapFeedback(message, filepath) {
 
 function FormLabel(props) {
   const {
-    argkey, argname, argtype, required, units,
+    inputId, argkey, argname, argtype, required, units,
   } = props;
 
   const userFriendlyArgType = parseArgType(argtype);
@@ -49,7 +49,7 @@ function FormLabel(props) {
   const includeComma = userFriendlyArgType && optional;
 
   return (
-    <Form.Label column sm="3" htmlFor={argkey}>
+    <Form.Label column sm="3" htmlFor={`${argkey}-${inputId}`}>
       <span className="argname">{argname} </span>
       {
        (userFriendlyArgType || optional) &&
@@ -157,6 +157,7 @@ function parseArgType(argtype) {
 }
 
 export default function ArgInput(props) {
+  const inputId = useId();
   const inputRef = useRef();
 
   const {
@@ -221,7 +222,7 @@ export default function ArgInput(props) {
       <Button
         aria-label={`browse for ${argSpec.name}`}
         className="ml-2"
-        id={argkey}
+        id={`${argkey}-${inputId}`}
         variant="outline-dark"
         value={argSpec.type} // dialog will limit options accordingly
         name={argkey}
@@ -242,7 +243,7 @@ export default function ArgInput(props) {
       <Form.Check
         inline
         type="switch"
-        id={argkey}
+        id={`${argkey}-${inputId}`}
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
@@ -253,7 +254,7 @@ export default function ArgInput(props) {
   } else if (argSpec.type === 'option_string') {
     form = (
       <Form.Control
-        id={argkey}
+        id={`${argkey}-${inputId}`}
         as="select"
         name={argkey}
         value={value}
@@ -279,7 +280,7 @@ export default function ArgInput(props) {
       <React.Fragment>
         <Form.Control
           ref={inputRef}
-          id={argkey}
+          id={`${argkey}-${inputId}`}
           name={argkey}
           type="text"
           placeholder={placeholderText}
@@ -309,6 +310,7 @@ export default function ArgInput(props) {
       className={className} // this grays out the label but doesn't actually disable the field
     >
       <FormLabel
+        inputId={inputId}
         argkey={argkey}
         argname={argSpec.name}
         argtype={argSpec.type}

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -49,7 +49,7 @@ function FormLabel(props) {
   const includeComma = userFriendlyArgType && optional;
 
   return (
-    <Form.Label column sm="3" htmlFor={`${argkey}-${inputId}`}>
+    <Form.Label column sm="3" htmlFor={inputId}>
       <span className="argname">{argname} </span>
       {
        (userFriendlyArgType || optional) &&
@@ -157,7 +157,7 @@ function parseArgType(argtype) {
 }
 
 export default function ArgInput(props) {
-  const inputId = useId();
+  const uniqueId = useId();
   const inputRef = useRef();
 
   const {
@@ -176,6 +176,8 @@ export default function ArgInput(props) {
     scrollEventCount,
   } = props;
   let { validationMessage } = props;
+
+  const inputId = `${argkey}-${uniqueId}`;
 
   // Occasionaly we want to force a scroll to the end of input fields
   // so that the most important part of a filepath is visible.
@@ -222,7 +224,7 @@ export default function ArgInput(props) {
       <Button
         aria-label={`browse for ${argSpec.name}`}
         className="ml-2"
-        id={`${argkey}-${inputId}`}
+        id={inputId}
         variant="outline-dark"
         value={argSpec.type} // dialog will limit options accordingly
         name={argkey}
@@ -243,7 +245,7 @@ export default function ArgInput(props) {
       <Form.Check
         inline
         type="switch"
-        id={`${argkey}-${inputId}`}
+        id={inputId}
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
@@ -254,7 +256,7 @@ export default function ArgInput(props) {
   } else if (argSpec.type === 'option_string') {
     form = (
       <Form.Control
-        id={`${argkey}-${inputId}`}
+        id={inputId}
         as="select"
         name={argkey}
         value={value}
@@ -280,7 +282,7 @@ export default function ArgInput(props) {
       <React.Fragment>
         <Form.Control
           ref={inputRef}
-          id={`${argkey}-${inputId}`}
+          id={inputId}
           name={argkey}
           type="text"
           placeholder={placeholderText}


### PR DESCRIPTION
## Description
Fixes #1842 

If you open two tabs of the same model in the workbench, the form input elements have the same ID. This was causing unexpected behavior with the toggle inputs, specifically, but also violates general best practices. There's a React Hook, `useId`, that can be used to generate unique IDs.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
