### PR TITLE
Update Python version in Makefile env

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,8 @@ Unreleased Changes
 
 General
 =======
+* Updated Python version in Makefile env target from 3.8 to 3.9.
+  (`#1847 <https://github.com/natcap/invest/issues/1847>`_).
 * Fixed a bug where the ``invest`` CLI could raise a circular
   ``ImportError`` while trying to discover available plugins.
   (`#2012 <https://github.com/natcap/invest/issues/2012>`_).

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ fetch: $(GIT_UG_REPO_PATH) $(GIT_SAMPLE_DATA_REPO_PATH) $(GIT_TEST_DATA_REPO_PAT
 env:
 	@echo "NOTE: requires 'requests' be installed in base Python"
 	$(PYTHON) ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-docs.txt > requirements-all.yml
-	$(CONDA) create -p $(ENV) -y -c conda-forge python=3.8 nomkl
+	$(CONDA) create -p $(ENV) -y -c conda-forge python=3.9 nomkl
 	$(CONDA) env update -p $(ENV) --file requirements-all.yml
 	@echo "----------------------------"
 	@echo "To activate the new conda environment and install natcap.invest:"


### PR DESCRIPTION
## Description
Update Python version in Makefile env target from 3.8 to 3.9. 

Resolves pygeoprocessing requiring Python 3.9 or greater. 

Fixes #1847

## Checklist
- [X] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
