### PR TITLE
Handle float nodata comparisons correctly in Scenic Quality

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -196,6 +196,12 @@ Scenario Generator
   converted during the model run.
   https://github.com/natcap/invest/issues/1295
 
+Scenic Quality
+==============
+* Fixed a bug where the visibility raster could be incorrectly set to 1
+  ('visible') if the DEM value was within floating point imprecision of the
+  DEM nodata value (`#1859 <https://github.com/natcap/invest/issues/1859>`_).
+
 SDR
 ===
 * Raster outputs that previously contained per-pixel values (e.g., t/pixel)

--- a/src/natcap/invest/managed_raster/ManagedRaster.h
+++ b/src/natcap/invest/managed_raster/ManagedRaster.h
@@ -851,6 +851,10 @@ public:
   UpslopeNeighborNoDivideIterator<T> end() { return UpslopeNeighborNoDivideIterator<T>(&endVal); }
 };
 
+// Note: I was concerned that checking each value for nan would be too slow, but
+// I compared its performance against another implementation where we first reclassify
+// nans to a regular float, and then skip the nan check, and that was much slower:
+// https://github.com/natcap/invest/issues/1714#issuecomment-2762134419
 inline bool is_close(double x, double y) {
   if (isnan(x) and isnan(y)) {
     return true;

--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -40,6 +40,7 @@ from libc cimport math
 cimport numpy
 cimport cython
 from ..managed_raster.managed_raster cimport ManagedRaster
+from ..managed_raster.managed_raster cimport is_close
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
@@ -297,12 +298,13 @@ def viewshed(dem_raster_path_band,
 
     band_to_array_index = dem_raster_path_band[1] - 1
     nodata_value = dem_raster_info['nodata'][band_to_array_index]
-    if viewpoint_elevation == nodata_value:
-        raise LookupError('Viewpoint is over nodata')
 
     # Need to handle the case where the nodata value is not defined.
     if nodata_value is None:
         nodata_value = IMPROBABLE_NODATA
+    else:
+        if is_close(viewpoint_elevation, nodata_value):
+            raise LookupError('Viewpoint is over nodata')
     cdef double nodata = nodata_value
 
     # Verify that pixels are very close to square.  The Wang et al algorithm
@@ -511,7 +513,7 @@ def viewshed(dem_raster_path_band,
             adjusted_dem_height = target_dem_height - adjustment
             if (adjusted_dem_height >= z and
                     target_distance < max_visible_radius and
-                    target_dem_height != nodata):
+                    not is_close(target_dem_height, nodata)):
                 visibility_managed_raster.set(ix_target, iy_target, 1)
                 aux_managed_raster.set(ix_target, iy_target, adjusted_dem_height)
             else:
@@ -638,22 +640,21 @@ def viewshed(dem_raster_path_band,
         # than or equal to the minimum-visible height AND is closer than the
         # maximum visible radius.
         target_dem_height = dem_managed_raster.get(n, m)
-        adjusted_dem_height = dem_managed_raster.get(n, m) - adjustment
-        if (adjusted_dem_height >= z and
-                target_pixel.distance_to_viewpoint < max_visible_radius and
-                target_dem_height != nodata):
-            visibility_managed_raster.set(n, m, 1)
+        adjusted_dem_height = target_dem_height - adjustment
+
+        # If it's close enough to nodata to be interpreted as nodata,
+        # consider it to be nodata.  Nodata implies that visibility is
+        # undefined ... which it is, since there's no defined DEM value for
+        # this pixel.
+        if is_close(target_dem_height, nodata):
+            visibility_managed_raster.set(n, m, VISIBILITY_NODATA)
+            aux_managed_raster.set(n, m, z)
+        elif (adjusted_dem_height >= z and
+                target_pixel.distance_to_viewpoint < max_visible_radius):
+            visibility_managed_raster.set(n, m, 1)  # the pixel is visible
             aux_managed_raster.set(n, m, adjusted_dem_height)
         else:
-            # If it's close enough to nodata to be interpreted as nodata,
-            # consider it to be nodata.  Nodata implies that visibility is
-            # undefined ... which it is, since there's no defined DEM value for
-            # this pixel.
-            if math.fabs(target_dem_height - nodata) <= 1.0e-7:
-                visibility_managed_raster.set(n, m, VISIBILITY_NODATA)
-            else:
-                # If we're not over nodata, then the pixel isn't visible.
-                visibility_managed_raster.set(n, m, 0)
+            visibility_managed_raster.set(n, m, 0)  # the pixel isn't visible
             aux_managed_raster.set(n, m, z)
         pixels_touched += 1
 

--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -302,9 +302,8 @@ def viewshed(dem_raster_path_band,
     # Need to handle the case where the nodata value is not defined.
     if nodata_value is None:
         nodata_value = IMPROBABLE_NODATA
-    else:
-        if is_close(viewpoint_elevation, nodata_value):
-            raise LookupError('Viewpoint is over nodata')
+    elif is_close(viewpoint_elevation, nodata_value):
+        raise LookupError('Viewpoint is over nodata')
     cdef double nodata = nodata_value
 
     # Verify that pixels are very close to square.  The Wang et al algorithm


### PR DESCRIPTION
## Description
Fixes #1714 
Fixes #1859 

- Use `is_close` for float nodata comparisons in Scenic Quality
- Fix confusing/buggy conditional
- Add a note about `is_close` performance

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
