### PR TITLE
update release 3.15.0 highlights

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -76,8 +76,8 @@ Highlights
   * SDR
 * NDR, SDR, and Seasonal Water Yield now support the D8 routing algorithm
   in addition to MFD.
-* Visitation: Recreation and Tourism model now includes twitter data.
-* InVEST models outputs now include metadata. Open the '.yml' files
+* Visitation: Recreation and Tourism model now includes Twitter data.
+* InVEST model outputs now include metadata. Open the '.yml' files
   in a text editor to read and add to the metadata.
 
 General

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -76,8 +76,9 @@ Highlights
   * SDR
 * NDR, SDR, and Seasonal Water Yield now support the D8 routing algorithm
   in addition to MFD.
-
 * Visitation: Recreation and Tourism model now includes twitter data.
+* InVEST models outputs now include metadata. Open the '.yml' files
+  in a text editor to read and add to the metadata.
 
 General
 =======

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := dbcc9e2670d67528abde5e7ce6c824852b7f4c8b
+GIT_SAMPLE_DATA_REPO_REV    := ecdab62bd6e2d3d9105e511cfd6884bf07f3d27b
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := cdf79891645e2d8e07727197f5f65a179bc0a62a
+GIT_TEST_DATA_REPO_REV      := f0ebe739207ae57ae53a285d0fd954d6e8cfee54
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := ee95e3bf32d7af02e06f2d713701cc8c25f495b6
+GIT_UG_REPO_REV             := b45b01daa0dda3ac7abdb9dd5089cc7380838b86
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
A note for HISTORY.

I also updated the Makefile to point to the HEAD of `release/3.15.0` on all our connected repos. That's something we typically do as part of the release process anyway.

Fixes #1852 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
