### PR TITLE
Workbench: prevent displaying `0` when there are no recent jobs to show

### DIFF
--- a/workbench/src/renderer/components/HomeTab/index.jsx
+++ b/workbench/src/renderer/components/HomeTab/index.jsx
@@ -241,7 +241,7 @@ function RecentInvestJobs(props) {
             </Card>
         )}
       </Row>
-      {recentButtons.length
+      {recentButtons.length > 0
         &&
         <Row>
           <Button


### PR DESCRIPTION
## Description
Corrects conditional logic to prevent displaying `0` when there are no recent jobs to show.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)

## Before
<img width="454" alt="no-recent-jobs-before_2025-06-02" src="https://github.com/user-attachments/assets/71e91c99-0025-4276-a4b9-73b91e06c175" />

## After
<img width="446" alt="no-recent-jobs-after_2025-06-02" src="https://github.com/user-attachments/assets/997ec454-9b11-4681-a48f-b957e2dcb96c" />
