### PR TITLE
Urban Flood Risk: Rename `Runoff_retention.tif`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,13 @@ Workbench
   existing user-added metadata preserved)
   (`#1774 <https://github.com/natcap/invest/issues/1774>`_).
 
+Urban Flood Risk
+================
+* The raster output ``Runoff_retention.tif`` has been renamed
+  ``Runoff_retention_index.tif`` to clarify the difference between it and
+  ``Runoff_retention_m3.tif``
+  (`#1837 <https://github.com/natcap/invest/issues/1837>`_).
+
 
 3.15.1 (2025-05-06)
 -------------------

--- a/src/natcap/invest/urban_flood_risk_mitigation.py
+++ b/src/natcap/invest/urban_flood_risk_mitigation.py
@@ -113,7 +113,7 @@ MODEL_SPEC = {
         }
     },
     "outputs": {
-        "Runoff_retention.tif": {
+        "Runoff_retention_index.tif": {
             "about": "Map of runoff retention index.",
             "bands": {1: {
                 "type": "number",
@@ -364,7 +364,7 @@ def execute(args):
     # Generate Runoff Retention
     runoff_retention_nodata = -9999
     runoff_retention_raster_path = os.path.join(
-        args['workspace_dir'], f'Runoff_retention{file_suffix}.tif')
+        args['workspace_dir'], f'Runoff_retention_index{file_suffix}.tif')
     runoff_retention_task = task_graph.add_task(
         func=pygeoprocessing.raster_calculator,
         args=([


### PR DESCRIPTION
## Description
Fixes #1837 

Updated the name of the output raster `Runoff_retention.tif` to `Runoff_retention_index.tif`, to help clarify the difference between it and `Runoff_retention_m3.tif`.  

User's Guide PR: https://github.com/natcap/invest.users-guide/pull/177

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
~Tested the Workbench UI (if relevant)~
