### PR TITLE
Wind Energy: Remove Raster Outputs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -89,6 +89,7 @@ Wind Energy
 * The model no longer returns results as rasters; instead, values are
   written to the output ``wind_energy_points`` shapefile for each point
   (`#1698 <https://github.com/natcap/invest/issues/1698>`_).
+  Any Decision Record (ADR): `ADR-0004: Remove Wind Energy Raster Outputs <https://github.com/natcap/invest/blob/main/doc/decision-records/ADR-0004-Remove-Wind-Energy-Raster-Outputs.md>`_
 * The output ``wind_energy_points.shp`` no longer returns Harvested or
   Valuation-related values for points that are invalid wind farm locations
   due to depth or distance constraints

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -77,6 +77,16 @@ Urban Flood Risk
   ``Runoff_retention_m3.tif``
   (`#1837 <https://github.com/natcap/invest/issues/1837>`_).
 
+Wind Energy
+===========
+* The model no longer returns results as rasters; instead, values are
+  written to the output ``wind_energy_points`` shapefile for each point
+  (`#1698 <https://github.com/natcap/invest/issues/1698>`_).
+* The output ``wind_energy_points.shp`` no longer returns Harvested or
+  Valuation-related values for points that are invalid wind farm locations
+  due to depth or distance constraints
+  (`#1699 <https://github.com/natcap/invest/issues/1699>`_).
+
 
 3.15.1 (2025-05-06)
 -------------------

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 4692cbab39cca4e49e39ee88926024e81acbb8cd
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 44fced6be50e932f911459ca243a284c21d17483
+GIT_UG_REPO_REV             := 51a746b8eeb87061bb0600d9ce1fb451b4dee7fe
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := ecdab62bd6e2d3d9105e511cfd6884bf07f3d27b
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := 346df82ed3de8a40aef0fc355218df6b0620e864
+GIT_TEST_DATA_REPO_REV      := 4692cbab39cca4e49e39ee88926024e81acbb8cd
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := ecdab62bd6e2d3d9105e511cfd6884bf07f3d27b
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := f0ebe739207ae57ae53a285d0fd954d6e8cfee54
+GIT_TEST_DATA_REPO_REV      := 346df82ed3de8a40aef0fc355218df6b0620e864
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 4692cbab39cca4e49e39ee88926024e81acbb8cd
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 7d83c5bf05f0bef8dd4d2a4bd2f565ecf270af75
+GIT_UG_REPO_REV             := 44fced6be50e932f911459ca243a284c21d17483
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1504,7 +1504,7 @@ def _index_raster_values_to_point_vector(
 
 def _reproject_bathymetry(base_raster_path, aoi_vector_path,
         comparison_pixel_size, target_raster_path):
-    """Reproject and clip bathymetry raster to AOI bounding box and SRS
+    """Reproject and clip bathymetry raster to AOI bounding box and SRS.
 
     The minimum of the ``comparison_pixel_size`` and the base raster's pixel
     size will be used as the target pixel size in the ``warp_raster`` call.

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -585,7 +585,7 @@ _TARGET_RESAMPLE_METHOD = 'near'
 # Target pixel size, in meters. Given the increased availability of
 # high-resolution wind data (e.g. 2km horizontal resolution), we want a fine
 # resolution for rasterizing wind point vector values.
-_TARGET_PIXEL_SIZE = (90, -90)
+_TARGET_PIXEL_SIZE = (1500, -1500)
 
 
 def execute(args):
@@ -1403,6 +1403,7 @@ def _index_raster_values_to_point_vector(
     # We'll check encountered features against this list at the end,
     # for the purposes of removing any points that weren't encountered
     all_fids = [feat.GetFID() for feat in target_layer]
+    encountered_fids = set()
 
     # Initialize an R-Tree indexing object with point geom from base_vector
     def generator_function():
@@ -1416,9 +1417,6 @@ def _index_raster_values_to_point_vector(
                 geom_trans_x, geom_trans_x, geom_trans_y, geom_trans_y), None)
 
     vector_idx = index.Index(generator_function(), interleaved=False)
-
-    # For all the features (points) add the proper raster value
-    encountered_fids = set()
 
     iterables = [pygeoprocessing.iterblocks((base_raster_path_list[index], 1))
         for index in range(len(base_raster_path_list))]

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -64,13 +64,6 @@ INPUT_WIND_DATA_FIELDS = {
 
 OUTPUT_WIND_DATA_FIELDS = {
     **INPUT_WIND_DATA_FIELDS,
-    "lam": {
-        "type": "number",
-        "units": u.none,
-        "about": gettext(
-            "Weibull scale factor calculated for the "
-            "proposed hub height at this point.")
-    },
     "ref_lam": {
         "type": "number",
         "units": u.degree,

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1563,12 +1563,13 @@ def _index_raster_values_to_point_vector(
 
             encountered_fids.add(vector_fid)
             invalid_feature = False # Always valid if no mask
-            if mask_field:
+            if mask_keys:
                 invalid_feature = None in [data.get(mask_key, None)
                                            for mask_key in mask_keys]
-                base_vector_feat = base_layer.GetFeature(vector_fid)
-                base_vector_feat.SetField(mask_field, invalid_feature)
-                base_layer.SetFeature(base_vector_feat)
+                if mask_field:
+                    base_vector_feat = base_layer.GetFeature(vector_fid)
+                    base_vector_feat.SetField(mask_field, invalid_feature)
+                    base_layer.SetFeature(base_vector_feat)
 
             if invalid_feature:
                 target_layer.DeleteFeature(vector_fid)

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1340,11 +1340,12 @@ def _index_raster_values_to_point_vector(
     geospatial_info = [
         raster_info['raster_size'] for raster_info in raster_info_list]
     if len(set(geospatial_info)) > 1:
+        mismatched_rasters = [(raster_path, dimensions) for
+            (raster_path, dimensions) in
+            zip(base_raster_path_list, geospatial_info)]
         raise ValueError(
             "Input Rasters are not the same dimensions. The following rasters "
-            f"are not identical: {
-                [(raster_path, dimensions) for (raster_path, dimensions) in
-                zip(base_raster_path_list, geospatial_info)]}")
+            f"are not identical: {mismatched_rasters}")
     # When writing values to the vector, we replace nodata with None;
     # map the fieldnames to the nodata values of their corresponding rasters
     raster_nodata = [raster_info['nodata'][0] for raster_info in raster_info_list]

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -89,6 +89,41 @@ OUTPUT_WIND_DATA_FIELDS = {
         "about": gettext(
             "Predicted energy harvested from a wind "
             "farm centered on this point.")
+    },
+    "DepthVal": {
+        "type": "number",
+        "units": u.meter,
+        "about": gettext(
+            "Ocean depth at this point.")
+    },
+    "DistVal": {
+        "type": "number",
+        "units": u.meter,
+        "about": gettext(
+            "Distance to shore from this point. Included only "
+            "if distance parameters were provided.")
+    },
+    "CO2_Tons": {
+        "type": "number",
+        "units": u.metric_ton/u.year,
+        "about": gettext(
+            "Offset carbon emissions for a farm centered "
+            "on this point. Included only if Valuation is run.")
+    },
+    "Level_Cost": {
+        "type": "number",
+        "units": u.currency/u.kilowatt_hour,
+        "about": gettext(
+            "Energy price that would be required to set the "
+            "present value of a farm centered on this point "
+            "equal to zero. Included only if Valuation is run.")
+    },
+    "NPV": {
+        "type": "number",
+        "units": u.currency,
+        "about": gettext(
+            "The net present value of a farm centered on "
+            "this point. Included only if Valuation is run.")
     }
 }
 
@@ -457,13 +492,6 @@ MODEL_SPEC = {
                         "units": u.metric_ton/u.year
                     }}
                 },
-                "density_W_per_m2.tif": {
-                    "about": gettext("Map of power density."),
-                    "bands": {1: {
-                        "type": "number",
-                        "units": u.watt/u.meter**2
-                    }}
-                },
                 "depth_mask.tif": {
                     "about": (
                         "Bathymetry map masked to show only the pixels that "
@@ -510,14 +538,6 @@ MODEL_SPEC = {
                 },
                 "projection_params.pickle": {
                     "about": "Pickled bathymetry reprojection parameters"
-                },
-                "temp_density.tif": {
-                    "about": "Interpolated wind power density",
-                    "bands": {1: {"type": "number", "units": u.watt/u.meter**2}}
-                },
-                "temp_harvested.tif": {
-                    "about": "Interpolated harvested wind energy",
-                    "bands": {1: {"type": "number", "units": u.megawatt_hour/u.year}}
                 },
                 "wind_data.pickle": {"about": "Pickled wind data dictionary"},
                 "wind_energy_points_from_data.shp": {

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -1363,9 +1363,14 @@ def _index_raster_values_to_point_vector(
         # Since we're mutating the base vector, if the
         # supplied fieldname already exists, don't overwrite it
         if base_layer.FindFieldIndex(mask_field, True) != -1:
-            raise ValueError(
-                f"A field called '{mask_field}' already exists in the base "
-                "vector. Please supply a different name for `mask_field`.")
+            i = 1
+            mask_field = f'Masked_{i}'
+            while base_layer.FindFieldIndex(mask_field, True) != -1:
+                i += 1
+            LOGGER.warning(
+                "A field with the same name as the supplied `mask_field` "
+                "already exists in the base vector. To avoid overwriting, "
+                f"the field name `{mask_field}` is being used instead.")
         field_defn = ogr.FieldDefn(mask_field, ogr.OFTReal)
         field_defn.SetWidth(24)
         field_defn.SetPrecision(11)


### PR DESCRIPTION
## Description
Fixes #1698 and #1699 

ADR: #1892 
User's Guide PR: https://github.com/natcap/invest.users-guide/pull/178
Test Data PR: [invest-test-data#36](https://bitbucket.org/natcap/invest-test-data/pull-requests/36)

The Wind Energy model has historically interpolated Harvested and Density values to rasters, which are then used to calculate NPV, Levelized Cost, and Carbon Emissions. The method of interpolation resulted in data existing outside of the bounds of the input wind data. 

Based on Rob's use of the model, and review and evaluation of the problem by the team, the consensus is that the model's current use of interpolation introduces too many potential violations of the constraints of the model (e.g. interpolating over areas that are invalid due to ocean depth or distance from shore, or are outside of the areas included in the input wind speed data) and requires assumptions that may not be helpful for users. 

We are therefore removing the raster outputs and retaining the associated values in the output `wind_energy_points.shp` vector. (In cases where Valuation is run, there will still be intermediate rasters for Harvested, NPV, Levelized Cost, and Carbon Emissions.)

The process of doing so has required careful consideration on a few points:
- We want to do away with interpolation but still be able to make use of the efficiency that comes along with raster calculations. As such, Harvested values do still need to be rasterized so that the raster can be used in the NPV, Levelized Cost, and Carbon Emissions calculations. This PR moves rasterization of Harvested values into the Valuation half of the model, since this raster is only needed for Valuation calculations. 
- Higher-resolution wind datasets are now available, some with horizontal resolution as fine as 2km. As such, when rasterizing the Wind Data, we need to make sure our pixel size is fine enough. This PR manually sets a (90, -90) pixel size for the rasters.
- To write raster values back to the wind data vector, this PR uses pixel-picking. The intermediate `unmasked_wind_energy_points.shp` contains Density and Harvested values for all points, as well as an additional field, `Masked`, that indicates whether or not a point has been masked out. The final output only contains valid points, with values for Density, Harvested, Depth, Distance, NPV, Levelized Cost, and Carbon Emissions. 

These changes also address #1699; data points in the final wind vector will now be appropriately masked out by depth and distance. 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)