### PR TITLE
update Makefile to HEAD of UG release branch. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f0ebe739207ae57ae53a285d0fd954d6e8cfee54
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := b45b01daa0dda3ac7abdb9dd5089cc7380838b86
+GIT_UG_REPO_REV             := 7d83c5bf05f0bef8dd4d2a4bd2f565ecf270af75
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
This is after merging `main` into `release/3.15.0` on the UG repo.
sample-data and test-data repos are already pointing to the head of their release branches.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
