### PR TITLE
"Add a plugin" form updates: user acknowledgment checkbox, form validation

### DIFF
--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -275,7 +275,7 @@ export default function PluginModal(props) {
           </Form.Group>
           <Form.Group>
             <Form.Check
-              id="user-acknowledgement-checkbox"
+              id="user-acknowledgment-checkbox"
               label={t('I acknowledge and accept the risks associated with installing this plugin.')}
               value={userAcknowledgment}
               onChange={(event) => setUserAcknowledgment(event.target.checked)}

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -13,6 +13,7 @@
 */
 body {
   --invest-green: #148F68;
+  --color-error: #f13232;
   --header-height: 64px;
   --content-height: calc(100vh - var(--header-height));
   min-height: 100vh;
@@ -327,7 +328,7 @@ exceed 100% of window.*/
 }
 
 .card-footer .status-error {
-  color: red;
+  color: var(--color-error);
 }
 
 .card-footer .status-success {
@@ -591,11 +592,11 @@ input[type=text]::placeholder {
 }
 
 #log-display .invest-log-primary-warning {
-  color: #f13232;
+  color: var(--color-error);
 }
 
 #log-display .invest-log-error {
-  color: #f13232;
+  color: var(--color-error);
   font-weight: bold;
 }
 
@@ -703,13 +704,35 @@ input[type=text]::placeholder {
 }
 
 .plugin-error {
+  color: var(--color-error);
+}
+
+.plugin-install-remove-error {
   font-family: monospace;
   margin: 1rem;
   overflow-wrap: break-word;
-  color: #f13232;
   font-weight: bold;
+}
+
+.plugin-source-missing-error,
+.plugin-user-acknowledgment-error {
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0.5rem 0 0;
+}
+
+.plugin-user-acknowledgment-error {
+  margin-bottom: 1rem;
+}
+
+.plugin-form-text {
+  font-size: 0.875rem;
 }
 
 code {
   color: inherit;
+}
+
+.text-italic {
+  font-style: italic;
 }

--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -322,27 +322,29 @@ test.skip('Install and run a plugin', async () => {
   });
   await page.screenshot({ path: `${SCREENSHOT_PREFIX}1-page-load.png` });
   const downloadModal = await page.waitForSelector('.modal-dialog');
