### PR TITLE
Update copyright year in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9,6 +9,6 @@ Project to develop this policy and any trademark licensing. Visit
 naturalcapitalproject.stanford.edu/invest-trademark-and-logo-use-policy for the
 complete trademark and logo policy.
 
-Copyright (c) 2023, Natural Capital Project
+Copyright (c) 2025, Natural Capital Project
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
While installing the new version of the Workbench, I noticed the copyright year in the license agreement dialog was out of date. This should correct it for the next release.

<img width="648" alt="workbench-installation-notice" src="https://github.com/user-attachments/assets/cd6aea50-0007-452c-87d7-1b9ccb081537" />

It could be interesting to think about ways to automatically update this (and other copyright notices we maintain) in the future.