### PR TITLE
Remove pyname attribute from all model specs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,22 +132,21 @@ jobs:
           NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --wheel
           ls -la dist
 
-      # # Uncomment this when we uncomment the C++ extensions
-      # # This produces a wheel that should work on any distro with glibc>=2.39.
-      # # This is a very recent version. If we want to support older versions, I
-      # # suspect we would need to build GDAL from source on an appropriate
-      # # system (such as a manylinux docker container) to ensure compatibility.
-      # # Symbols used in libgdal are the cause of the high minimum version,
-      # # possibly because of installing with conda.
-      # - name: Audit and repair wheel for manylinux
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: |
-      #     ldd --version
-      #     pip install auditwheel
-      #     WHEEL=$(find dist -name "natcap[._-]invest*.whl")
-      #     auditwheel show $WHEEL
-      #     auditwheel repair $WHEEL --plat manylinux_2_39_x86_64 -w dist
-      #     rm $WHEEL  # remove the original wheel
+      # This produces a wheel that should work on any distro with glibc>=2.39.
+      # This is a very recent version. If we want to support older versions, I
+      # suspect we would need to build GDAL from source on an appropriate
+      # system (such as a manylinux docker container) to ensure compatibility.
+      # Symbols used in libgdal are the cause of the high minimum version,
+      # possibly because of installing with conda.
+      - name: Audit and repair wheel for manylinux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          ldd --version
+          pip install auditwheel
+          WHEEL=$(find dist -name "natcap[._-]invest*.whl")
+          auditwheel show $WHEEL
+          auditwheel repair $WHEEL --plat manylinux_2_39_x86_64 -w dist
+          rm $WHEEL  # remove the original wheel
 
       - name: Install wheel and run model tests
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,21 +132,22 @@ jobs:
           NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --wheel
           ls -la dist
 
-      # This produces a wheel that should work on any distro with glibc>=2.39.
-      # This is a very recent version. If we want to support older versions, I
-      # suspect we would need to build GDAL from source on an appropriate
-      # system (such as a manylinux docker container) to ensure compatibility.
-      # Symbols used in libgdal are the cause of the high minimum version,
-      # possibly because of installing with conda.
-      - name: Audit and repair wheel for manylinux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          ldd --version
-          pip install auditwheel
-          WHEEL=$(find dist -name "natcap[._-]invest*.whl")
-          auditwheel show $WHEEL
-          auditwheel repair $WHEEL --plat manylinux_2_39_x86_64 -w dist
-          rm $WHEEL  # remove the original wheel
+      # # Uncomment this when we uncomment the C++ extensions
+      # # This produces a wheel that should work on any distro with glibc>=2.39.
+      # # This is a very recent version. If we want to support older versions, I
+      # # suspect we would need to build GDAL from source on an appropriate
+      # # system (such as a manylinux docker container) to ensure compatibility.
+      # # Symbols used in libgdal are the cause of the high minimum version,
+      # # possibly because of installing with conda.
+      # - name: Audit and repair wheel for manylinux
+      #   if: matrix.os == 'ubuntu-latest'
+      #   run: |
+      #     ldd --version
+      #     pip install auditwheel
+      #     WHEEL=$(find dist -name "natcap[._-]invest*.whl")
+      #     auditwheel show $WHEEL
+      #     auditwheel repair $WHEEL --plat manylinux_2_39_x86_64 -w dist
+      #     rm $WHEEL  # remove the original wheel
 
       - name: Install wheel and run model tests
         run: |

