### PR TITLE
fix auto-release twine upload step

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -107,7 +107,7 @@ jobs:
           twine upload \
             --username="__token__" \
             --password=${{ secrets.PYPI_NATCAP_INVEST_TOKEN }} \
-            artifacts/natcap.invest* artifacts/natcap_invest*
+            artifacts/natcap_invest*
 
       - name: Roll back on failure
         if: failure()


### PR DESCRIPTION
The `twine upload` failed the last time we ran the automated release process. The artifacts that we're trying to upload look like this, so the updated pattern should find them.

```
-rw-r--r-- 1 dmf 197121 1.9M Apr  3 15:16 natcap_invest-3.15.0.tar.gz
-rw-r--r-- 1 dmf 197121 1.6M Apr  3 15:11 natcap_invest-3.15.0-cp310-cp310-macosx_10_13_x86_64.whl
-rw-r--r-- 1 dmf 197121  44M Apr  3 15:10 natcap_invest-3.15.0-cp310-cp310-manylinux_2_39_x86_64.whl
-rw-r--r-- 1 dmf 197121 1.1M Apr  3 15:11 natcap_invest-3.15.0-cp310-cp310-win_amd64.whl
-rw-r--r-- 1 dmf 197121 1.6M Apr  3 15:11 natcap_invest-3.15.0-cp311-cp311-macosx_10_13_x86_64.whl
-rw-r--r-- 1 dmf 197121  44M Apr  3 15:11 natcap_invest-3.15.0-cp311-cp311-manylinux_2_39_x86_64.whl
-rw-r--r-- 1 dmf 197121 1.1M Apr  3 15:11 natcap_invest-3.15.0-cp311-cp311-win_amd64.whl
-rw-r--r-- 1 dmf 197121 1.6M Apr  3 15:11 natcap_invest-3.15.0-cp312-cp312-macosx_10_13_x86_64.whl
-rw-r--r-- 1 dmf 197121  44M Apr  3 15:11 natcap_invest-3.15.0-cp312-cp312-manylinux_2_39_x86_64.whl
-rw-r--r-- 1 dmf 197121 1.1M Apr  3 15:11 natcap_invest-3.15.0-cp312-cp312-win_amd64.whl
-rw-r--r-- 1 dmf 197121 1.6M Apr  3 15:11 natcap_invest-3.15.0-cp313-cp313-macosx_10_13_x86_64.whl
-rw-r--r-- 1 dmf 197121  44M Apr  3 15:11 natcap_invest-3.15.0-cp313-cp313-manylinux_2_39_x86_64.whl
-rw-r--r-- 1 dmf 197121 1.1M Apr  3 15:11 natcap_invest-3.15.0-cp313-cp313-win_amd64.whl
-rw-r--r-- 1 dmf 197121 1.6M Apr  3 15:11 natcap_invest-3.15.0-cp39-cp39-macosx_10_13_x86_64.whl
-rw-r--r-- 1 dmf 197121  44M Apr  3 15:11 natcap_invest-3.15.0-cp39-cp39-manylinux_2_39_x86_64.whl
-rw-r--r-- 1 dmf 197121 1.1M Apr  3 15:11 natcap_invest-3.15.0-cp39-cp39-win_amd64.whl
```

Fixes #1871 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
