### PR TITLE
Fix Workbench dialog for selecting location to extract datastack

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,12 @@
   Unreleased Changes
   ------------------
 
+Workbench
+=========
+* Fixed a bug that did not allow users to select a folder as the location
+  to extract a datastack archive.
+  (`#1879 <https://github.com/natcap/invest/issues/1879>`_).
+
 Crop Production
 ===============
 * Both the Percentile and Regression models now issue a warning if any LULC

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -484,7 +484,6 @@ describe('Sidebar Buttons', () => {
   });
 
   test('Load parameters from datastack: tgz asks for extract location', async () => {
-    // const spyInvoke = jest.spyOn(ipcRenderer, 'invoke');
     const mockDatastack = {
       module_name: spec.pyname,
       args: {
@@ -506,25 +505,16 @@ describe('Sidebar Buttons', () => {
       }
       return Promise.resolve(undefined);
     });
-    // ipcRenderer.invoke.mockResolvedValue(mockDialogData);
 
-    // Render with a completed model run so we can navigate to Log Tab
-    // and assert that Loading new params toggles back to Setup Tab
     const job = new InvestJob({
       modelRunName: 'carbon',
       modelHumanName: 'Carbon Model',
-      status: 'success',
       argsValues: {},
-      logfile: 'foo.txt',
     });
-    const { findByText, findByLabelText, findByRole } = renderInvestTab(job);
+    const { findByText, findByLabelText } = renderInvestTab(job);
 
-    await userEvent.click(await findByRole('tab', { name: 'Log' }));
     const loadButton = await findByText('Load parameters from file');
     await userEvent.click(loadButton);
-
-    const setupTab = await findByRole('tab', { name: 'Setup' });
-    expect(setupTab.classList.contains('active')).toBeTruthy();
 
     const input1 = await findByLabelText((content) => content.startsWith(spec.args.workspace.name));
     expect(input1).toHaveValue(mockDatastack.args.workspace);

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -48,7 +48,6 @@ function renderInvestTab(job = DEFAULT_JOB) {
     <InvestTab
       job={job}
       tabID={tabID}
-      // investSettings={{ nWorkers: '-1', loggingLevel: 'INFO', taskgraphLoggingLevel: 'ERROR' }}
       saveJob={() => {}}
       updateJobProperties={() => {}}
     />

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -48,7 +48,7 @@ function renderInvestTab(job = DEFAULT_JOB) {
     <InvestTab
       job={job}
       tabID={tabID}
-      investSettings={{ nWorkers: '-1', loggingLevel: 'INFO', taskgraphLoggingLevel: 'ERROR' }}
+      // investSettings={{ nWorkers: '-1', loggingLevel: 'INFO', taskgraphLoggingLevel: 'ERROR' }}
       saveJob={() => {}}
       updateJobProperties={() => {}}
     />
@@ -125,6 +125,9 @@ describe('Run status Alert renders with status from a recent run', () => {
 
 describe('Open Workspace button', () => {
   const spec = {
+    pyname: 'natcap.invest.foo',
+    model_name: 'Foo Model',
+    userguide: 'foo.html',
     args: {},
   };
 
@@ -456,6 +459,55 @@ describe('Sidebar Buttons', () => {
       filePaths: ['foo.json']
     };
     ipcRenderer.invoke.mockResolvedValue(mockDialogData);
+
+    // Render with a completed model run so we can navigate to Log Tab
+    // and assert that Loading new params toggles back to Setup Tab
+    const job = new InvestJob({
+      modelRunName: 'carbon',
+      modelHumanName: 'Carbon Model',
+      status: 'success',
+      argsValues: {},
+      logfile: 'foo.txt',
+    });
+    const { findByText, findByLabelText, findByRole } = renderInvestTab(job);
+
+    await userEvent.click(await findByRole('tab', { name: 'Log' }));
+    const loadButton = await findByText('Load parameters from file');
+    await userEvent.click(loadButton);
+
+    const setupTab = await findByRole('tab', { name: 'Setup' });
+    expect(setupTab.classList.contains('active')).toBeTruthy();
+
+    const input1 = await findByLabelText((content) => content.startsWith(spec.args.workspace.name));
+    expect(input1).toHaveValue(mockDatastack.args.workspace);
+    const input2 = await findByLabelText((content) => content.startsWith(spec.args.port.name));
+    expect(input2).toHaveValue(mockDatastack.args.port);
+  });
+
+  test('Load parameters from datastack: tgz asks for extract location', async () => {
+    // const spyInvoke = jest.spyOn(ipcRenderer, 'invoke');
+    const mockDatastack = {
+      module_name: spec.pyname,
+      args: {
+        workspace: 'myworkspace',
+        port: '9999',
+      },
+    };
+    fetchDatastackFromFile.mockResolvedValue(mockDatastack);
+    const mockDialogData = {
+      canceled: false,
+      filePaths: ['foo.tgz'],
+    };
+    ipcRenderer.invoke.mockImplementation((channel, options) => {
+      if (channel === ipcMainChannels.SHOW_OPEN_DIALOG) {
+        return Promise.resolve(mockDialogData);
+      }
+      if (channel === ipcMainChannels.CHECK_FILE_PERMISSIONS) {
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(undefined);
+    });
+    // ipcRenderer.invoke.mockResolvedValue(mockDialogData);
 
     // Render with a completed model run so we can navigate to Log Tab
     // and assert that Loading new params toggles back to Setup Tab


### PR DESCRIPTION
We needed to change the way we use the `electron.shell.dialog` API to allow users to select a folder instead of a file. I also added a check to see if the folder is writeable. This now matches how we handle selecting the download location from the sample data `DownloadModal`.

Fixes #1879 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
