### PR TITLE
Usage logging for plugins

### DIFF
--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 
 import { getLogger } from './logger';
 import pkg from '../../package.json';
+import { settingsStore } from './settingsStore';
 
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 const WORKBENCH_VERSION = pkg.version;
@@ -15,14 +16,26 @@ export default function investUsageLogger() {
 
   function start(modelID, args, port) {
     logger.debug('logging model start');
+
+    const body = {
+      model_id: modelID,
+      model_args: JSON.stringify(args),
+      invest_interface: `Workbench ${WORKBENCH_VERSION}`,
+      session_id: sessionId,
+    };
+
+    const plugins = settingsStore.get('plugins');
+    if (plugins && Object.keys(plugins).includes(modelID)) {
+      const source = plugins[modelID].source;
+      body.type = 'plugin';
+      // don't log the path to a local plugin, just log that it's local
+      body.source = source.startsWith('git+') ? source : 'local';
+    } else {
+      body.type = 'core';
+    }
     fetch(`${HOSTNAME}:${port}/${PREFIX}/log_model_start`, {
       method: 'post',
-      body: JSON.stringify({
-        model_id: modelID,
-        model_args: JSON.stringify(args),
-        invest_interface: `Workbench ${WORKBENCH_VERSION}`,
-        session_id: sessionId,
-      }),
+      body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' },
     })
       .then(async (response) => {

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -33,6 +33,7 @@ import { findInvestBinaries } from '../../src/main/findBinaries';
 import extractZipInplace from '../../src/main/extractZipInplace';
 import { ipcMainChannels } from '../../src/main/ipcMainChannels';
 import investUsageLogger from '../../src/main/investUsageLogger';
+import { settingsStore } from '../../src/main/settingsStore';
 
 jest.mock('node-fetch');
 jest.mock('child_process');
@@ -256,10 +257,42 @@ describe('investUsageLogger', () => {
     expect(fetch.mock.calls).toHaveLength(2);
     const exitPayload = JSON.parse(fetch.mock.calls[1][1].body);
 
+    expect(startPayload.type).toBe('core');
     expect(startPayload.session_id).toBe(exitPayload.session_id);
     expect(startPayload.model_id).toBe(modelID);
     expect(JSON.parse(startPayload.model_args)).toMatchObject(args);
     expect(startPayload.invest_interface).toContain('Workbench');
     expect(exitPayload.status).toBe(investStdErr);
+  });
+
+  test('logs plugin usage correctly', () => {
+    const modelID = 'plugin';
+    const args = {
+      workspace_dir: 'foo',
+      aoi: 'bar',
+    };
+    const investStdErr = '';
+    const usageLogger = investUsageLogger();
+
+    settingsStore.set('plugins', {
+      pluginA: {
+        source: 'git+https://plugin'
+      },
+      pluginB: {
+        source: '/path/to/local/plugin'
+      }
+    });
+
+    usageLogger.start('pluginA', args, PORT);
+    let startPayload = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(startPayload.type).toBe('plugin');
+    expect(startPayload.model_id).toBe('pluginA');
+    expect(startPayload.source).toBe('git+https://plugin');
+
+    usageLogger.start('pluginB', args, PORT);
+    startPayload = JSON.parse(fetch.mock.calls[1][1].body);
+    expect(startPayload.type).toBe('plugin');
+    expect(startPayload.model_id).toBe('pluginB');
+    expect(startPayload.source).toBe('local');
   });
 });


### PR DESCRIPTION
## Description
Fixes #1782

This PR adds to the usage information that is sent to the usage logging server on model start. To distinguish between core models and plugins, I added a `type` attribute which can have the value `core` or `plugin`. For logging runs with `type: 'plugin'`, a `source` attribute is also logged, which is the source of the plugin install if installed from github (e.g. `git+https://github.com/foo/bar@main`, or `'local'` if installed from a local path on the user's computer.

The Cloud Run function that receives and stores usage logging will need to be updated to reflect these changes, which should be simple. That function lives on Google Cloud - there is no repo tracking it, so we can't do a PR, but I thought we could walk through it on a team call sometime.
## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
