### PR TITLE
Get plugin package version programatically rather than from pyproject.toml

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -55,9 +55,10 @@
   1. Highlights
   2. General
   3. Workbench
-  4. InVEST model A
-  5. ...
-  6. InVEST model Z (model names should be sorted A-Z)
+  4. Plugins
+  5. InVEST model A
+  6. ...
+  7. InVEST model Z (model names should be sorted A-Z)
 
 
 Unreleased Changes
@@ -69,7 +70,11 @@ General
   ``ImportError`` while trying to discover available plugins.
   (`#2012 <https://github.com/natcap/invest/issues/2012>`_).
 
-
+Plugins
+=======
+* The plugin package version is now queried programatically using
+  ``importlib`` rather than being read directly from the ``pyproject.toml``
+  (`#2025 <https://github.com/natcap/invest/issues/2025>`_).
 
 3.16.0 (2025-06-04)
 -------------------

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -123,7 +123,6 @@ export function setupAddPlugin(i18n) {
         // Access plugin metadata from the pyproject.toml
         const condaDeps = pyprojectTOML.tool.natcap.invest.conda_dependencies;
         const packageName = pyprojectTOML.tool.natcap.invest.package_name;
-        const version = pyprojectTOML.project.version;
 
         // Create a conda env containing the plugin and its dependencies
         // use timestamp to ensure a unique path
@@ -149,14 +148,19 @@ export function setupAddPlugin(i18n) {
         );
         logger.info('installed plugin into its env');
         event.sender.send('plugin-install-status', i18n.t('Importing plugin...'));
-        // Access plugin metadata from the MODEL_SPEC
+        // Access plugin metadata from the package
         const modelID = execSync(
           `${micromamba} run --prefix "${pluginEnvPrefix}" ` +
           `python -c "import ${packageName}; print(${packageName}.MODEL_SPEC.model_id)"`
         ).toString().trim();
-        const modelTitle= execSync(
+        const modelTitle = execSync(
           `${micromamba} run --prefix "${pluginEnvPrefix}" ` +
           `python -c "import ${packageName}; print(${packageName}.MODEL_SPEC.model_title)"`
+        ).toString().trim();
+        const version = execSync(
+          `${micromamba} run --prefix "${pluginEnvPrefix}" ` +
+          `python -c "from importlib.metadata import version; ` +
+          `print(version('${packageName}'))"`
         ).toString().trim();
 
         // Write plugin metadata to the workbench's config.json


### PR DESCRIPTION
## Description
Fixes #2025 

Use `importlib` to query the package version programatically.

I added a "Plugins" section to HISTORY.rst, since I expect we'll have several updates in this category.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
