### PR TITLE
update pyproject.toml license information for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "natcap.invest"
 description = "InVEST Ecosystem Service models"
 readme = "README_PYTHON.rst"
 requires-python = ">=3.9"
-license = {file = "LICENSE.txt"}
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 maintainers = [
     {name = "Natural Capital Project Software Team"}
 ]
@@ -23,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Cython",
-    "License :: OSI Approved :: BSD License",
     "Topic :: Scientific/Engineering :: GIS"
 ]
 # the version is provided dynamically by setuptools_scm


### PR DESCRIPTION
## Description
Fixes #1846 

Removing our deprecated license classifier, and updating the format of `project.license` according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license. This resolves the deprecation warnings.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
