### PR TITLE
Migrate recent jobs data to new format

### DIFF
--- a/src/natcap/invest/validation.py
+++ b/src/natcap/invest/validation.py
@@ -72,6 +72,8 @@ MESSAGES = {
     'WRONG_GEOM_TYPE': gettext('Geometry type must be one of {allowed}')
 }
 
+def get_message(key):
+    return gettext(MESSAGES[key])
 
 def _evaluate_expression(expression, variable_map):
     """Evaluate a python expression.

--- a/workbench/src/renderer/InvestJob.js
+++ b/workbench/src/renderer/InvestJob.js
@@ -32,6 +32,19 @@ export default class InvestJob {
         (key) => investJobStore.getItem(key)
       ));
     }
+    // Migrate old-style jobs
+    // We can eventually remove this code once it's likely that most users
+    // will have updated and ran a newer version of the workbench
+    jobArray = await Promise.all(jobArray.map(async (job) => {
+      if (job.modelID === undefined) {
+        job.modelID = job.modelRunName;
+        job.modelTitle = job.modelHumanName;
+        delete job.modelRunName;
+        delete job.modelHumanName;
+        await investJobStore.setItem(job.hash, job);
+      }
+      return job;
+    }));
     return jobArray;
   }
 

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -63,20 +63,6 @@ export default class App extends React.Component {
   async componentDidMount() {
     const investList = await this.updateInvestList();
     let recentJobs = await InvestJob.getJobStore();
-    // Migrate old-style jobs
-    // We can eventually remove this code once it's likely that most users
-    // will have updated and ran a newer version of the workbench
-    InvestJob.clearStore();
-    recentJobs = recentJobs.map((job) => {
-      if (job.modelID === undefined) {
-        job.modelID = job.modelRunName;
-        job.modelTitle = job.modelHumanName;
-        delete job.modelRunName;
-        delete job.modelHumanName;
-        InvestJob.saveJob(job);
-      }
-      return job;
-    });
     this.setState({
       // filter out models that do not exist in current version of invest
       recentJobs: recentJobs.filter((job) => (

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -62,7 +62,21 @@ export default class App extends React.Component {
   /** Initialize the list of invest models, recent invest jobs, etc. */
   async componentDidMount() {
     const investList = await this.updateInvestList();
-    const recentJobs = await InvestJob.getJobStore();
+    let recentJobs = await InvestJob.getJobStore();
+    // Migrate old-style jobs
+    // We can eventually remove this code once it's likely that most users
+    // will have updated and ran a newer version of the workbench
+    InvestJob.clearStore();
+    recentJobs = recentJobs.map((job) => {
+      if (job.modelID === undefined) {
+        job.modelID = job.modelRunName;
+        job.modelTitle = job.modelHumanName;
+        delete job.modelRunName;
+        delete job.modelHumanName;
+        InvestJob.saveJob(job);
+      }
+      return job;
+    });
     this.setState({
       // filter out models that do not exist in current version of invest
       recentJobs: recentJobs.filter((job) => (

--- a/workbench/src/renderer/app.jsx
+++ b/workbench/src/renderer/app.jsx
@@ -62,7 +62,7 @@ export default class App extends React.Component {
   /** Initialize the list of invest models, recent invest jobs, etc. */
   async componentDidMount() {
     const investList = await this.updateInvestList();
-    let recentJobs = await InvestJob.getJobStore();
+    const recentJobs = await InvestJob.getJobStore();
     this.setState({
       // filter out models that do not exist in current version of invest
       recentJobs: recentJobs.filter((job) => (


### PR DESCRIPTION
## Description
Fixes #1922 

Updates the job property names in any old job data, mapping `modelRunName` to `modelID` and `modelHumanName` to `modelTitle`, and re-saves them in the new format.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
