### PR TITLE
Bugfixes for extracting datastack archive

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -74,6 +74,16 @@ General
   https://doi.org/10.60793/natcap-invest-3.16.0.
   (`#1548 <https://github.com/natcap/invest/issues/1548>`_)
 
+Workbench
+=========
+* Fixed a bug where extracting and loading parameters from a datastack archive
+  would overwrite data in the extraction location. Now, a new directory
+  will be created in the chosen extraction location.
+  (`#1996 <https://github.com/natcap/invest/issues/1996>`_)
+* Fixed a bug where the "Open" button on the home page would not
+  open archived datastacks (.tgz) files.
+  (`#1993 <https://github.com/natcap/invest/issues/1993>`_)
+
 
 3.16.0a2 (2025-05-28)
 ---------------------

--- a/workbench/src/main/findBinaries.js
+++ b/workbench/src/main/findBinaries.js
@@ -62,7 +62,7 @@ export function findInvestBinaries(isDevMode) {
 export function findMicromambaExecutable(isDevMode) {
   let micromambaExe;
   if (isDevMode) {
-    micromambaExe = 'micromamba'; // assume that micromamba is available
+    micromambaExe = 'mamba'; // assume that micromamba is available
   } else {
     micromambaExe = `"${upath.join(process.resourcesPath, 'micromamba')}"`;
   }

--- a/workbench/src/main/findBinaries.js
+++ b/workbench/src/main/findBinaries.js
@@ -62,7 +62,7 @@ export function findInvestBinaries(isDevMode) {
 export function findMicromambaExecutable(isDevMode) {
   let micromambaExe;
   if (isDevMode) {
-    micromambaExe = 'mamba'; // assume that micromamba is available
+    micromambaExe = 'micromamba'; // assume that micromamba is available
   } else {
     micromambaExe = `"${upath.join(process.resourcesPath, 'micromamba')}"`;
   }

--- a/workbench/src/renderer/components/DataDownloadModal/index.jsx
+++ b/workbench/src/renderer/components/DataDownloadModal/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from 'i18next';
 
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
@@ -95,7 +96,10 @@ class DataDownloadModal extends React.Component {
     // a directory, so must use OpenDialog.
     const data = await ipcRenderer.invoke(
       ipcMainChannels.SHOW_OPEN_DIALOG,
-      { properties: ['openDirectory'] }
+      {
+        buttonLabel: i18n.t('Choose location to save data'),
+        properties: ['openDirectory'],
+      }
     );
     if (data.filePaths.length) {
       const writable = await ipcRenderer.invoke(

--- a/workbench/src/renderer/components/DataDownloadModal/index.jsx
+++ b/workbench/src/renderer/components/DataDownloadModal/index.jsx
@@ -97,8 +97,10 @@ class DataDownloadModal extends React.Component {
     const data = await ipcRenderer.invoke(
       ipcMainChannels.SHOW_OPEN_DIALOG,
       {
-        buttonLabel: i18n.t('Choose location to save data'),
-        properties: ['openDirectory'],
+        // title is only for Windows, but default 'Open' is misleading
+        title: i18n.t('Choose a directory'),
+        buttonLabel: i18n.t('Download here'),
+        properties: ['openDirectory', 'createDirectory'],
       }
     );
     if (data.filePaths.length) {

--- a/workbench/src/renderer/components/OpenButton/index.jsx
+++ b/workbench/src/renderer/components/OpenButton/index.jsx
@@ -8,6 +8,7 @@ import { withTranslation } from 'react-i18next';
 
 import InvestJob from '../../InvestJob';
 import { fetchDatastackFromFile } from '../../server_requests';
+import { openDatastack } from '../../utils';
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 const { ipcRenderer } = window.Workbench.electron;
@@ -24,18 +25,17 @@ class OpenButton extends React.Component {
   }
 
   async browseFile() {
-    const { t, investList, openInvestModel } = this.props;
+    const { investList, openInvestModel } = this.props;
     const data = await ipcRenderer.invoke(ipcMainChannels.SHOW_OPEN_DIALOG);
     if (!data.canceled) {
       let datastack;
       try {
-        datastack = await fetchDatastackFromFile({ filepath: data.filePaths[0] });
+        datastack = await openDatastack(data.filePaths[0]);
       } catch (error) {
-        logger.error(error);
-        alert( // eslint-disable-line no-alert
-          `${t('No InVEST model data can be parsed from the file:')}\n${data.filePaths[0]}`
-        );
-        return;
+        alert(error);
+      }
+      if (!datastack) {
+        return; // the open dialog was cancelled
       }
       const job = new InvestJob({
         modelID: datastack.model_id,

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -17,7 +17,6 @@ import ArgsForm from './ArgsForm';
 import SaveAsModal from '../SaveAsModal';
 import {
   archiveDatastack,
-  fetchDatastackFromFile,
   fetchValidation,
   fetchArgsEnabled,
   getDynamicDropdowns,

--- a/workbench/src/renderer/utils.js
+++ b/workbench/src/renderer/utils.js
@@ -51,7 +51,7 @@ export async function openDatastack(filepath) {
       const extractLocation = await ipcRenderer.invoke(
         ipcMainChannels.SHOW_OPEN_DIALOG,
         {
-          title: t('Choose location to extract archive'),
+          buttonLabel: t('Choose location to extract archive'),
           properties: ['openDirectory'],
         }
       );

--- a/workbench/src/renderer/utils.js
+++ b/workbench/src/renderer/utils.js
@@ -51,9 +51,10 @@ export async function openDatastack(filepath) {
       const extractLocation = await ipcRenderer.invoke(
         ipcMainChannels.SHOW_OPEN_DIALOG,
         {
+          // title is only for Windows, but default 'Open' is misleading
           title: i18n.t('Choose a directory'),
           buttonLabel: t('Extract archive here'),
-          properties: ['openDirectory, createDirectory'],
+          properties: ['openDirectory', 'createDirectory'],
         }
       );
       if (extractLocation.filePaths.length) {

--- a/workbench/src/renderer/utils.js
+++ b/workbench/src/renderer/utils.js
@@ -51,8 +51,9 @@ export async function openDatastack(filepath) {
       const extractLocation = await ipcRenderer.invoke(
         ipcMainChannels.SHOW_OPEN_DIALOG,
         {
-          buttonLabel: t('Choose location to extract archive'),
-          properties: ['openDirectory'],
+          title: i18n.t('Choose a directory'),
+          buttonLabel: t('Extract archive here'),
+          properties: ['openDirectory, createDirectory'],
         }
       );
       if (extractLocation.filePaths.length) {

--- a/workbench/src/renderer/utils.js
+++ b/workbench/src/renderer/utils.js
@@ -1,6 +1,10 @@
+import i18n from 'i18next';
+
 import { ipcMainChannels } from '../main/ipcMainChannels';
+import { fetchDatastackFromFile } from './server_requests';
 
 const { ipcRenderer } = window.Workbench.electron;
+const { logger } = window.Workbench;
 
 /**
  * Create a JSON string with invest argument keys and values.
@@ -37,4 +41,41 @@ export function openLinkInBrowser(event) {
     ipcMainChannels.OPEN_EXTERNAL_URL,
     event.currentTarget.href
   );
+}
+
+export async function openDatastack(filepath) {
+  const { t } = i18n;
+  let datastack;
+  try {
+    if (filepath.endsWith('gz')) { // .tar.gz, .tgz
+      const extractLocation = await ipcRenderer.invoke(
+        ipcMainChannels.SHOW_OPEN_DIALOG,
+        {
+          title: t('Choose location to extract archive'),
+          properties: ['openDirectory'],
+        }
+      );
+      if (extractLocation.filePaths.length) {
+        const directoryPath = extractLocation.filePaths[0];
+        const writable = await ipcRenderer.invoke(
+          ipcMainChannels.CHECK_FILE_PERMISSIONS, directoryPath);
+        if (writable) {
+          const newDir = filepath.split(/\\+|\/+/).pop()
+            .replace(/\.tgz|\.tar\.gz/gi, '');
+          datastack = await fetchDatastackFromFile({
+            filepath: filepath,
+            extractPath: `${directoryPath}/${newDir}`,
+          });
+        } else {
+          throw new Error(`${t('Permission denied extracting files to:')}\n${directoryPath}`);
+        }
+      }
+    } else {
+      datastack = await fetchDatastackFromFile({ filepath: filepath });
+    }
+  } catch (error) {
+    logger.error(error);
+    throw new Error(`${t('No InVEST model data can be parsed from the file:')}\n${filepath}`);
+  }
+  return datastack;
 }

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -82,6 +82,7 @@ function renderSetupFromSpec(baseSpec, inputFieldOrder, initValues = undefined, 
       sidebarFooterElementId="foo"
       executeClicked={false}
       switchTabs={() => {}}
+      investList={{}}
       tabID={'999'}
       updateJobProperties={() => {}}
     />
@@ -379,9 +380,6 @@ describe('Arguments form interactions', () => {
 describe('UI spec functionality', () => {
   beforeEach(() => {
     fetchValidation.mockResolvedValue([]);
-    fetchArgsEnabled.mockResolvedValue({
-      arg1: true, arg2: true, arg3: true, arg4: true, arg5: true, arg6: true
-    });
   });
 
   test('A UI spec with conditionally enabled args', async () => {
@@ -396,14 +394,6 @@ describe('UI spec functionality', () => {
           name: 'Bfoo',
           type: 'boolean',
         },
-        arg3: {
-          name: 'Cfoo',
-          type: 'number',
-        },
-        arg4: {
-          name: 'Dfoo',
-          type: 'number',
-        },
       },
     };
     fetchArgsEnabled.mockResolvedValue({ arg1: false, arg2: true });
@@ -413,11 +403,11 @@ describe('UI spec functionality', () => {
     const { findByLabelText } = renderSetupFromSpec(spec, inputFieldOrder);
     const arg1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
     const arg2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
-    const arg3 = await findByLabelText((content) => content.startsWith(spec.args.arg3.name));
-    const arg4 = await findByLabelText((content) => content.startsWith(spec.args.arg4.name));
 
     await waitFor(() => {
       expect(arg1).toBeDisabled();
+    });
+    await waitFor(() => {
       expect(arg2).toBeEnabled();
     });
   });
@@ -483,6 +473,10 @@ describe('UI spec functionality', () => {
         },
       },
     };
+
+    fetchArgsEnabled.mockResolvedValue({
+      arg1: true, arg2: true, arg3: true, arg4: true, arg5: true, arg6: true
+    });
 
     // intentionally leaving out arg6, it should not be in the setup form
     const inputFieldOrder = [['arg4'], ['arg3', 'arg2'], ['arg1'], ['arg5']];
@@ -657,7 +651,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDropEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupForm, fileDropEvent);
+    await fireEvent(setupForm, fileDropEvent);
 
     expect(await findByLabelText((content) => content.startsWith(spec.args.arg1.name)))
       .toHaveValue(mockDatastack.args.arg1);
@@ -711,7 +705,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupForm, fileDragEvent);
+    await fireEvent(setupForm, fileDragEvent);
 
     expect(setupForm).toHaveClass('dragging');
 
@@ -719,7 +713,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDropEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupForm, fileDropEvent);
+    await fireEvent(setupForm, fileDropEvent);
 
     expect(await findByLabelText((content) => content.startsWith(spec.args.arg1.name)))
       .toHaveValue(mockDatastack.args.arg1);
@@ -763,12 +757,12 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragEnterEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupForm, fileDragEnterEvent);
+    await fireEvent(setupForm, fileDragEnterEvent);
 
     expect(setupForm).toHaveClass('dragging');
 
     const fileDragLeaveEvent = createEvent.dragLeave(setupForm);
-    fireEvent(setupForm, fileDragLeaveEvent);
+    await fireEvent(setupForm, fileDragLeaveEvent);
 
     expect(setupForm).not.toHaveClass('dragging');
   });
@@ -811,7 +805,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDragEvent);
+    await fireEvent(setupInput, fileDragEvent);
 
     expect(setupForm).not.toHaveClass('dragging');
     expect(setupInput).toHaveClass('input-dragging');
@@ -820,7 +814,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDropEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDropEvent);
+    await fireEvent(setupInput, fileDropEvent);
 
     expect(setupInput).not.toHaveClass('input-dragging');
     expect(setupForm).not.toHaveClass('dragging');
@@ -862,7 +856,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragEnterEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDragEnterEvent);
+    await fireEvent(setupInput, fileDragEnterEvent);
 
     expect(setupInput).toHaveClass('input-dragging');
 
@@ -870,7 +864,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragLeaveEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDragLeaveEvent);
+    await fireEvent(setupInput, fileDragLeaveEvent);
 
     expect(setupInput).not.toHaveClass('input-dragging');
   });
@@ -912,7 +906,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDragEnterEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDragEnterEvent);
+    await fireEvent(setupInput, fileDragEnterEvent);
 
     expect(setupInput).not.toHaveClass('input-dragging');
 
@@ -920,7 +914,7 @@ describe('Form drag-and-drop', () => {
     Object.defineProperty(fileDropEvent, 'dataTransfer', {
       value: { files: [fileValue] },
     });
-    fireEvent(setupInput, fileDropEvent);
+    await fireEvent(setupInput, fileDropEvent);
 
     expect(setupInput).not.toHaveClass('input-dragging');
     expect(setupInput).toHaveValue('');


### PR DESCRIPTION
Fixes #1996 
Fixes #1993 

Loading parameters from an archive via the Workbench will,
1. prompt the user to first choose a datastack to load from, then if an archive was chosen,
2. prompt the user to select a location to extract the data, and
3. create a new folder in that location named from the basename of the datastack file.

* Code for the Home page "browse" button and the model tab's "Load" button has been unified in a `utils.js` function.
* Some tests were updated because these changes seemed to illuminate a race condition in the tests. And some warnings about missing props during tests were resolved.
* In filesystem dialog boxes, button labels are used instead of dialog box headers whenever the default "Open" label is not descriptive enough. Because dialog headers don't seem to exist on MacOS.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
