### PR TITLE
Clarify how emails are sent on code-signing server

### DIFF
--- a/codesigning/signing-worker/logwatch.conf
+++ b/codesigning/signing-worker/logwatch.conf
@@ -1,0 +1,153 @@
+########################################################
+# This was written and is maintained by:
+#    Kirk Bauer <kirk@kaybee.org>
+#
+# Please send all comments, suggestions, bug reports,
+#    etc, to kirk@kaybee.org.
+#
+########################################################
+
+# NOTE:
+#   All these options are the defaults if you run logwatch with no
+#   command-line arguments.  You can override all of these on the
+#   command-line.
+
+# You can put comments anywhere you want to.  They are effective for the
+# rest of the line.
+
+# this is in the format of <name> = <value>.  Whitespace at the beginning
+# and end of the lines is removed.  Whitespace before and after the = sign
+# is removed.  Everything is case *insensitive*.
+
+# Yes = True  = On  = 1
+# No  = False = Off = 0
+
+# You can override the default temp directory (/tmp) here
+TmpDir = /var/cache/logwatch
+
+# Output/Format Options
+# By default Logwatch will print to stdout in text with no encoding.
+# To make email Default set Output = mail to save to file set Output = file
+Output = mail
+# To make Html the default formatting Format = html
+Format = text
+# To make Base64 [aka uuencode] Encode = base64
+# Encode = none is the same as Encode = 8bit.
+# You can also specify 'Encode = 7bit', but only if all text is ASCII only.
+Encode = none
+
+# Input Encoding
+# Logwatch assumes that the input is in UTF-8 encoding.  Defining CharEncoding
+# will use iconv to convert text to the UTF-8 encoding.  Set CharEncoding
+# to an empty string to use the default current locale.  If set to a valid
+# encoding, the input characters are converted to UTF-8, discarding any
+# illegal characters.  Valid encodings are as used by the iconv program,
+# and `iconv -l` lists valid character set encodings.   
+# Setting CharEncoding to UTF-8 simply discards illegal UTF-8 characters.
+#CharEncoding = ""
+
+# Default person to mail reports to.  Can be a local account or a
+# complete email address.  Variable Output should be set to mail, or
+# --output mail should be passed on command line to enable mail feature.
+MailTo = jdouglass@stanford.edu
+# WHen using option --multiemail, it is possible to specify a different
+# email recipient per host processed.  For example, to send the report
+# for hostname host1 to user@example.com, use:
+#Mailto_host1 = user@example.com
+# Multiple recipients can be specified by separating them with a space.
+
+# Default person to mail reports from.  Can be a local account or a
+# complete email address.
+MailFrom = logwatch@ncp-inkwell.stanford.edu
+
+# if set, the results will be saved in <filename> instead of mailed
+# or displayed. Be sure to set Output = file also.
+#Filename = /tmp/logwatch
+
+# Use archives?  If set to 'Yes', the archives of logfiles
+# (i.e. /var/log/messages.1 or /var/log/messages.1.gz) will
+# be searched in addition to the /var/log/messages file.
+# This usually will not do much if your range is set to just
+# 'Yesterday' or 'Today'... it is probably best used with Range = All
+# By default this is now set to Yes. To turn off Archives uncomment this.
+#Archives = No
+
+# The default time range for the report...
+# The current choices are All, Today, Yesterday
+Range = yesterday
+
+# The default detail level for the report.
+# This can either be Low, Med, High or a number.
+# Low = 0
+# Med = 5
+# High = 10
+Detail = High
+
+
+# The 'Service' option expects either the name of a filter
+# (in /usr/share/logwatch/scripts/services/*) or 'All'.
+# The default service(s) to report on.  This should be left as All for
+# most people.
+Service = All
+# You can also disable certain services (when specifying all)
+#Service = "-zz-network"     # Prevents execution of zz-network service, which
+#                            # prints useful network configuration info.
+#Service = "-zz-sys"         # Prevents execution of zz-sys service, which
+#                            # prints useful system configuration info.
+#Service = "-eximstats"      # Prevents execution of eximstats service, which
+#                            # is a wrapper for the eximstats program.
+# If you only cared about FTP messages, you could use these 2 lines
+# instead of the above:
+#Service = ftpd-messages   # Processes ftpd messages in /var/log/messages
+#Service = ftpd-xferlog    # Processes ftpd messages in /var/log/xferlog
+# Maybe you only wanted reports on PAM messages, then you would use:
+#Service = pam_pwdb        # PAM_pwdb messages - usually quite a bit
+#Service = pam             # General PAM messages... usually not many
+
+# You can also choose to use the 'LogFile' option.  This will cause
+# logwatch to only analyze that one logfile.. for example:
+#LogFile = messages
+# will process /var/log/messages.  This will run all the filters that
+# process that logfile.  This option is probably not too useful to
+# most people.  Setting 'Service' to 'All' above analyzes all LogFiles
+# anyways...
+
+#
+# By default we assume that all Unix systems have sendmail or a sendmail-like MTA.
+# The mailer code prints a header with To: From: and Subject:.
+# At this point you can change the mailer to anything that can handle this output
+# stream.
+# TODO test variables in the mailer string to see if the To/From/Subject can be set
+# From here with out breaking anything. This would allow mail/mailx/nail etc..... -mgt
+mailer = "/usr/sbin/sendmail -t"
+
+#
+# With this option set to a comma separated list of hostnames, only log entries
+# for these particular hosts will be processed.  This can allow a log host to
+# process only its own logs, or Logwatch can be run once per a set of hosts
+# included in the logfiles.
+# Example: HostLimit = hosta,hostb,myhost
+#
+# The default is to report on all log entries, regardless of its source host.
+# Note that some logfiles do not include host information and will not be
+# influenced by this setting.
+#
+#HostLimit = myhost
+
+# Default Log Directory
+# All log-files are assumed to be given relative to the LogDir directory.
+# Multiple LogDir statements are possible.  Additional configuration variables
+# to set particular directories follow, so LogDir need not be set.
+#LogDir = /var/log
+#
+# By default /var/adm is searched after LogDir.
+#AppendVarAdmToLogDirs = 1
+#
+# By default /var/log is to be searched after LogDir and /var/adm/ .
+#AppendVarLogToLogDirs = 1
+#
+# The current working directory can be searched after the above.  Not set by
+# default.
+#AppendCWDToLogDirs = 0
+
+# vi: shiftwidth=3 tabstop=3 et

