### PR TITLE
Get `gsutil` working again on macos-13 GHA runners

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -441,9 +441,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+        id: python-312-task
 
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
+        env:
+          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-312-task.outputs.python-path }}
         run: make deploy
 
       # This relies on the file existing on GCP, so it must be run after `make

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -436,6 +436,12 @@ jobs:
         working-directory: workbench
         run: npx cross-env CI=true yarn run test-electron-app
 
+      # gsutil (part of make deploy) can't use python 3.13 yet, so set up 3.12 for use for now.
+      - name: Set up python 3.12 for gsutil
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
         run: make deploy


### PR DESCRIPTION
This PR for our GHA restores a functioning `gsutil` by setting up one of GHA's other cached python versions and specifically telling `gsutil` to use that python binary through an environment variable.

Also, today I learned that `gsutil` on mac is a shell script wrapper around a `gsutil.py` python script.

Fixes #1917

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
