### PR TITLE
Crop Production: improved validation of inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Any code you contribute to InVEST will fall under the same license as InVEST. Pl
 3. Wait for a member of the NatCap team to respond. One of the following will happen:
     1. If it’s OK for you to work on the issue, a member of the NatCap team will let you know (in a comment on the issue) and assign the issue to you. Proceed to step 4.
     2. If there’s some reason you shouldn’t work on the issue (because the issue is invalid, or we are intentionally delaying work on it, or—oops—someone else is already working on it), a member of the NatCap team will let you know by leaving a comment on the issue. Return to step 1!
-4. Review the [InVEST Contributor License Agreement](https://vpejnqubjf.us-east-2.awsapprunner.com/), if you haven’t already. If you do not sign the Contributor License Agreement, you will not be able to contribute code to InVEST.
+4. Review the [InVEST Contributor License Agreement](https://natcap.github.io/invest-cla), if you haven’t already. If you do not sign the Contributor License Agreement, you will not be able to contribute code to InVEST.
 
 ### Forking the Repository and Creating a Branch
 1. Fork the `natcap/invest` repository. Check [GitHub’s “Fork a repository” guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) for details, if needed.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -67,9 +67,10 @@
 
 Crop Production
 ===============
-* Both the Percentile and Regression models now issue a warning if any values
-  in the LULC raster are not present in the landcover to crop table
-  (`#925 <https://github.com/natcap/invest/issues/925>`_).
+* Both the Percentile and Regression models now issue a warning if any LULC
+  code in the LULC raster is not present in the landcover to crop table, or if
+  any LULC code in the landcover to crop table is not present in the LULC
+  raster (`#925 <https://github.com/natcap/invest/issues/925>`_).
 * The Regression model now correctly validates crop names against the existence
   of a corresponding regression yield table
   (`#1723 <https://github.com/natcap/invest/issues/1723>`_).

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,16 @@
   Unreleased Changes
   ------------------
 
+Crop Production
+===============
+* Both the Percentile and Regression models now issue a warning if any values
+  in the LULC raster are not present in the landcover to crop table
+  (`#925 <https://github.com/natcap/invest/issues/925>`_).
+* The Regression model now correctly validates crop names against the existence
+  of a corresponding regression yield table
+  (`#1723 <https://github.com/natcap/invest/issues/1723>`_).
+
+
 3.15.0 (2025-04-03)
 -------------------
 Highlights

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -614,12 +614,14 @@ def execute(args):
 
     lucodes_in_table = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
 
-    unique_lucodes_in_raster = numpy.array([])
-    for _, lu_band_data in pygeoprocessing.iterblocks(
-            (args['landcover_raster_path'], 1)):
-        unique_block = numpy.unique(lu_band_data)
-        unique_lucodes_in_raster = numpy.unique(numpy.concatenate(
-            (unique_lucodes_in_raster, unique_block)))
+    def update_unique_lucodes_in_raster(unique_codes, block):
+        unique_codes.update(numpy.unique(block))
+        return unique_codes
+
+    unique_lucodes_in_raster = pygeoprocessing.raster_reduce(
+        update_unique_lucodes_in_raster,
+        (args['landcover_raster_path'], 1),
+        set())
 
     lucodes_missing_from_raster = set(lucodes_in_table).difference(
         set(unique_lucodes_in_raster))

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -626,14 +626,14 @@ def execute(args):
     if len(lucodes_missing_from_raster) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
-            "aren't in the landcover raster: %s", lucodes_missing_from_raster)
+            f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
     lucodes_missing_from_table = set(unique_lucodes_in_raster).difference(
         set(lucodes_in_table))
     if len(lucodes_missing_from_table) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "
-            "in the landcover to crop table: %s", lucodes_missing_from_table)
+            f"in the landcover to crop table: {lucodes_missing_from_table}")
 
     bad_crop_name_list = []
     for crop_name in crop_to_landcover_df.index:

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -612,7 +612,8 @@ def execute(args):
         args['landcover_to_crop_table_path'],
         **MODEL_SPEC['args']['landcover_to_crop_table_path'])
 
-    lucodes_in_table = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
+    lucodes_in_table = set(list(
+        crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER]))
 
     def update_unique_lucodes_in_raster(unique_codes, block):
         unique_codes.update(numpy.unique(block))
@@ -623,15 +624,15 @@ def execute(args):
         (args['landcover_raster_path'], 1),
         set())
 
