### PR TITLE
Wind Energy: Check that `aoi_vector_path` isn't an empty string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -93,6 +93,12 @@ Seasonal Water Yield
   were being incorrectly converted to 0's
   (`#1592 <https://github.com/natcap/invest/issues/1592>`_).
 
+Wind Energy
+===========
+* Fixed a bug where the model would error if no AOI was provided when run from
+  the workbench or from a datastack file where the value for 'aoi_vector_path'
+  was an empty string. (`#1900 <https://github.com/natcap/invest/issues/1900`)
+
 
 3.15.0 (2025-04-03)
 -------------------

--- a/src/natcap/invest/wind_energy.py
+++ b/src/natcap/invest/wind_energy.py
@@ -757,7 +757,7 @@ def execute(args):
         target_path_list=[wind_data_pickle_path],
         task_name='compute_density_harvested_fields')
 
-    if 'aoi_vector_path' in args:
+    if 'aoi_vector_path' in args and args['aoi_vector_path'] != '':
         LOGGER.info('AOI Provided')
         aoi_vector_path = args['aoi_vector_path']
 


### PR DESCRIPTION
## Description
Fixes #1900

When checking if an AOI was provided, we were only checking if the key 'aoi_vector_path' existed in the args. On workbench runs, the key always appears in args; the value is just an empty string if no path is provided. As such, the model run fails on the workbench when no AOI is provided. Also checking for empty strings solves the problem.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Tested the Workbench UI (if relevant)
~- [ ] Updated the user's guide (if needed)~