### PR TITLE
Hide model status indicator when a parameter is changed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -76,6 +76,10 @@ Workbench
 * Fixed a bug that did not allow users to select a folder as the location
   to extract a datastack archive.
   (`#1879 <https://github.com/natcap/invest/issues/1879>`_).
+* When a parameter from a previous model run is changed, the model status
+  indicator (e.g., the "Model Complete" notice) is cleared to help prevent
+  confusion about which parameters went into the most recent model run
+  (`#1655 <https://github.com/natcap/invest/issues/1655>`_).
 
 Crop Production
 ===============
@@ -97,7 +101,7 @@ Wind Energy
 ===========
 * Fixed a bug where the model would error if no AOI was provided when run from
   the workbench or from a datastack file where the value for 'aoi_vector_path'
-  was an empty string. (`#1900 <https://github.com/natcap/invest/issues/1900`)
+  was an empty string. (`#1900 <https://github.com/natcap/invest/issues/1900>`_)
 
 
 3.15.0 (2025-04-03)

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -299,6 +299,8 @@ class InvestTab extends React.Component {
                     sidebarFooterElementId={sidebarFooterElementId}
                     executeClicked={executeClicked}
                     switchTabs={this.switchTabs}
+                    tabID={tabID}
+                    updateJobProperties={this.props.updateJobProperties}
                   />
                 </TabPane>
                 <TabPane

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -261,7 +261,7 @@ export default function ArgInput(props) {
         name={argkey}
         value={value}
         onChange={handleChange}
-        onFocus={handleChange}
+        onFocus={handleFocus}
         disabled={!enabled}
         isValid={enabled && isValid}
         custom

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -608,7 +608,6 @@ class SetupTab extends React.Component {
             </React.Fragment>
           </Portal>
           <Portal elId={sidebarFooterElementId}>
-            {/* @TODO: re-enable button when model status is is cleared */}
             <Button
               block
               variant="primary"

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -383,6 +383,7 @@ class SetupTab extends React.Component {
    * Updating means:
    * 1) setting the value
    * 2) toggling the enabled/disabled/hidden state of any dependent args
+   * 3) clearing job status in case args are being updated after the model has been run.
    *
    * @param {string} key - the invest argument key
    * @param {string} value - the invest argument value
@@ -394,6 +395,9 @@ class SetupTab extends React.Component {
     this.setState({
       argsValues: argsValues,
     }, () => {
+      this.props.updateJobProperties(this.props.tabID, {
+        status: undefined,  // Clear job status to hide model status indicator.
+      });
       this.debouncedValidate();
       this.callUISpecFunctions();
     });
@@ -604,6 +608,7 @@ class SetupTab extends React.Component {
             </React.Fragment>
           </Portal>
           <Portal elId={sidebarFooterElementId}>
+            {/* @TODO: re-enable button when model status is is cleared */}
             <Button
               block
               variant="primary"
@@ -646,4 +651,6 @@ SetupTab.propTypes = {
   sidebarFooterElementId: PropTypes.string.isRequired,
   executeClicked: PropTypes.bool.isRequired,
   switchTabs: PropTypes.func.isRequired,
+  tabID: PropTypes.string.isRequired,
+  updateJobProperties: PropTypes.func.isRequired,
 };

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -75,6 +75,8 @@ function renderSetupFromSpec(baseSpec, uiSpec, initValues = undefined) {
       sidebarFooterElementId="foo"
       executeClicked={false}
       switchTabs={() => {}}
+      tabID={'999'}
+      updateJobProperties={() => {}}
     />
   );
   return utils;


### PR DESCRIPTION
## Description
Fixes #1655 by clearing job status on arg change. This hides the model status indicator (if one is present), to limit confusion when updating params after a model run.

Also updates an existing focus handler from `handleChange` to `handleFocus`.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