-    lucodes_missing_from_raster = set(lucodes_in_table).difference(
-        set(unique_lucodes_in_raster))
+    lucodes_missing_from_raster = lucodes_in_table.difference(
+        unique_lucodes_in_raster)
     if len(lucodes_missing_from_raster) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
             f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
-    lucodes_missing_from_table = set(unique_lucodes_in_raster).difference(
-        set(lucodes_in_table))
+    lucodes_missing_from_table = unique_lucodes_in_raster.difference(
+        lucodes_in_table)
     if len(lucodes_missing_from_table) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -626,14 +626,14 @@ def execute(args):
 
     lucodes_missing_from_raster = lucodes_in_table.difference(
         unique_lucodes_in_raster)
-    if len(lucodes_missing_from_raster) > 0:
+    if lucodes_missing_from_raster:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
             f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
     lucodes_missing_from_table = unique_lucodes_in_raster.difference(
         lucodes_in_table)
-    if len(lucodes_missing_from_table) > 0:
+    if lucodes_missing_from_table:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "
             f"in the landcover to crop table: {lucodes_missing_from_table}")

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -523,14 +523,15 @@ def execute(args):
 
     LOGGER.info("Checking that crops correspond to known types.")
     for crop_name in crop_to_landcover_df.index:
-        crop_climate_bin_raster_path = os.path.join(
+        crop_regression_yield_table_path = os.path.join(
             args['model_data_path'],
-            _EXTENDED_CLIMATE_BIN_FILE_PATTERN % crop_name)
-        if not os.path.exists(crop_climate_bin_raster_path):
+            _REGRESSION_TABLE_PATTERN % crop_name)
+        if not os.path.exists(crop_regression_yield_table_path):
             raise ValueError(
-                "Expected climate bin map called %s for crop %s "
-                "specified in %s", crop_climate_bin_raster_path, crop_name,
-                args['landcover_to_crop_table_path'])
+                "Expected regression yield table called %s for crop %s "
+                "specified in %s"
+                % (crop_regression_yield_table_path, crop_name,
+                    args['landcover_to_crop_table_path']))
 
     landcover_raster_info = pygeoprocessing.get_raster_info(
         args['landcover_raster_path'])

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -505,7 +505,8 @@ def execute(args):
         args['fertilization_rate_table_path'],
         **MODEL_SPEC['args']['fertilization_rate_table_path'])
 
-    lucodes_in_table = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
+    lucodes_in_table = set(list(
+        crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER]))
 
     def update_unique_lucodes_in_raster(unique_codes, block):
         unique_codes.update(numpy.unique(block))
@@ -516,15 +517,15 @@ def execute(args):
         (args['landcover_raster_path'], 1),
         set())
 
-    lucodes_missing_from_raster = set(lucodes_in_table).difference(
-        set(unique_lucodes_in_raster))
+    lucodes_missing_from_raster = lucodes_in_table.difference(
+        unique_lucodes_in_raster)
     if len(lucodes_missing_from_raster) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
             f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
-    lucodes_missing_from_table = set(unique_lucodes_in_raster).difference(
-        set(lucodes_in_table))
+    lucodes_missing_from_table = unique_lucodes_in_raster.difference(
+        lucodes_in_table)
     if len(lucodes_missing_from_table) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -537,7 +537,7 @@ def execute(args):
             raise ValueError(
                 f"Expected regression yield table called "
                 f"{crop_regression_yield_table_path} for crop {crop_name} "
-                f"specified in {args['landcover_to_crop_table_path']}"
+                f"specified in {args['landcover_to_crop_table_path']}")
 
     landcover_raster_info = pygeoprocessing.get_raster_info(
         args['landcover_raster_path'])

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -519,14 +519,14 @@ def execute(args):
 
     lucodes_missing_from_raster = lucodes_in_table.difference(
         unique_lucodes_in_raster)
-    if len(lucodes_missing_from_raster) > 0:
+    if lucodes_missing_from_raster:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
             f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
     lucodes_missing_from_table = unique_lucodes_in_raster.difference(
         lucodes_in_table)
-    if len(lucodes_missing_from_table) > 0:
+    if lucodes_missing_from_table:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "
             f"in the landcover to crop table: {lucodes_missing_from_table}")

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -519,14 +519,14 @@ def execute(args):
     if len(lucodes_missing_from_raster) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
