### PR TITLE
Ignore semantic versioning check to allow alpha release tag

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -101,6 +101,7 @@ jobs:
         uses: BellCubeDev/update-package-version-by-release-tag@v2
         with:
           version: ${{ inputs.version }}
+          ignore-semver-check: false  # allow PEP 440 alpha/beta/rc releases
           package-json-path: workbench/package.json
 
       - name: Commit updated HISTORY.rst, changelog.html, and package.json


### PR DESCRIPTION
## Description
Updating an option in the release workflow to allow the alpha release tag.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
