### PR TITLE
add RasterOutput class and expand on another docstring

### DIFF
--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -320,7 +320,7 @@ class RasterInput(FileInput):
     This represents a raster file input (all GDAL-supported raster file types
     are allowed), which may have multiple bands.
     """
-    bands: typing.Iterable[RasterBand] = dataclasses.field(default_factory=[])
+    bands: typing.Iterable[RasterBand] = dataclasses.field(default_factory=list)
     """An iterable of `RasterBand` representing the bands expected to be in
     the raster."""
 
@@ -1129,7 +1129,7 @@ class RasterOutput(Output):
     This represents a raster file output (all GDAL-supported raster file types
     are allowed), which may have multiple bands.
     """
-    bands: typing.Iterable[RasterBand] = dataclasses.field(default_factory=[])
+    bands: typing.Iterable[RasterBand] = dataclasses.field(default_factory=list)
     """An iterable of `RasterBand` representing the bands expected to be in
     the raster."""
 

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -297,7 +297,7 @@ class FileInput(Input):
 
 
 @dataclasses.dataclass
-class RasterBand(FileInput):
+class RasterBand():
     """A single-band raster input, or parameter, of an invest model.
 
     This represents a raster file input (all GDAL-supported raster file types

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1179,7 +1179,7 @@ class DirectoryOutput(Output):
     or an unknown number of file-based outputs, by grouping them together in a
     directory.
     """
-    contents: typing.Union[typing.Iterable[Input], None] = None
+    contents: typing.Union[typing.Iterable[Output], None] = None
     """An iterable of `Output`s representing the contents of this directory.
     The `key` of each output must be the file name or pattern."""
 

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -190,7 +190,16 @@ class Input:
     """Input identifier that should be unique within a model"""
 
     name: str = ''
-    """User-facing name for the input"""
+    """The user-facing name of the input. The workbench UI displays this
+    property as a label for each input. The name should be as short as
+    possible. Any extra description should go in ``about``. The name should
+    be all lower-case, except for things that are always capitalized (acronyms,
+    proper names).
+
+    Good examples: ``precipitation``, ``Kc factor``, ``valuation table``
+
+    Bad examples: ``PRECIPITATION``, ``kc_factor``, ``table of valuation parameters``
+    """
 
     about: str = ''
     """User-facing description of the input"""
@@ -1111,6 +1120,18 @@ class SingleBandRasterOutput(Output):
 
     units: typing.Union[pint.Unit, None] = None
     """units of measurement of the raster values"""
+
+
+@dataclasses.dataclass
+class RasterOutput(Output):
+    """A raster output, or result, of an invest model.
+
+    This represents a raster file output (all GDAL-supported raster file types
+    are allowed), which may have multiple bands.
+    """
+    bands: typing.Iterable[RasterBand] = dataclasses.field(default_factory=[])
+    """An iterable of `RasterBand` representing the bands expected to be in
+    the raster."""
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Description
Adding a `RasterOutput` class to represent multiband raster outputs. Also sneaking in a better docstring for another class attribute!

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