-            "aren't in the landcover raster: %s", lucodes_missing_from_raster)
+            f"aren't in the landcover raster: {lucodes_missing_from_raster}")
 
     lucodes_missing_from_table = set(unique_lucodes_in_raster).difference(
         set(lucodes_in_table))
     if len(lucodes_missing_from_table) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover raster but aren't "
-            "in the landcover to crop table: %s", lucodes_missing_from_table)
+            f"in the landcover to crop table: {lucodes_missing_from_table}")
 
     LOGGER.info("Checking that crops correspond to known types.")
     for crop_name in crop_to_landcover_df.index:
@@ -535,10 +535,9 @@ def execute(args):
             _REGRESSION_TABLE_PATTERN % crop_name)
         if not os.path.exists(crop_regression_yield_table_path):
             raise ValueError(
-                "Expected regression yield table called %s for crop %s "
-                "specified in %s"
-                % (crop_regression_yield_table_path, crop_name,
-                    args['landcover_to_crop_table_path']))
+                f"Expected regression yield table called "
+                f"{crop_regression_yield_table_path} for crop {crop_name} "
+                f"specified in {args['landcover_to_crop_table_path']}"
 
     landcover_raster_info = pygeoprocessing.get_raster_info(
         args['landcover_raster_path'])

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -507,12 +507,14 @@ def execute(args):
 
     lucodes_in_table = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
 
-    unique_lucodes_in_raster = numpy.array([])
-    for _, lu_band_data in pygeoprocessing.iterblocks(
-            (args['landcover_raster_path'], 1)):
-        unique_block = numpy.unique(lu_band_data)
-        unique_lucodes_in_raster = numpy.unique(numpy.concatenate(
-            (unique_lucodes_in_raster, unique_block)))
+    def update_unique_lucodes_in_raster(unique_codes, block):
+        unique_codes.update(numpy.unique(block))
+        return unique_codes
+
+    unique_lucodes_in_raster = pygeoprocessing.raster_reduce(
+        update_unique_lucodes_in_raster,
+        (args['landcover_raster_path'], 1),
+        set())
 
     lucodes_missing_from_raster = set(lucodes_in_table).difference(
         set(unique_lucodes_in_raster))

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -505,21 +505,28 @@ def execute(args):
         args['fertilization_rate_table_path'],
         **MODEL_SPEC['args']['fertilization_rate_table_path'])
 
-    crop_lucodes = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
+    lucodes_in_table = list(crop_to_landcover_df[_EXPECTED_LUCODE_TABLE_HEADER])
 
-    unique_lucodes = numpy.array([])
+    unique_lucodes_in_raster = numpy.array([])
     for _, lu_band_data in pygeoprocessing.iterblocks(
             (args['landcover_raster_path'], 1)):
         unique_block = numpy.unique(lu_band_data)
-        unique_lucodes = numpy.unique(numpy.concatenate(
-            (unique_lucodes, unique_block)))
+        unique_lucodes_in_raster = numpy.unique(numpy.concatenate(
+            (unique_lucodes_in_raster, unique_block)))
 
-    missing_lucodes = set(crop_lucodes).difference(
-        set(unique_lucodes))
-    if len(missing_lucodes) > 0:
+    lucodes_missing_from_raster = set(lucodes_in_table).difference(
+        set(unique_lucodes_in_raster))
+    if len(lucodes_missing_from_raster) > 0:
         LOGGER.warning(
             "The following lucodes are in the landcover to crop table but "
-            "aren't in the landcover raster: %s", missing_lucodes)
+            "aren't in the landcover raster: %s", lucodes_missing_from_raster)
+
+    lucodes_missing_from_table = set(unique_lucodes_in_raster).difference(
+        set(lucodes_in_table))
+    if len(lucodes_missing_from_table) > 0:
+        LOGGER.warning(
+            "The following lucodes are in the landcover raster but aren't "
+            "in the landcover to crop table: %s", lucodes_missing_from_table)
 
     LOGGER.info("Checking that crops correspond to known types.")
     for crop_name in crop_to_landcover_df.index:


### PR DESCRIPTION
## Description
Fixes #925 and fixes #1723.

- The Regression model now correctly validates crop names against the existence of a corresponding regression yield table (instead of a climate bin raster).
- Both the Percentile and Regression models now issue a warning if any values in the LULC raster are not present in the landcover to crop table.
- The Percentile model now issues a warning if any values in the landcover to crop table are not present in the LULC raster. (The Regression model already did this.)

I also snuck in a tiny update to the contributing guidelines, since it didn't seem worth creating a separate PR for it.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