-  const downloadModalCancel = await downloadModal.waitForSelector(
-    'aria/[name="close modal"][role="button"]'
+  const downloadModalClose = await downloadModal.waitForSelector(
+    'aria/[name="Close modal"][role="button"]'
   );
   await page.waitForTimeout(WAIT_TO_CLICK); // waiting for click handler to be ready
-  await downloadModalCancel.click();
+  await downloadModalClose.click();
   const changelogModal = await page.waitForSelector('.modal-dialog');
-  const changelogModalCancel = await changelogModal.waitForSelector(
+  const changelogModalClose = await changelogModal.waitForSelector(
     'aria/[name="Close modal"][role="button"]'
   );
   await page.waitForTimeout(WAIT_TO_CLICK);
-  await changelogModalCancel.click();
+  await changelogModalClose.click();
 
   const dropdownButton = await page.waitForSelector('aria/[name="menu"][role="button"]');
   await dropdownButton.click();
-  const pluginsModalButton = await page.waitForSelector('aria/[name="Manage plugins"][role="button"]');
+  const pluginsModalButton = await page.waitForSelector('aria/[name="Manage Plugins"][role="button"]');
   await pluginsModalButton.click();
   console.log('opened plugin modal');
   const urlInputField = await page.waitForSelector('aria/[name="Git URL"][role="textbox"]');
   console.log('found url field');
   await urlInputField.type(TEST_PLUGIN_GIT_URL, { delay: TYPE_DELAY });
   console.log('typed into input field');
+  const userAcknowledgmentCheckbox = await page.waitForSelector('#user-acknowledgment-checkbox');
+  await userAcknowledgmentCheckbox.click();
   const submitButton = await page.waitForSelector('aria/[name="Add"][role="button"]');
   console.log('found submit button');
   console.log(submitButton);

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -75,13 +75,13 @@ describe('Add plugin modal', () => {
 
       await userEvent.click(await findByRole('button', { name: 'menu' }));
       const managePluginsButton = await findByText(/Manage plugins/i);
-      userEvent.click(managePluginsButton);
+      await userEvent.click(managePluginsButton);
 
       const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
-      userEvent.click(userAcknowledgmentCheckbox);
+      await userEvent.click(userAcknowledgmentCheckbox);
 
       const submitButton = await findByText('Add');
-      userEvent.click(submitButton);
+      await userEvent.click(submitButton);
 
       const missingUrlError = await findByText('Error: URL is required.');
       expect(missingUrlError).toBeInTheDocument();
@@ -96,16 +96,16 @@ describe('Add plugin modal', () => {
 
       await userEvent.click(await findByRole('button', { name: 'menu' }));
       const managePluginsButton = await findByText(/Manage plugins/i);
-      userEvent.click(managePluginsButton);
+      await userEvent.click(managePluginsButton);
 
       const sourceType = await findByLabelText('Install from');
-      userEvent.selectOptions(sourceType, 'local path');
+      await userEvent.selectOptions(sourceType, 'local path');
 
       const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
-      userEvent.click(userAcknowledgmentCheckbox);
+      await userEvent.click(userAcknowledgmentCheckbox);
 
       const submitButton = await findByText('Add');
-      userEvent.click(submitButton);
+      await userEvent.click(submitButton);
 
       const missingPathError = await findByText('Error: Path is required.');
       expect(missingPathError).toBeInTheDocument();
@@ -120,13 +120,13 @@ describe('Add plugin modal', () => {
 
       await userEvent.click(await findByRole('button', { name: 'menu' }));
       const managePluginsButton = await findByText(/Manage plugins/i);
-      userEvent.click(managePluginsButton);
+      await userEvent.click(managePluginsButton);
 
       const urlField = await findByLabelText('Git URL');
       await userEvent.type(urlField, 'fake url', { delay: 0 });
 
       const submitButton = await findByText('Add');
-      userEvent.click(submitButton);
+      await userEvent.click(submitButton);
 
       const userAcknowledgmentError = await findByText(/Error: Before installing a plugin/i);
       expect(userAcknowledgmentError).toBeInTheDocument();
@@ -157,14 +157,15 @@ describe('Add plugin modal', () => {
 
     await userEvent.click(await findByRole('button', { name: 'menu' }));
     const managePluginsButton = await findByText(/Manage plugins/i);
-    userEvent.click(managePluginsButton);
+    await userEvent.click(managePluginsButton);
 
     const urlField = await findByLabelText('Git URL');
     await userEvent.type(urlField, 'fake url', { delay: 0 });
     const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
-    userEvent.click(userAcknowledgmentCheckbox);
+    await userEvent.click(userAcknowledgmentCheckbox);
 
     const submitButton = await findByText('Add');
+    // The following event is synchronous bc awaiting it causes the test to fail.
     userEvent.click(submitButton);
 
     await findByText('Adding...');

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -1,18 +1,20 @@
-import { ipcRenderer } from 'electron';
 import React from 'react';
+import { ipcRenderer } from 'electron';
+import '@testing-library/jest-dom';
 import {
-  within, render, waitFor
+  within, render, waitFor,
+  findByText
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import '@testing-library/jest-dom';
+
 import { ipcMainChannels } from '../../src/main/ipcMainChannels';
-import App from '../../src/renderer/app';
 import {
   getSpec,
   getInvestModelIDs,
   fetchArgsEnabled,
   fetchValidation
 } from '../../src/renderer/server_requests';
+import App from '../../src/renderer/app';
 
 jest.mock('../../src/renderer/server_requests');
 
@@ -45,7 +47,95 @@ describe('Add plugin modal', () => {
     getInvestModelIDs.mockResolvedValue({});
   });
 
-  test('Interface to add a plugin', async () => {
+  describe('"Add a plugin" form validation', () => {
+    let spy;
+
+    beforeEach(async () => {
+      spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
+        if (channel === ipcMainChannels.GET_SETTING) {
+          if (setting === 'plugins') {
+            return Promise.resolve({
+              foo: {
+                modelTitle: 'Foo',
+                type: 'plugin',
+              },
+            });
+          }
+        } else if (channel === ipcMainChannels.HAS_MSVC) {
+          return Promise.resolve(true);
+        }
+        return Promise.resolve();
+      });
+    });
+
+    test('Should render an error on submit if git URL is empty', async () => {
+      const {
+        findByText, findByLabelText, findByRole,
+      } = render(<App />);
+
+      await userEvent.click(await findByRole('button', { name: 'menu' }));
+      const managePluginsButton = await findByText(/Manage plugins/i);
+      userEvent.click(managePluginsButton);
+
+      const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
+      userEvent.click(userAcknowledgmentCheckbox);
+
+      const submitButton = await findByText('Add');
+      userEvent.click(submitButton);
+
+      const missingUrlError = await findByText('Error: URL is required.');
+      expect(missingUrlError).toBeInTheDocument();
+
+      expect(spy).not.toHaveBeenCalledWith(ipcMainChannels.ADD_PLUGIN);
+    });
+
+    test('Should render an error on submit if local path is empty', async () => {
+      const {
+        findByText, findByLabelText, findByRole,
+      } = render(<App />);
+
+      await userEvent.click(await findByRole('button', { name: 'menu' }));
+      const managePluginsButton = await findByText(/Manage plugins/i);
+      userEvent.click(managePluginsButton);
+
+      const sourceType = await findByLabelText('Install from');
+      userEvent.selectOptions(sourceType, 'local path');
+
+      const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
+      userEvent.click(userAcknowledgmentCheckbox);
+
+      const submitButton = await findByText('Add');
+      userEvent.click(submitButton);
+
+      const missingPathError = await findByText('Error: Path is required.');
+      expect(missingPathError).toBeInTheDocument();
+
+      expect(spy).not.toHaveBeenCalledWith(ipcMainChannels.ADD_PLUGIN);
+    });
+
+    test('Should render an error on submit if user acknowledgment is unchecked', async () => {
+      const {
+        findByText, findByLabelText, findByRole,
+      } = render(<App />);
+
+      await userEvent.click(await findByRole('button', { name: 'menu' }));
+      const managePluginsButton = await findByText(/Manage plugins/i);
+      userEvent.click(managePluginsButton);
+
+      const urlField = await findByLabelText('Git URL');
+      await userEvent.type(urlField, 'fake url', { delay: 0 });
+
+      const submitButton = await findByText('Add');
+      userEvent.click(submitButton);
+
+      const userAcknowledgmentError = await findByText(/Error: Before installing a plugin/i);
+      expect(userAcknowledgmentError).toBeInTheDocument();
+
+      expect(spy).not.toHaveBeenCalledWith(ipcMainChannels.ADD_PLUGIN);
+    });
+  });
+
+  test('Add a plugin', async () => {
     const spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
@@ -71,6 +161,9 @@ describe('Add plugin modal', () => {
 
     const urlField = await findByLabelText('Git URL');
     await userEvent.type(urlField, 'fake url', { delay: 0 });
+    const userAcknowledgmentCheckbox = await findByLabelText(/I acknowledge and accept/i);
+    userEvent.click(userAcknowledgmentCheckbox);
+
     const submitButton = await findByText('Add');
     userEvent.click(submitButton);
 


### PR DESCRIPTION
## Description
Resolves #1941 by adding a plugin installation risk statement and checkbox, along with form validation and error messages.

I did not update HISTORY, since this is part of the plugins feature rather than a standalone update.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)

## Screenshots
### Full plugin modal with new risk statement & acknowledgment checkbox
<img width="539" alt="add-plugin-risk-statement_2025-05-27" src="https://github.com/user-attachments/assets/d1b973cd-ef91-4e42-bd42-4b5cd75d3fe8" />

### Example form validation scenario: git URL empty, checkbox unchecked
<img width="538" alt="add-plugin-url-and-acknowledgment-errors_2025-05-27" src="https://github.com/user-attachments/assets/71f726f1-c589-4612-824c-e682d396f2a4" />

### Example form validation scenario: path empty, checkbox checked
<img width="539" alt="add-plugin-path-error_2025-05-27" src="https://github.com/user-attachments/assets/511f4e88-565c-4083-b46a-34e7bd23eb6a" />
