### PR TITLE
Changed output location of `stream.tif` for SWY and NDR

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,17 @@ Workbench
   existing user-added metadata preserved)
   (`#1774 <https://github.com/natcap/invest/issues/1774>`_).
 
+
+NDR
+====
+* ``stream.tif`` is now saved in the main output folder rather than the
+  intermediate folder (`#1864 <https://github.com/natcap/invest/issues/1864>`_).
+
+Seasonal Water Yield
+====================
+* ``stream.tif`` is now saved in the main output folder rather than the
+  intermediate folder (`#1864 <https://github.com/natcap/invest/issues/1864>`_).
+
 Urban Flood Risk
 ================
 * The raster output ``Runoff_retention.tif`` has been renamed

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,7 +70,6 @@ Workbench
   existing user-added metadata preserved)
   (`#1774 <https://github.com/natcap/invest/issues/1774>`_).
 
-
 NDR
 ====
 * ``stream.tif`` is now saved in the main output folder rather than the

--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -247,6 +247,7 @@ MODEL_SPEC = {
                 "units": u.kilogram/u.hectare
             }}
         },
+        "stream.tif": spec_utils.STREAM,
         "intermediate_outputs": {
             "type": "directory",
             "contents": {
@@ -346,7 +347,6 @@ MODEL_SPEC = {
                     "about": "Inverse of slope",
                     "bands": {1: {"type": "number", "units": u.none}}
                 },
-                "stream.tif": spec_utils.STREAM,
                 "sub_load_n.tif": {
                     "about": "Nitrogen loads for subsurface transport",
                     "bands": {1: {
@@ -451,6 +451,7 @@ _OUTPUT_BASE_FILES = {
     'n_total_export_path': 'n_total_export.tif',
     'p_surface_export_path': 'p_surface_export.tif',
     'watershed_results_ndr_path': 'watershed_results_ndr.gpkg',
+    'stream_path': 'stream.tif'
 }
 
 INTERMEDIATE_DIR_NAME = 'intermediate_outputs'
@@ -468,7 +469,6 @@ _INTERMEDIATE_BASE_FILES = {
     's_accumulation_path': 's_accumulation.tif',
     's_bar_path': 's_bar.tif',
     's_factor_inverse_path': 's_factor_inverse.tif',
-    'stream_path': 'stream.tif',
     'sub_load_n_path': 'sub_load_n.tif',
     'surface_load_n_path': 'surface_load_n.tif',
     'surface_load_p_path': 'surface_load_p.tif',

--- a/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
+++ b/src/natcap/invest/seasonal_water_yield/seasonal_water_yield.py
@@ -364,6 +364,7 @@ MODEL_SPEC = {
                 "units": u.millimeter/u.year
             }}
         },
+        "stream.tif": spec_utils.STREAM,
         "P.tif": {
             "about": gettext("The total precipitation across all months on this pixel."),
             "bands": {1: {
@@ -421,15 +422,6 @@ MODEL_SPEC = {
                     "bands": {1: {
                         "type": "number",
                         "units": u.millimeter
-                    }}
-                },
-                "stream.tif": {
-                    "about": gettext(
-                        "Stream network map generated from the input DEM and "
-                        "Threshold Flow Accumulation. Values of 1 represent "
-                        "streams, values of 0 are non-stream pixels."),
-                    "bands": {1: {
-                        "type": "integer"
                     }}
                 },
                 'Si.tif': {
@@ -500,6 +492,7 @@ _OUTPUT_BASE_FILES = {
     'l_sum_path': 'L_sum.tif',
     'l_sum_avail_path': 'L_sum_avail.tif',
     'qf_path': 'QF.tif',
+    'stream_path': 'stream.tif',
     'b_sum_path': 'B_sum.tif',
     'b_path': 'B.tif',
     'vri_path': 'Vri.tif',
@@ -510,7 +503,6 @@ _INTERMEDIATE_BASE_FILES = {
     'aetm_path_list': ['aetm_%d.tif' % (x+1) for x in range(N_MONTHS)],
     'flow_dir_path': 'flow_dir.tif',
     'qfm_path_list': ['qf_%d.tif' % (x+1) for x in range(N_MONTHS)],
-    'stream_path': 'stream.tif',
     'si_path': 'Si.tif',
     'lulc_aligned_path': 'lulc_aligned.tif',
     'dem_aligned_path': 'dem_aligned.tif',


### PR DESCRIPTION
## Description
Changed location where `stream.tif` is saved for both Seasonal Water Yield and Nutrient Delivery Ratio. Previously, it was saved in the intermediate folder, and is now saved in the main output folder. This ensures an output location consistent with SDR. 

Related UG PR: https://github.com/natcap/invest.users-guide/pull/183

Fixes #1864

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
