### PR TITLE
Add issue types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.md
@@ -4,6 +4,7 @@ about: Did you find a problem in InVEST? Let us know!
 title: ''
 labels: ''
 assignees: ''
+type: 'Bug'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/02-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.md
@@ -4,6 +4,7 @@ about: Have an idea for a new InVEST feature? Let us know!
 title: ''
 labels: ''
 assignees: ''
+type: 'Feature'
 
 ---
 


### PR DESCRIPTION
## Description
Added issue types to the issue templates. I'm not entirely sure this will work, since issue types are mentioned only in [the documentation for issue _forms_](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax), but it's worth a try!

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
