### PR TITLE
Update CBC docs to describe implications of accum/decay --> no carbon change

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,12 @@ Workbench
   existing user-added metadata preserved)
   (`#1774 <https://github.com/natcap/invest/issues/1774>`_).
 
+Coastal Blue Carbon
+===================
+* Updated the Coastal Blue Carbon documentation to clarify what happens when a
+  class transitions from a state of accumulation or decay to a No Carbon Change
+  ("NCC") state. (`#671 <https://github.com/natcap/invest/issues/671>`_).
+
 
 3.15.1 (2025-05-06)
 -------------------

--- a/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
+++ b/src/natcap/invest/coastal_blue_carbon/coastal_blue_carbon.py
@@ -93,8 +93,8 @@ here for several reasons:
 """
 import logging
 import os
-import time
 import shutil
+import time
 
 import numpy
 import pandas
@@ -103,13 +103,12 @@ import scipy.sparse
 import taskgraph
 from osgeo import gdal
 
-from .. import utils
+from .. import gettext
 from .. import spec_utils
-from ..unit_registry import u
+from .. import utils
 from .. import validation
 from ..model_metadata import MODEL_METADATA
-from .. import gettext
-
+from ..unit_registry import u
 
 LOGGER = logging.getLogger(__name__)
 
@@ -328,7 +327,14 @@ MODEL_SPEC = {
                             "description": gettext("low carbon disturbance rate")
                         },
                         "NCC": {
-                            "description": gettext("no change in carbon")
+                            "description": gettext(
+                                "no change in carbon. Defining 'NCC' for a "
+                                "transition will halt any in-progress carbon "
+                                "accumulation or emissions at the year of "
+                                "transition, until the class transitions "
+                                "again to a state of accumulation or "
+                                "disturbance."
+                            )
                         }
                     },
                     "about": gettext(


### PR DESCRIPTION
This PR updates the CBC documentation to clarify what happens when a transition shifts from a state of accumulation or decay to one of no carbon change.

I couldn't bring myself to make assumptions about what the user intends, so I'd rather clarify the model's logic through docs than assume intent.

Fixes #671 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
