### PR TITLE
Ensure consistent nodata handling in Stormwater volume calculations to prevent output inf values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -68,6 +68,10 @@ Unreleased Changes
     * Fixed bug in the calculation of Cooling Capacity (CC) provided by parks,
       where the CC Index was not being properly incorporated.
       https://github.com/natcap/invest/issues/1726
+* Urban Stormwater Retention
+    * Fixed a bug causing ``inf`` values in volume outputs because nodata
+      values were not being set correctly (`InVEST #1850
+      <https://github.com/natcap/invest/issues/1850>`_).
 * Wind Energy
     * Fixed a bug that could cause the Workbench to crash when running the Wind
       Energy model with ``Taskgraph`` logging set to ``DEBUG`` (`InVEST #1497

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -634,7 +634,8 @@ def execute(args):
                     files['ratio_average_path'],
                     files['near_connected_lulc_path'],
                     files['near_road_path']],
-                target_path=files['adjusted_retention_ratio_path']),
+                target_path=files['adjusted_retention_ratio_path'],
+                target_nodata=FLOAT_NODATA),
             target_path_list=[files['adjusted_retention_ratio_path']],
             task_name='adjust stormwater retention ratio',
             dependent_task_list=[retention_ratio_task, average_ratios_task,
@@ -669,7 +670,8 @@ def execute(args):
         kwargs=dict(
             op=retention_to_runoff_op,
             rasters=[final_retention_ratio_path],
-            target_path=files['runoff_ratio_path']),
+            target_path=files['runoff_ratio_path'],
+            target_nodata=FLOAT_NODATA),
         target_path_list=[files['runoff_ratio_path']],
         dependent_task_list=[final_retention_ratio_task],
         task_name='calculate stormwater runoff ratio'
@@ -872,6 +874,7 @@ def lookup_ratios(lulc_path, soil_group_path, ratio_lookup, sorted_lucodes,
             soil_group_array],
         rasters=[lulc_path, soil_group_path],
         target_path=output_path,
+        target_nodata=FLOAT_NODATA,
         target_dtype=numpy.float32)
 
 


### PR DESCRIPTION
## Description
Fixes a bug in the Urban Stormwater Retention model that caused `inf` values to appear in the runoff and retention volume outputs. This issue was due to a mismatch between the expected nodata value (`FLOAT_NODATA`, set to `-1`) and the actual nodata value in `_ratio` rasters (set via `pgp.raster_map` to a default value of `3.40282e+38`). The fix ensures that runoff and retention ratio rasters use FLOAT_NODATA as their target_nodata, so nodata pixels are properly masked during volume calculations.

Fixes #1850

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
