### PR TITLE
Fix the requests to geometamaker endpoints

### DIFF
--- a/workbench/src/renderer/server_requests.js
+++ b/workbench/src/renderer/server_requests.js
@@ -273,8 +273,9 @@ export async function getSupportedLanguages() {
  * @returns {Promise} resolves object
  */
 export async function getGeoMetaMakerProfile() {
+  const port = await getCorePort();
   return (
-    window.fetch(`${HOSTNAME}:${PORT}/${PREFIX}/get_geometamaker_profile`, {
+    window.fetch(`${HOSTNAME}:${port}/${PREFIX}/get_geometamaker_profile`, {
       method: 'get',
     })
       .then((response) => response.json())
@@ -300,8 +301,9 @@ export async function getGeoMetaMakerProfile() {
  * @returns {Promise} resolves object
  */
 export async function setGeoMetaMakerProfile(payload) {
+  const port = await getCorePort();
   return (
-    window.fetch(`${HOSTNAME}:${PORT}/${PREFIX}/set_geometamaker_profile`, {
+    window.fetch(`${HOSTNAME}:${port}/${PREFIX}/set_geometamaker_profile`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers: { 'Content-Type': 'application/json' },

--- a/workbench/tests/invest/flaskapp.test.js
+++ b/workbench/tests/invest/flaskapp.test.js
@@ -149,6 +149,31 @@ describe('requests to flask endpoints', () => {
       break;
     }
   });
+
+  test('get geometamaker profile', async () => {
+    const profile = await serverRequests.getGeoMetaMakerProfile();
+    expect(profile).toHaveProperty('contact');
+    expect(profile).toHaveProperty('license');
+  });
+
+  test('set geometamaker profile', async () => {
+    const result = {
+      message: 'Metadata profile saved',
+      error: false,
+    };
+    jest.spyOn(window, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(result),
+      });
+
+    const payload = {
+      contact: {},
+      license: {},
+    };
+    const response = await serverRequests.setGeoMetaMakerProfile(payload);
+    expect(response).toStrictEqual(result);
+  });
 });
 
 /** Some tests make http requests to check that links are status 200.


### PR DESCRIPTION
We didn't use the new `port` variable in these requests. And we didn't have any tests to catch this bug, so I added a couple.
Fixes #1936 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
