### PR TITLE
Forest Carbon: Global model vector clipping and reprojection

### DIFF
--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -832,7 +832,7 @@ def _clip_global_regression_models_vector(
                     new_feature.SetField(field_name, field_value)
                 target_layer.CreateFeature(new_feature)
 
-        except (shapely.errors.ReadingError, ValueError):
+        except (shapely.errors.ShapelyError, ValueError):
             invalid_feature_count += 1
             LOGGER.warning(
                 "The geometry at feature %s is invalid and will be "

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -118,7 +118,8 @@ MODEL_SPEC = {
             "about": spec_utils.LULC['about'] + " " + gettext(
                 "All values in this raster must "
                 "have corresponding entries in the Biophysical Table."),
-            "projected": True
+            "projected": True,
+            "projection_units": u.meter
         },
         "pools_to_calculate": {
             "type": "option_string",
@@ -170,6 +171,8 @@ MODEL_SPEC = {
                         "Used only for the asymptotic model.")}
             },
             "geometries": spec_utils.POLYGONS,
+            "projected": True,
+            "projection_units": u.meter,
             "required": "compute_forest_edge_effects",
             "about": gettext(
                 "Map storing the optimal regression model for each tropical "
@@ -254,6 +257,13 @@ MODEL_SPEC = {
                     "bands": {1: {
                         "type": "number", "units": u.metric_ton/u.hectare
                     }}
+                },
+                "regression_model_params_clipped.shp": {
+                    "about": (
+                        "The Global Regression Models shapefile clipped "
+                        "to the study area."),
+                    "geometries": spec_utils.POLYGONS,
+                    "fields": {}
                 }
             }
         },

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -873,10 +873,9 @@ def _build_spatial_index(
     lulc_projection_wkt = pygeoprocessing.get_raster_info(
         base_raster_path)['projection_wkt']
 
-    with utils._set_gdal_configuration('OGR_ENABLE_PARTIAL_REPROJECTION', 'TRUE'):
-        pygeoprocessing.reproject_vector(
-            tropical_forest_edge_carbon_model_vector_path, lulc_projection_wkt,
-            carbon_model_reproject_path)
+    pygeoprocessing.reproject_vector(
+        tropical_forest_edge_carbon_model_vector_path, lulc_projection_wkt,
+        carbon_model_reproject_path)
 
     model_vector = gdal.OpenEx(carbon_model_reproject_path)
     model_layer = model_vector.GetLayer()
@@ -888,17 +887,14 @@ def _build_spatial_index(
     # put all the polygons in the kd_tree because it's fast and simple
     for poly_feature in model_layer:
         poly_geom = poly_feature.GetGeometryRef()
-        if poly_geom.IsValid():
-            poly_centroid = poly_geom.Centroid()
-            # put in row/col order since rasters are row/col indexed
-            kd_points.append([poly_centroid.GetY(), poly_centroid.GetX()])
+        poly_centroid = poly_geom.Centroid()
+        # put in row/col order since rasters are row/col indexed
+        kd_points.append([poly_centroid.GetY(), poly_centroid.GetX()])
 
-            theta_model_parameters.append([
-                poly_feature.GetField(feature_id) for feature_id in
-                ['theta1', 'theta2', 'theta3']])
-            method_model_parameter.append(poly_feature.GetField('method'))
-        else:
-            LOGGER.warning(f'skipping invalid geometry {poly_geom}')
+        theta_model_parameters.append([
+            poly_feature.GetField(feature_id) for feature_id in
+            ['theta1', 'theta2', 'theta3']])
+        method_model_parameter.append(poly_feature.GetField('method'))
 
     method_model_parameter = numpy.array(
         method_model_parameter, dtype=numpy.int32)

--- a/tests/test_forest_carbon_edge.py
+++ b/tests/test_forest_carbon_edge.py
@@ -1,13 +1,16 @@
 """Module for Regression Testing the InVEST Forest Carbon Edge model."""
-import unittest
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
+import unittest
 
-from osgeo import gdal
 import numpy
-
 import pygeoprocessing
+import shapely
+from osgeo import gdal
+from osgeo import ogr
+from osgeo import osr
+from shapely.geometry import Polygon
 
 gdal.UseExceptions()
 REGRESSION_DATA = os.path.join(
@@ -242,6 +245,149 @@ class ForestCarbonEdgeTests(unittest.TestCase):
         expected_message = 'The landcover raster '
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
+
+    def test_invalid_geometries(self):
+        """Forest Carbon: Check handling of invalid vector geometries."""
+        from natcap.invest import forest_carbon_edge_effect
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)
+        projection_wkt = srs.ExportToWkt()
+
+        lulc_matrix = numpy.ones((5,5), dtype=numpy.int8)
+        lulc_raster_path = os.path.join(self.workspace_dir, 'lulc.tif')
+        pygeoprocessing.numpy_array_to_raster(
+            lulc_matrix, 255, (1, -1), (461262, 4923269), projection_wkt,
+            lulc_raster_path)
+
+        fields_polys = {'geom_id': ogr.OFTInteger}
+        attrs_polys = [
+            {'geom_id': 1},
+            {'geom_id': 2},
+            {'geom_id': 3}
+        ]
+
+        # valid polygon
+        valid_poly = Polygon([
+            (461265, 4923269), (461267, 4923269), (461267, 4923267),
+            (461265, 4923267), (461265, 4923269)])
+        self.assertTrue(shapely.is_valid(valid_poly))
+
+        # invalid bowtie polygon
+        invalid_bowtie_poly = Polygon([
+            (461262, 4923267), (461264, 4923267), (461262, 4923265),
+            (461264, 4923265), (461262, 4923267)])
+        self.assertFalse(shapely.is_valid(invalid_bowtie_poly))
+
+        # invalid bowtie polygon with vertex in the middle
+        invalid_alt_bowtie_poly = Polygon([
+            (461262, 4923267), (461264, 4923267), (461263, 4923266),
+            (461264, 4923265), (461262, 4923265), (461263, 4923266),
+            (461262, 4923267)])
+        self.assertFalse(shapely.is_valid(invalid_alt_bowtie_poly))
+
+        test_vector_path = os.path.join(self.workspace_dir, 'vector.gpkg')
+        pygeoprocessing.shapely_geometry_to_vector(
+            [valid_poly, invalid_bowtie_poly,
+             invalid_alt_bowtie_poly],
+            test_vector_path, projection_wkt, 'GPKG',
+            fields=fields_polys,
+            attribute_list=attrs_polys)
+
+        test_vector = gdal.OpenEx(
+            test_vector_path, gdal.OF_VECTOR | gdal.GA_ReadOnly)
+        test_layer = test_vector.GetLayer()
+        self.assertEqual(test_layer.GetFeatureCount(), 3)
+        test_layer = None
+        test_vector = None
+
+        target_vector_path = os.path.join(
+            self.workspace_dir, 'checked_geometries.gpkg')
+        forest_carbon_edge_effect._clip_global_regression_models_vector(
+            lulc_raster_path, test_vector_path, target_vector_path)
+
+        target_vector = gdal.OpenEx(target_vector_path, gdal.OF_VECTOR)
+        target_layer = target_vector.GetLayer()
+        self.assertEqual(
+            target_layer.GetFeatureCount(), 1)
+        # valid_polygon geom_id == 1
+        self.assertEqual(target_layer.GetFeature(0).GetField('geom_id'), 1)
+
+        target_layer = None
+        target_vector = None
+
+    def test_vector_clipping_buffer(self):
+        """Forest Carbon: Check DISTANCE_UPPER_BOUND buffer."""
+        from natcap.invest import forest_carbon_edge_effect
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(26910)
+        projection_wkt = srs.ExportToWkt()
+
+        lulc_matrix = numpy.ones((5,5), dtype=numpy.int8)
+        lulc_raster_path = os.path.join(self.workspace_dir, 'lulc.tif')
+        pygeoprocessing.numpy_array_to_raster(
+            lulc_matrix, 255, (1000, -1000), (461261, 4923270), projection_wkt,
+            lulc_raster_path)
+
+        # get LULC bouding box; will be used to construct polygons
+        raster_info = pygeoprocessing.get_raster_info(lulc_raster_path)
+        bbox_minx, bbox_miny, bbox_maxx, bbox_maxy = raster_info['bounding_box']
+
+        fields_polys = {'geom_id': ogr.OFTInteger}
+        attrs_polys = [
+            {'geom_id': 1},
+            {'geom_id': 2},
+            {'geom_id': 3},
+            {'geom_id': 4}
+        ]
+
+        # polygon that intersects with the lulc
+        in_bbox_poly = shapely.geometry.box(
+            bbox_maxx - 150, bbox_maxy - 150,
+            bbox_maxx - 50, bbox_maxy - 50)
+        self.assertTrue(shapely.is_valid(in_bbox_poly))
+
+        # polygon outside of lulc bb, but within buffer distance
+        in_buffer_poly = shapely.geometry.box(
+            bbox_maxx + 50, bbox_maxy + 50,
+            bbox_maxx + 150, bbox_maxy + 150)
+        self.assertTrue(shapely.is_valid(in_buffer_poly))
+
+        buffer = forest_carbon_edge_effect.DISTANCE_UPPER_BOUND
+        # polygon on the edge of the buffer
+        buffer_edge_poly = shapely.geometry.box(
+            bbox_maxx + buffer + 50, bbox_maxy + buffer + 50,
+            bbox_maxx + buffer - 50, bbox_maxy + buffer - 50)
+        self.assertTrue(shapely.is_valid(buffer_edge_poly))
+
+        # polygon outside of buffer distance
+        out_of_buffer_poly = shapely.geometry.box(
+            bbox_maxx + buffer + 50, bbox_maxy + buffer + 50,
+            bbox_maxx + buffer + 150, bbox_maxy + buffer + 150)
+        self.assertTrue(shapely.is_valid(out_of_buffer_poly))
+
+        test_vector_path = os.path.join(self.workspace_dir, 'vector.gpkg')
+        pygeoprocessing.shapely_geometry_to_vector(
+            [in_bbox_poly, in_buffer_poly,
+             buffer_edge_poly, out_of_buffer_poly],
+            test_vector_path, projection_wkt, 'GPKG',
+            fields=fields_polys,
+            attribute_list=attrs_polys)
+
+        target_vector_path = os.path.join(
+            self.workspace_dir, 'checked_geometries.gpkg')
+        forest_carbon_edge_effect._clip_global_regression_models_vector(
+            lulc_raster_path, test_vector_path, target_vector_path)
+
+        vector = gdal.OpenEx(
+            target_vector_path, gdal.OF_VECTOR | gdal.GA_ReadOnly)
+        layer = vector.GetLayer()
+        self.assertEqual(layer.GetFeatureCount(), 3)
+
+        feat_ids = []
+        for i in range(layer.GetFeatureCount()):
+            feat_ids.append(layer.GetFeature(i).GetField('geom_id'))
+        self.assertEqual(feat_ids, [1, 2, 3])
+
 
     @staticmethod
     def _test_same_files(base_list_path, directory_path):

--- a/tests/test_forest_carbon_edge.py
+++ b/tests/test_forest_carbon_edge.py
@@ -383,11 +383,8 @@ class ForestCarbonEdgeTests(unittest.TestCase):
         layer = vector.GetLayer()
         self.assertEqual(layer.GetFeatureCount(), 3)
 
-        feat_ids = []
-        for i in range(layer.GetFeatureCount()):
-            feat_ids.append(layer.GetFeature(i).GetField('geom_id'))
+        feat_ids = [feat.GetField('geom_id') for feat in layer]
         self.assertEqual(feat_ids, [1, 2, 3])
-
 
     @staticmethod
     def _test_same_files(base_list_path, directory_path):


### PR DESCRIPTION
## Description
Fixes #1689 

### Background:
Enabling `gdal.UseExceptions` led to the discovery that invalid geometries were being created during reprojection of the Forest Carbon "Global Regression Models" vector (`forest_carbon_edge_regression_model_parameters.shp`). This was happening even with partial reprojection enabled. Digging into it, it seems partial reprojection doesn't necessarily remove entire geometries, just points that can't be reprojected; as such, you can end up with geometries that have insufficient points to be valid polygons.

Based on recommendations from @emlys and @phargogh, this PR does away with partial reprojection and instead clips the global vector prior to reprojection, so that only those polygons relevant to the model run need be reprojected. Clipping is based on the LULC raster's bounding box, plus a buffer (explained below). 

While this model does include an AIO input, it's optional and is only used to calculate aggregate statistics at the end of the model run. For consistency, I'm ignoring it for the purposes of clipping. 

### Bounding Box Buffering: 
The Global Regression Model vector data is used to construct a kd-tree. When querying the kd-tree, we set a `distance_upper_bound`. To ensure the clipped vector will contain all of the relevant data to the querying process, I'm buffering the LULC bounding box by the same `DISTANCE_UPPER_BOUND` value (currently set to 500km). 

I'm also keeping all polygons that intersect with the clipping polygon, rather than using `gdal.Layer.Clip()`, in order to preserve the shape of the polygons (this is important because we use the centroid when constructing the kd-tree). 

To summarize my clipping methodology: 
- Get the bounding box of the LULC raster; buffer it by `DISTANCE_UPPER_BOUND`
- Reproject the buffered bounding box to the coordinate system of the vector
- Copy all polygons from the global vector that intersect with the bounding box to a new vector
- Pass the clipped vector along to `_build_spatial_index`, to be reprojected and used to create the kd-tree

### Additional notes:
The User's Guide says, "Note that all spatial inputs must be in the same projected coordinate system and in linear meter units." However, we weren't validating the units within the model. I've updated the model spec to include `"projection_units": u.meter` for validation purposes.

Digging into this model, I also noticed a contradiction. The user's guide says, related to the "Number Of Points To Average," (in "How it works"): 
"The user can designate the number of local models used in the interpolation scheme which is defaulted to 10 but can range anywhere from 1 (only closest point) to 2635 (every regression model on the planet)."

However, within the code itself, we specify the aforementioned `DISTANCE_UPPER_BOUND` of 500km that we use when querying the kd-tree (there's a note that reads, "grid cells are 100km. Becky says 500km is a good upper bound to search"). We may want to update the User's Guide to reflect this, especially now that we're using that `DISTANCE_UPPER_BOUND` as a buffer when clipping the global vector to the LULC raster's bounding box.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
