### PR TITLE
Miscellaneous styling updates, mostly related to not-yet-released features

### DIFF
--- a/workbench/src/renderer/components/AppMenu/index.jsx
+++ b/workbench/src/renderer/components/AppMenu/index.jsx
@@ -11,7 +11,7 @@ export default function AppMenu(props) {
     <Dropdown>
       <Dropdown.Toggle
         className="app-menu-button"
-        aria-label="menu"
+        aria-label={t('menu')}
         childBsPrefix="outline-secondary"
       >
         <GiHamburgerMenu />
@@ -24,31 +24,31 @@ export default function AppMenu(props) {
           as="button"
           onClick={props.openPluginModal}
         >
-          Manage Plugins
+          {t('Manage Plugins')}
         </Dropdown.Item>
         <Dropdown.Item
           as="button"
           onClick={props.openDownloadModal}
         >
-          Download Sample Data
+          {t('Download Sample Data')}
         </Dropdown.Item>
         <Dropdown.Item
           as="button"
           onClick={props.openMetadataModal}
         >
-          Configure Metadata
+          {t('Configure Metadata')}
         </Dropdown.Item>
         <Dropdown.Item
           as="button"
           onClick={props.openChangelogModal}
         >
-          View Changelog
+          {t('View Changelog')}
         </Dropdown.Item>
         <Dropdown.Item
           as="button"
           onClick={props.openSettingsModal}
         >
-          Settings
+          {t('Settings')}
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>

--- a/workbench/src/renderer/components/AppMenu/index.jsx
+++ b/workbench/src/renderer/components/AppMenu/index.jsx
@@ -18,7 +18,7 @@ export default function AppMenu(props) {
       </Dropdown.Toggle>
       <Dropdown.Menu
         align="right"
-        className="shadow"
+        className="app-menu"
       >
         <Dropdown.Item
           as="button"

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -222,10 +222,10 @@ function RecentInvestJobs(props) {
     <Container>
       <Row>
         {recentButtons.length
-          ? <div />
+          ? recentButtons
           : (
             <Card
-              className="text-left recent-job-card mr-2 w-100"
+              className="col-12 text-left recent-job-card mr-2 w-100"
               key="placeholder"
             >
               <Card.Header>
@@ -239,22 +239,20 @@ function RecentInvestJobs(props) {
                 </Card.Title>
               </Card.Body>
             </Card>
-          )}
-        {recentButtons}
+        )}
       </Row>
       {recentButtons.length
-        ? (
-          <Row>
-            <Button
-              variant="secondary"
-              onClick={clearRecentJobs}
-              className="col-12"
-            >
-              {t('Clear all model runs')}
-            </Button>
-          </Row>
-        )
-        : <div />}
+        &&
+        <Row>
+          <Button
+            variant="secondary"
+            onClick={clearRecentJobs}
+            className="col-12"
+          >
+            {t('Clear all model runs')}
+          </Button>
+        </Row>
+      }
     </Container>
   );
 }

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -99,10 +99,10 @@ export default class HomeTab extends React.Component {
             {investButtons}
             <ListGroup.Item
               key="browse"
-              className="py-2 border-0"
+              className="px-0 py-2 border-0"
             >
               <OpenButton
-                className="w-100 border-1 py-2 pl-3 text-left text-truncate"
+                className="open-button text-wrap"
                 openInvestModel={openInvestModel}
                 investList={investList}
               />

--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -10,8 +10,8 @@ import Row from 'react-bootstrap/Row';
 import Button from 'react-bootstrap/Button';
 import { useTranslation } from 'react-i18next';
 import {
-  MdClose,
-} from 'react-icons/md';
+  BsTrash3,
+} from 'react-icons/bs';
 
 import OpenButton from '../OpenButton';
 import InvestJob from '../../InvestJob';
