### PR TITLE
Disable default conda channels

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -58,8 +58,9 @@ runs:
         environment-file: environment.yml
         environment-name: env
         condarc: |
-              channels:
-                - conda-forge
+          channels:
+            - conda-forge
+            - nodefaults
         init-shell: bash
         cache-environment: true
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ fetch: $(GIT_UG_REPO_PATH) $(GIT_SAMPLE_DATA_REPO_PATH) $(GIT_TEST_DATA_REPO_PAT
 env:
 	@echo "NOTE: requires 'requests' be installed in base Python"
 	$(PYTHON) ./scripts/convert-requirements-to-conda-yml.py requirements.txt requirements-dev.txt requirements-docs.txt > requirements-all.yml
-	$(CONDA) create -p $(ENV) -y -c conda-forge python=3.8 nomkl
+	$(CONDA) create -p $(ENV) -y --override-channels -c conda-forge python=3.8 nomkl
 	$(CONDA) env update -p $(ENV) --file requirements-all.yml
 	@echo "----------------------------"
 	@echo "To activate the new conda environment and install natcap.invest:"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,8 @@ ARG DEBIAN_GDAL_VERSION="3.6"
 
 # The environment.yml file will be built during github actions.
 COPY --chown=$MAMBA_USER:$MAMBA_USER docker/environment.yml /tmp/environment.yml
-RUN micromamba install -y -n base -c conda-forge python==${PYTHON_VERSION} gdal=${DEBIAN_GDAL_VERSION} && \
-        micromamba install -y -n base -c conda-forge -f /tmp/environment.yml && \
+RUN micromamba install -y -n base --override-channels -c conda-forge python==${PYTHON_VERSION} gdal=${DEBIAN_GDAL_VERSION} && \
+        micromamba install -y -n base --override-channels -c conda-forge -f /tmp/environment.yml && \
         micromamba clean --all --yes && \
         /opt/conda/bin/python -m pip install /tmp/*.whl && \
         /opt/conda/bin/python -m pip cache purge && \

--- a/scripts/convert-requirements-to-conda-yml.py
+++ b/scripts/convert-requirements-to-conda-yml.py
@@ -7,7 +7,7 @@ import sys
 
 YML_TEMPLATE = """channels:
 - conda-forge
-- defaults
+- nodefaults
 dependencies:
 {conda_dependencies}
 {pip_dependencies}

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -81,7 +81,7 @@ export function setupAddPlugin(i18n) {
             event.sender.send('plugin-install-status', i18n.t('Creating base environment...'));
             await spawnWithLogging(
               micromamba,
-              ['create', '--yes', '--prefix', `"${baseEnvPrefix}"`, '-c', 'conda-forge', 'git']
+              ['create', '--yes', '--prefix', `"${baseEnvPrefix}"`, '--override-channels', '-c', 'conda-forge', 'git']
             );
           }
 
@@ -133,7 +133,7 @@ export function setupAddPlugin(i18n) {
         const pluginEnvPrefix = upath.join(rootPrefix, `plugin_${Date.now()}`);
         const createCommand = [
           'create', '--yes', '--prefix', `"${pluginEnvPrefix}"`,
-          '-c', 'conda-forge', 'python', 'git'];
+          '--override-channels', '-c', 'conda-forge', 'python', 'git'];
         if (condaDeps) { // include dependencies read from pyproject.toml
           condaDeps.forEach((dep) => createCommand.push(`"${dep}"`));
         }


### PR DESCRIPTION
## Description
Fixes #1802 
Add `nodefaults` or `--override-channels` wherever we use `conda-forge` to make sure that the default channel is not used.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
