### PR TITLE
Workbench download sample data progress bar fix

### DIFF
--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -70,6 +70,7 @@ button,
 }
 
 .navbar-right {
+  display: flex;
   max-width: fit-content;
   margin-left: 0.5rem;
   margin-right: -15px;


### PR DESCRIPTION
I'm guessing I messed this up in #1934 , so here's a fix to revert it back. Perhaps not the best UX overall, as mentioned in #1997 , but just maintaining the design we had is okay for now, I think. No change to history because I don't think we released the broken version.

Fixes #1997 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)

![download_alert](https://github.com/user-attachments/assets/7eadebd7-86c4-451a-a409-7ec48e83d4d3)
![flex](https://github.com/user-attachments/assets/54b7af2f-6e56-4a8f-98f8-3e708fd09636)


