### PR TITLE
Move egg_info from to src to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ env:
 # compatible with pip>=7.0.0
 # REQUIRED: Need to remove natcap.invest.egg-info directory so recent versions
 # of pip don't think CWD is a valid package.
-install: $(DIST_DIR)/natcap.invest%.whl
+install: $(BUILD_DIR) $(DIST_DIR)/natcap.invest%.whl
 	-$(RMDIR) natcap.invest.egg-info
 	$(PIP) install --no-deps --isolated --upgrade --no-index --only-binary natcap.invest --find-links=dist "natcap.invest==$(VERSION)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.distutils.egg_info]
+egg_base = "build"
+
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"


### PR DESCRIPTION
## Description
Keep src directory clean by having natcap.invest.egg_info saved in build folder.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
