### PR TITLE
Bugfix for NDR: OverflowError when filling nodata

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -86,6 +86,8 @@ NDR
 ====
 * ``stream.tif`` is now saved in the main output folder rather than the
   intermediate folder (`#1864 <https://github.com/natcap/invest/issues/1864>`_).
+* Fixed a bug where input rasters (e.g. LULC) without a defined nodata value could
+  cause an OverflowError. (`#1904 <https://github.com/natcap/invest/issues/1904>`_).
 
 Seasonal Water Yield
 ====================

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -376,6 +376,39 @@ class NDRTests(unittest.TestCase):
         if mismatch_list:
             raise RuntimeError("results not expected: %s" % mismatch_list)
 
+    def test_mask_raster_nodata_overflow(self):
+        """NDR test when target nodata value overflows source dtype."""
+        from natcap.invest.ndr import ndr
+
+        source_raster_path = os.path.join(self.workspace_dir, 'source.tif')
+        target_raster_path = os.path.join(
+            self.workspace_dir, 'target.tif')
+        source_dtype = numpy.int8
+        target_dtype = gdal.GDT_Int32
+        target_nodata = numpy.iinfo(numpy.int32).min
+
+        pygeoprocessing.numpy_array_to_raster(
+            base_array=numpy.full((4, 4), 1, dtype=source_dtype),
+            target_nodata=None,
+            pixel_size=(1, -1),
+            origin=(0, 0),
+            projection_wkt=None,
+            target_path=source_raster_path)
+
+        ndr._mask_raster(
+            source_raster_path=source_raster_path,
+            mask_raster_path=source_raster_path,  # mask=source for convenience
+            target_masked_raster_path=target_raster_path,
+            target_nodata=target_nodata,
+            target_dtype=target_dtype)
+
+        # Mostly we're testing that _mask_raster did not raise an OverflowError,
+        # but we can assert the results anyway.
+        array = pygeoprocessing.raster_to_numpy_array(target_raster_path)
+        numpy.testing.assert_array_equal(
+            array,
+            numpy.full((4, 4), 1, dtype=numpy.int32))  # matches target_dtype
+
     def test_validation(self):
         """NDR test argument validation."""
         from natcap.invest import validation


### PR DESCRIPTION
`_mask_raster` was trying to fill a numpy array with a module-defined (as opposed to user-defined) default nodata value, but using the source raster's native dtype for the array.

This only occurred when the source raster didn't have it's own nodata value defined. Depending on the source raster's datatype, the default nodata value might overflow it.

Since `_mask_raster` is always specifying the target dtype for the raster, it didn't make sense to use the source raster's dtype to initialize the numpy array.

Also, since we're always specifying the target dtype, I didn't see a reason to try to re-use the source raster's nodata value. So I changed the parameter from `default_nodata` to `target_nodata`.

Fixes #1904 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