--- a/codesigning/signing-worker/logwatch.conf
+++ b/codesigning/signing-worker/logwatch.conf
@@ -42,7 +42,7 @@ Encode = none
 # to an empty string to use the default current locale.  If set to a valid
 # encoding, the input characters are converted to UTF-8, discarding any
 # illegal characters.  Valid encodings are as used by the iconv program,
-# and `iconv -l` lists valid character set encodings.   
+# and `iconv -l` lists valid character set encodings.
 # Setting CharEncoding to UTF-8 simply discards illegal UTF-8 characters.
 #CharEncoding = ""
 
@@ -50,7 +50,7 @@ Encode = none
 # complete email address.  Variable Output should be set to mail, or
 # --output mail should be passed on command line to enable mail feature.
 MailTo = jdouglass@stanford.edu
-# WHen using option --multiemail, it is possible to specify a different
+# When using option --multiemail, it is possible to specify a different
 # email recipient per host processed.  For example, to send the report
 # for hostname host1 to user@example.com, use:
 #Mailto_host1 = user@example.com

--- a/codesigning/signing-worker/playbook.yml
+++ b/codesigning/signing-worker/playbook.yml
@@ -43,6 +43,14 @@
           - google-cloud-sdk
           - google-cloud-cli
           - yubikey-manager
+          - logwatch
+          - fwlogwatch
+          - sendmail
+
+    - name: Configure logwatch
+      ansible.builtin.copy:
+        src: logwatch.conf
+        dest: /etc/logwatch/conf/logwatch.conf
 
     - name: Add bookworm-backports repository
       ansible.builtin.apt_repository:
@@ -137,3 +145,4 @@
         daemon_reload: true  # reload in case there are any config changes
         state: restarted
         enabled: true
+


### PR DESCRIPTION
This PR adds logwatch configuration (which was previously missing) and clarifies how emails are sent (via sendmail, not postfix), which should at least partially address the issue described in #1919 by reducing the server's attack surface.

Fixes #1919

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