--- a/src/natcap/invest/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield.py
@@ -107,7 +107,6 @@ WATERSHED_OUTPUT_FIELDS = {
 MODEL_SPEC = {
     "model_id": "annual_water_yield",
     "model_title": gettext("Annual Water Yield"),
-    "pyname": "natcap.invest.annual_water_yield",
     "userguide": "annual_water_yield.html",
     "aliases": ("hwy", "awy"),
     "ui_spec": {

--- a/src/natcap/invest/carbon.py
+++ b/src/natcap/invest/carbon.py
@@ -41,7 +41,6 @@ CARBON_OUTPUTS = {
 MODEL_SPEC = {
     "model_id": "carbon",
     "model_title": gettext("Carbon Storage and Sequestration"),
-    "pyname": "natcap.invest.carbon",
     "userguide": "carbonstorage.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -162,7 +162,6 @@ OUTPUT_DIR_NAME = 'output'
 MODEL_SPEC = {
     "model_id": "coastal_blue_carbon",
     "model_title": gettext("Coastal Blue Carbon"),
-    "pyname": "natcap.invest.coastal_blue_carbon.coastal_blue_carbon",
     "userguide": "coastal_blue_carbon.html",
     "aliases": ("cbc",),
     "ui_spec": {

--- a/src/natcap/invest/coastal_blue_carbon/preprocessor.py
+++ b/src/natcap/invest/coastal_blue_carbon/preprocessor.py
@@ -23,7 +23,6 @@ BIOPHYSICAL_COLUMNS_SPEC = coastal_blue_carbon.MODEL_SPEC[
 MODEL_SPEC = {
     "model_id": "coastal_blue_carbon_preprocessor",
     "model_title": gettext("Coastal Blue Carbon Preprocessor"),
-    "pyname": "natcap.invest.coastal_blue_carbon.preprocessor",
     "userguide": "coastal_blue_carbon.html",
     "aliases": ("cbc_pre",),
     "ui_spec": {

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -146,7 +146,6 @@ def get_vector_colnames(vector_path):
 MODEL_SPEC = {
     "model_id": "coastal_vulnerability",
     "model_title": gettext("Coastal Vulnerability"),
-    "pyname": "natcap.invest.coastal_vulnerability",
     "userguide": "coastal_vulnerability.html",
     "aliases": ("cv",),
     "ui_spec": {

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -243,7 +243,6 @@ nutrient_units = {
 MODEL_SPEC = {
     "model_id": "crop_production_percentile",
     "model_title": gettext("Crop Production: Percentile"),
-    "pyname": "natcap.invest.crop_production_percentile",
     "userguide": "crop_production.html",
     "aliases": ("cpp",),
     "ui_spec": {

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -69,7 +69,6 @@ NUTRIENTS = [
 MODEL_SPEC = {
     "model_id": "crop_production_regression",
     "model_title": gettext("Crop Production: Regression"),
-    "pyname": "natcap.invest.crop_production_regression",
     "userguide": "crop_production.html",
     "aliases": ("cpr",),
     "ui_spec": {

--- a/src/natcap/invest/delineateit/delineateit.py
+++ b/src/natcap/invest/delineateit/delineateit.py
@@ -26,7 +26,6 @@ LOGGER = logging.getLogger(__name__)
 MODEL_SPEC = {
     "model_id": "delineateit",
     "model_title": gettext("DelineateIt"),
-    "pyname": "natcap.invest.delineateit.delineateit",
     "userguide": "delineateit.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/forest_carbon_edge_effect.py
+++ b/src/natcap/invest/forest_carbon_edge_effect.py
@@ -33,7 +33,6 @@ NODATA_VALUE = -1
 MODEL_SPEC = {
     "model_id": "forest_carbon_edge_effect",
     "model_title": gettext("Forest Carbon Edge Effect"),
-    "pyname": "natcap.invest.forest_carbon_edge_effect",
     "userguide": "carbon_edge.html",
     "aliases": ("fc",),
     "ui_spec": {

--- a/src/natcap/invest/habitat_quality.py
+++ b/src/natcap/invest/habitat_quality.py
@@ -35,7 +35,6 @@ MISSING_WEIGHT_MSG = gettext("Weight value is missing for threats: {threat_list}
 MODEL_SPEC = {
     "model_id": "habitat_quality",
     "model_title": gettext("Habitat Quality"),
-    "pyname": "natcap.invest.habitat_quality",
     "userguide": "habitat_quality.html",
     "aliases": ("hq",),
     "ui_spec": {

--- a/src/natcap/invest/hra.py
+++ b/src/natcap/invest/hra.py
@@ -51,7 +51,6 @@ _DEFAULT_GTIFF_CREATION_OPTIONS = (
 MODEL_SPEC = {
     "model_id": "habitat_risk_assessment",
     "model_title": gettext("Habitat Risk Assessment"),
-    "pyname": "natcap.invest.hra",
     "userguide": "habitat_risk_assessment.html",
     "aliases": ("hra",),
     "ui_spec": {

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -26,7 +26,6 @@ MISSING_NUTRIENT_MSG = gettext('Either calc_n or calc_p must be True')
 MODEL_SPEC = {
     "model_id": "ndr",
     "model_title": gettext("Nutrient Delivery Ratio"),
-    "pyname": "natcap.invest.ndr.ndr",
     "userguide": "ndr.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/pollination.py
+++ b/src/natcap/invest/pollination.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger(__name__)
 MODEL_SPEC = {
     "model_id": "pollination",
     "model_title": gettext("Crop Pollination"),
-    "pyname": "natcap.invest.pollination",
     "userguide": "croppollination.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/recreation/recmodel_client.py
+++ b/src/natcap/invest/recreation/recmodel_client.py
@@ -102,7 +102,6 @@ predictor_table_columns = {
 MODEL_SPEC = {
     "model_id": "recreation",
     "model_title": gettext("Visitation: Recreation and Tourism"),
-    "pyname": "natcap.invest.recreation.recmodel_client",
     "userguide": "recreation.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/routedem.py
+++ b/src/natcap/invest/routedem.py
@@ -19,7 +19,6 @@ INVALID_BAND_INDEX_MSG = gettext('Must be between 1 and {maximum}')
 MODEL_SPEC = {
     "model_id": "routedem",
     "model_title": gettext("RouteDEM"),
-    "pyname": "natcap.invest.routedem",
     "userguide": "routedem.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/scenario_gen_proximity.py
+++ b/src/natcap/invest/scenario_gen_proximity.py
@@ -31,7 +31,6 @@ MISSING_CONVERT_OPTION_MSG = gettext(
 MODEL_SPEC = {
     "model_id": "scenario_generator_proximity",
     "model_title": gettext("Scenario Generator: Proximity Based"),
-    "pyname": "natcap.invest.scenario_gen_proximity",
     "userguide": "scenario_gen_proximity.html",
     "aliases": ("sgp",),
     "ui_spec": {

--- a/src/natcap/invest/scenic_quality/scenic_quality.py
+++ b/src/natcap/invest/scenic_quality/scenic_quality.py
@@ -49,7 +49,6 @@ _INTERMEDIATE_BASE_FILES = {
 MODEL_SPEC = {
     "model_id": "scenic_quality",
     "model_title": gettext("Scenic Quality"),
-    "pyname": "natcap.invest.scenic_quality.scenic_quality",
     "userguide": "scenic_quality.html",
     "aliases": ("sq",),
     "ui_spec": {

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -30,7 +30,6 @@ LOGGER = logging.getLogger(__name__)
 MODEL_SPEC = {
     "model_id": "sdr",
     "model_title": gettext("Sediment Delivery Ratio"),
-    "pyname": "natcap.invest.sdr.sdr",
     "userguide": "sdr.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -31,7 +31,6 @@ MONTH_ID_TO_LABEL = [
 MODEL_SPEC = {
     "model_id": "seasonal_water_yield",
     "model_title": gettext("Seasonal Water Yield"),
-    "pyname": "natcap.invest.seasonal_water_yield.seasonal_water_yield",
     "userguide": "seasonal_water_yield.html",
     "aliases": ("swy",),
     "ui_spec": {

--- a/src/natcap/invest/stormwater.py
+++ b/src/natcap/invest/stormwater.py
@@ -28,7 +28,6 @@ NONINTEGER_SOILS_RASTER_MESSAGE = 'Soil group raster data type must be integer'
 MODEL_SPEC = {
     "model_id": "stormwater",
     "model_title": gettext("Urban Stormwater Retention"),
-    "pyname": "natcap.invest.stormwater",
     "userguide": "stormwater.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -31,7 +31,6 @@ _LOGGING_PERIOD = 5
 MODEL_SPEC = {
     "model_id": "urban_cooling_model",
     "model_title": gettext("Urban Cooling"),
-    "pyname": "natcap.invest.urban_cooling_model",
     "userguide": "urban_cooling_model.html",
     "aliases": ("ucm",),
     "ui_spec": {

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -24,7 +24,6 @@ LOGGER = logging.getLogger(__name__)
 MODEL_SPEC = {
     "model_id": "urban_flood_risk_mitigation",
     "model_title": gettext("Urban Flood Risk Mitigation"),
-    "pyname": "natcap.invest.urban_flood_risk_mitigation",
     "userguide": "urban_flood_mitigation.html",
     "aliases": ("ufrm",),
     "ui_spec": {

--- a/src/natcap/invest/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access.py
@@ -41,7 +41,6 @@ ID_FIELDNAME = 'adm_unit_id'
 MODEL_SPEC = {
     'model_id': 'urban_nature_access',
     'model_title': gettext('Urban Nature Access'),
-    'pyname': 'natcap.invest.urban_nature_access',
     'userguide': 'urban_nature_access.html',
     'aliases': ('una',),
     'ui_spec': {

--- a/src/natcap/invest/wave_energy.py
+++ b/src/natcap/invest/wave_energy.py
@@ -133,7 +133,6 @@ CAPTURED_WEM_FIELDS = {
 MODEL_SPEC = {
     "model_id": "wave_energy",
     "model_title": gettext("Wave Energy Production"),
-    "pyname": "natcap.invest.wave_energy",
     "userguide": "wave_energy.html",
     "aliases": (),
     "ui_spec": {

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -93,7 +93,6 @@ OUTPUT_WIND_DATA_FIELDS = {
 MODEL_SPEC = {
     "model_id": "wind_energy",
     "model_title": gettext("Wind Energy Production"),
-    "pyname": "natcap.invest.wind_energy",
     "userguide": "wind_energy.html",
     "aliases": (),
     "ui_spec": {

--- a/tests/test_model_specs.py
+++ b/tests/test_model_specs.py
@@ -56,7 +56,7 @@ class ValidateModelSpecs(unittest.TestCase):
     def test_model_specs_are_valid(self):
         """MODEL_SPEC: test each spec meets the expected pattern."""
 
-        required_keys = {'model_id', 'model_title', 'pyname', 'userguide',
+        required_keys = {'model_id', 'model_title', 'userguide',
                          'aliases', 'args', 'ui_spec', 'outputs'}
         optional_spatial_key = 'args_with_spatial_overlap'
         for model_id, pyname in model_id_to_pyname.items():

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -44,7 +44,7 @@ class EndpointFunctionTests(unittest.TestCase):
         spec = json.loads(response.get_data(as_text=True))
         self.assertEqual(
             set(spec),
-            {'model_id', 'model_title', 'pyname', 'userguide', 'aliases',
+            {'model_id', 'model_title', 'userguide', 'aliases',
              'ui_spec', 'args_with_spatial_overlap', 'args', 'outputs'})
 
     def test_get_invest_validate(self):

--- a/workbench/tests/invest/flaskapp.test.js
+++ b/workbench/tests/invest/flaskapp.test.js
@@ -67,7 +67,7 @@ describe('requests to flask endpoints', () => {
 
   test('fetch invest model args spec', async () => {
     const spec = await serverRequests.getSpec('carbon');
-    const expectedKeys = ['model_id', 'model_title', 'pyname', 'userguide', 'args'];
+    const expectedKeys = ['model_id', 'model_title', 'userguide', 'args'];
     expectedKeys.forEach((key) => {
       expect(spec[key]).toBeDefined();
     });


### PR DESCRIPTION
## Description
While working on the plugins documentation, I realized that the `pyname` attribute of the `MODEL_SPEC` isn't being used anymore. Since we're dynamically gathering the list of models in `models.py`, we can set the pyname there without having to define it in the spec.

The test failures on ubuntu are expected, a fix for that is going separately in #1795.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