@@ -173,19 +173,21 @@ function RecentInvestJobs(props) {
       }
       recentButtons.push(
         <Card
-          className="text-left recent-job-card mr-2 w-100"
+          className="col-12 text-left recent-job-card mr-2 w-100"
           key={job.hash}
         >
           <Card.Header>
-            {badge}
+            <div className="badge-container">
+              {badge}
+            </div>
             <span className="header-title">{job.modelTitle}</span>
             <Button
               variant="outline-light"
               onClick={() => deleteJob(job.hash)}
-              className="float-right p-1 mr-1 border-0"
+              className="float-right border-0"
               aria-label="delete"
             >
-              <MdClose />
+              <BsTrash3 size="1.5rem" />
             </Button>
           </Card.Header>
           <Card.Body
@@ -246,7 +248,7 @@ function RecentInvestJobs(props) {
             <Button
               variant="secondary"
               onClick={clearRecentJobs}
-              className="mr-2 w-100"
+              className="col-12"
             >
               {t('Clear all model runs')}
             </Button>

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -347,7 +347,7 @@ exceed 100% of window.*/
 }
 
 .card-title {
-  padding-left: 1.25rem;
+  padding: 0 1.25rem;
   font-size: 1.1rem;
 }
 
@@ -364,7 +364,7 @@ exceed 100% of window.*/
   display: flex;
   justify-content: space-between;
   white-space: nowrap;
-  padding-right: 1rem;
+  padding: 0.75rem 1.25rem;
 }
 
 .card-footer span {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -1,5 +1,6 @@
 :root {
   font-size: 16px;
+  --bootstrap-secondary-gray:#6c757d;
 }
 
 
@@ -157,7 +158,7 @@ body {
 }
 
 .app-menu-button {
-  color: gray;
+  color: var(--bootstrap-secondary-gray);
   background-color: transparent;
   border: none;
   font-size: 2rem;
@@ -167,7 +168,7 @@ body {
 
 .app-menu-button:hover{
   color: white;
-  background-color: gray;
+  background-color: var(--bootstrap-secondary-gray);
 }
 
 .app-menu-button:after {
@@ -324,7 +325,7 @@ exceed 100% of window.*/
 }
 
 .card-title .text-heading {
-  color: gray;
+  color: var(--bootstrap-secondary-gray);
 }
 
 .card-title .text-mono {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -194,9 +194,12 @@ button,
   }
 }
 
-.dropdown-menu {
-  /* !important needed to override Bootstrap-defined box-shadow */
-  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .5) !important;
+.app-menu {
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .5);
+  & .dropdown-item {
+    height: 2.5rem;
+    font-weight: 500;
+  }
 }
 
 .language-icon {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -162,17 +162,19 @@ body {
   background-color: transparent;
   border: none;
   font-size: 2rem;
-  vertical-align: text-bottom;
   margin-right: 2px;
-}
+  height: 2.75rem;
+  display: flex;
+  align-items: center;
 
-.app-menu-button:hover{
-  color: white;
-  background-color: var(--bootstrap-secondary-gray);
-}
+  &:hover {
+    color: white;
+    background-color: var(--bootstrap-secondary-gray);
+  }
 
-.app-menu-button:after {
-  display: none;
+  &:after {
+    display: none;  /* Hide caret icon inserted by Bootstrap. */
+  }
 }
 
 .language-icon {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -242,13 +242,11 @@ exceed 100% of window.*/
 .recent-job-card-col {
   height: var(--content-height);
   overflow-y: auto;
-  padding-right: 0.5rem;
 }
 
 .recent-job-card-col .container {
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
-  padding-right: 0.5rem;
 }
 
 .recent-job-card-col .container .row {
@@ -256,7 +254,6 @@ exceed 100% of window.*/
 }
 
 .recent-job-card {
-  width: inherit;
   padding: 0;
   height: fit-content;
   filter: drop-shadow(2px 2px 2px grey);
@@ -274,25 +271,53 @@ exceed 100% of window.*/
 }
 
 .card-header {
+  --card-header-title-font-size: 1.25rem;
+  --card-header-title-line-height: 1.2;
+  --card-header-button-height: 2.625rem;
+  --card-header-button-offset: 0.375rem;
+  --card-header-top-bottom-padding: calc(
+    var(--card-header-button-offset)
+    + var(--card-header-button-height) / 2
+    - (var(--card-header-title-font-size) * var(--card-header-title-line-height)) / 2
+  );
+  position: relative;
+  display: flex;
   background-color: var(--invest-green);
   filter: opacity(0.75);
-  margin-left: -0.1rem;
-  margin-right: -0.05rem;
-  padding-right: 0;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
+  padding: var(--card-header-top-bottom-padding) 3.375rem var(--card-header-top-bottom-padding) 1.25rem;
+  min-height: calc(var(--card-header-button-height) + 2*var(--card-header-button-offset));
+  /* Adjust width & margins to correct the optical illusion created by the card border. */
+  width: calc(100% + 1.5px);
+  margin-right: -1px;
+  margin-top: -1px;
+  margin-left: -0.5px;
 
-.card-header .header-title {
-  color: white;
-  font-size: 1.35rem;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-}
+  & .badge-container {
+    display: flex;
+    align-items: center;
+    margin-right: 0.375rem;
+    height: calc(var(--card-header-title-font-size) * var(--card-header-title-line-height));
+  }
 
-.card-header .btn:hover {
-  background-color: white;
-  color: var(--invest-green);
+  & .header-title {
+    color: white;
+    font-size: var(--card-header-title-font-size);
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    line-height: var(--card-header-title-line-height);
+  }
+
+  & .btn {
+    position: absolute;
+    right: var(--card-header-button-offset);
+    top: var(--card-header-button-offset);
+    height: var(--card-header-button-height);
+    padding: 0.5rem;
+    &:hover {
+      background-color: white;
+      color: var(--invest-green);
+    }
+  }
 }
 
 .card-title {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -183,6 +183,8 @@ button,
   height: 2.75rem;
   display: flex;
   align-items: center;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 
   &:hover {
     color: white;

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -241,6 +241,12 @@ exceed 100% of window.*/
   margin-bottom: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  & .open-button {
+    font-weight: 600;
+    border-width: 0.125rem;
+    padding: 0.5rem 1.25rem;
+  }
 }
 
 .invest-button {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -194,6 +194,11 @@ button,
   }
 }
 
+.dropdown-menu {
+  /* !important needed to override Bootstrap-defined box-shadow */
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .5) !important;
+}
+
 .language-icon {
   color: black;
   font-size: 1rem;

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -1,5 +1,7 @@
 :root {
   font-size: 16px;
+  --invest-green: #148F68;
+  --digital-red: #B1040E;
   --bootstrap-secondary-gray:#6c757d;
 }
 
@@ -13,8 +15,6 @@
   to appear with height: 100%, even when parent has a fixed height;
 */
 body {
-  --invest-green: #148F68;
-  --color-error: #f13232;
   --header-height: 64px;
   --content-height: calc(100vh - var(--header-height));
   min-height: 100vh;
@@ -386,7 +386,7 @@ exceed 100% of window.*/
 }
 
 .card-footer .status-error {
-  color: var(--color-error);
+  color: var(--digital-red);
 }
 
 .card-footer .status-success {
@@ -650,11 +650,11 @@ input[type=text]::placeholder {
 }
 
 #log-display .invest-log-primary-warning {
-  color: var(--color-error);
+  color: var(--digital-red);
 }
 
 #log-display .invest-log-error {
-  color: var(--color-error);
+  color: var(--digital-red);
   font-weight: bold;
 }
 
@@ -762,7 +762,7 @@ input[type=text]::placeholder {
 }
 
 .plugin-error {
-  color: var(--color-error);
+  color: var(--digital-red);
 }
 
 .plugin-install-remove-error {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -359,7 +359,6 @@ exceed 100% of window.*/
 
 .card-title .text-mono {
   font-family: monospace;
-  font-size: 1.1rem;
 }
 
 .card-footer {

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -221,7 +221,6 @@ exceed 100% of window.*/
 .invest-button:hover {
   color: white;
   background-color: var(--invest-green);
-  opacity: 75%;
   font-weight: 600;
 }
 
@@ -283,7 +282,6 @@ exceed 100% of window.*/
   position: relative;
   display: flex;
   background-color: var(--invest-green);
-  filter: opacity(0.75);
   padding: var(--card-header-top-bottom-padding) 3.375rem var(--card-header-top-bottom-padding) 1.25rem;
   min-height: calc(var(--card-header-button-height) + 2*var(--card-header-button-offset));
   /* Adjust width & margins to correct the optical illusion created by the card border. */

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -22,6 +22,22 @@ body {
   overflow-y: hidden;
 }
 
+/* Default focus styles for buttons & links, to override system defaults.
+   Bootstrap-styled buttons have different focus styles, based on element/background colors.
+   This is a fallback, to be applied to elements whose focus styles are not defined by Bootstrap. */
+a,
+button,
+.btn-link {
+  &:focus {
+    outline-color: var(--invest-green);
+  }
+}
+
+.btn-link:focus {
+  outline-style: auto;
+  outline-width: 0.25rem;
+}
+
 /*Top Navigation*/
 
 .navbar {
@@ -42,6 +58,7 @@ body {
 .navbar-brand:hover {
   text-decoration-line: underline;
   text-decoration-thickness: 3px;
+  text-decoration-color: var(--invest-green);
 }
 
 .navbar-middle {


### PR DESCRIPTION
## Description
Addresses #1976 by making some updates to the styling of "recent job" cards, the new menu, and the new-and-improved "Browse to a datastack or InVEST logfile" button, along with a few color/opacity changes for stronger contrast/better usability. (Check the individual commit messages for more details!)

I'm not sure if this warrants a note in HISTORY, since these are only styling updates, and most of them are related to not-yet-released features, but I could be convinced if anyone thinks anything here is significant enough to mention.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)

## Screenshots
### Full screen
<img width="1727" alt="full-screen_2025-05-29" src="https://github.com/user-attachments/assets/79a6087c-65cc-4930-9060-2ab128027a42" />

### Window narrow enough for a long-named plugin card title to wrap
<img width="1194" alt="text-wrapping-open-button-plugin-card_2025-05-29" src="https://github.com/user-attachments/assets/f02c9bbe-ae41-4957-9984-8652c3f27bd7" />

### Window narrow enough for a core model card title to wrap
<img width="828" alt="text-wrapping-open-button-core-model-card_2025-05-29" src="https://github.com/user-attachments/assets/4278a0fa-e896-4527-bdc2-d9f6bbec8d20" />

### Updated menu styling
<img width="879" alt="menu-styling_2025-05-29" src="https://github.com/user-attachments/assets/7d630b62-8ef3-446d-b0be-ca48f9460b19" />

### Updated error text color
<img width="538" alt="error-text-color_2025-05-29" src="https://github.com/user-attachments/assets/2981010b-df68-40c7-99b6-8eace1e75491" />

