### PR TITLE
Remove requirement for oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ invest = "natcap.invest.cli:main"
 # available at runtime.
 requires = [
     'setuptools>=61', 'wheel', 'setuptools_scm>=8.0', 'cython>=3.0.0', 'babel',
-    'oldest-supported-numpy; python_version<="3.8"',
-    'numpy>=2; python_version>="3.9"',  # numpy 2 only available for 3.9+
+    'numpy>=2'
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Description
Requirement for oldest-supported-numpy is redundant having removed building and testing for Python version 3.8.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
