### PR TITLE
Fix new NDR load type column required attribute

### DIFF
--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -88,7 +88,7 @@ MODEL_SPEC = spec.build_model_spec({
                 "lucode": spec.LULC_TABLE_COLUMN,
                 "load_type_p": {
                     "type": "option_string",
-                    "required": True,
+                    "required": "calc_p",
                     "options": {
                         "application-rate": {
                             "description": gettext(
@@ -111,7 +111,7 @@ MODEL_SPEC = spec.build_model_spec({
                 },
                 "load_type_n": {
                     "type": "option_string",
-                    "required": True,
+                    "required": "calc_n",
                     "options": {
                         "application-rate": {
                             "description": gettext(


### PR DESCRIPTION
## Description
I realized I set these new columns to always being required. They should actually follow the `load_n` and `load_p` columns and only be required if `calc_n` or `calc_p`.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
