### PR TITLE
Workaround for gsutil python 3.13

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -255,8 +255,17 @@ jobs:
         if: github.event_name != 'pull_request' && matrix.os == 'macos-13' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         uses: google-github-actions/setup-gcloud@v2
 
+      # gsutil (part of make deploy) can't use python 3.13 yet, so set up 3.12 for use for now.
+      - name: Set up python 3.12 for gsutil
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+        id: python-312-task
+
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request' && matrix.os == 'macos-13' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        env:
+          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-312-task.outputs.python-path }}
         run: make deploy
 
   validate-resources:


### PR DESCRIPTION
## Description
I think the issue here is that we're running into the same gsutil error with mac and python 3.13. Here's an [example](https://github.com/natcap/invest/actions/runs/15355465721/job/43213430679#step:10:24.) of the failure. So, this PR adds that same gsutil workaround to the Check sdist workflow, since in that workflow we're specifically waiting for the mac and latest python version to deploy.

I'm a bit out of practice in these github workflow environments, so let me know if I"m way off base!

Fixes #1980 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
