### PR TITLE
Mitigate setuptools invalid metadata for twine upload

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -42,7 +42,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: pip install twine
+        run: |
+          # Workaround for setuptools generating invalid metadata
+          # https://github.com/natcap/invest/issues/1913
+          pip install "twine>=6.1.0"
+          pip install -U packaging
 
       - name: Extract version from autorelease branch name
         if: ${{ github.head_ref }}


### PR DESCRIPTION
## Description
In the autorelease part 2 step, twine uploads were failing on a invalid metadata from setuptools. Specifically the `license-files` attribute. Twine seems to have a mitigation for this in 6.1.0, but requires `packaging` 24.2 to work. So, it seems like the most straightforward patch is to update the `packaging` library.

Another possible workaround might be to include
```python
[tools.setuptools]
license-files = [License.txt]
```
In `pyproject.toml`. But, since we have `license-files` listed under `[project]`, I wasn't sure how this would resolve.
Fixes #1913 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
