### PR TITLE
Handle validation runtime error in `check_spatial_overlap`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,7 @@
 ..
   Unreleased Changes
   ------------------
+
 General
 =======
 * Handle exceptions that can arise during ``validation.check_spatial_overlap``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,11 @@
 ..
   Unreleased Changes
   ------------------
+General
+=======
+* Handle exceptions that can arise during ``validation.check_spatial_overlap``
+  when a layer's bounding box cannot be transformed to EPSG:4326.
+  (`#1849 <https://github.com/natcap/invest/issues/1849>`_).
 
 Workbench
 =========

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -811,7 +811,7 @@ def check_spatial_overlap(spatial_filepaths_list,
             except (ValueError, RuntimeError) as err:
                 LOGGER.debug(err)
                 LOGGER.warning(
-                    f'Skipping spatial overlap check for {filepath} '
+                    f'Skipping spatial overlap check for {filepath}. '
                     'Bounding box cannot be transformed to EPSG:4326')
                 continue
 
@@ -820,7 +820,8 @@ def check_spatial_overlap(spatial_filepaths_list,
 
         if all([numpy.isinf(coord) for coord in bounding_box]):
             LOGGER.warning(
-                'Skipping infinite bounding box for file %s', filepath)
+                f'Skipping spatial overlap check for {filepath} '
+                f'because of infinite bounding box {bounding_box}')
             continue
 
         bounding_boxes.append(bounding_box)

--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -805,8 +805,16 @@ def check_spatial_overlap(spatial_filepaths_list,
             return MESSAGES['NO_PROJECTION'].format(filepath=filepath)
 
         if different_projections_ok:
-            bounding_box = pygeoprocessing.transform_bounding_box(
-                info['bounding_box'], info['projection_wkt'], wgs84_wkt)
+            try:
+                bounding_box = pygeoprocessing.transform_bounding_box(
+                    info['bounding_box'], info['projection_wkt'], wgs84_wkt)
+            except (ValueError, RuntimeError) as err:
+                LOGGER.debug(err)
+                LOGGER.warning(
+                    f'Skipping spatial overlap check for {filepath} '
+                    'Bounding box cannot be transformed to EPSG:4326')
+                continue
+
         else:
             bounding_box = info['bounding_box']
 


### PR DESCRIPTION
When a model allows inputs to be in different projections, `check_spatial_overlap` tries to transform all input layer bounding boxes to EPSG:4326 in order to test that they all overlap. `transform_bounding_box` can raise `ValueError` or `RuntimeError` if a bounding box cannot be transformed. We need to handle those exceptions so that the process running validation does not crash.

I think it makes sense to skip the overlap check for the layer when this occurs, rather than issue a validation error. That matches the current behavior of `check_spatial_overlap` where there's already another case where a layer can be skipped. We don't want to prevent people from a running a model unless we're 100% certain the data is invalid.

Fixes #1849 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
