### PR TITLE
Bugfix/2055

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -92,6 +92,11 @@ Plugins
 * Plugin environments are now created using the conda-forge channel only.
   The default channel is excluded (`#1802 <https://github.com/natcap/invest/issues/1802>`_).
 
+NDR
+===
+* Fixed a bug where model outputs in D8 mode had some nodata holes resulting
+  from an incorrect nodata check (`#2055 <https://github.com/natcap/invest/issues/2055>`_).
+
 Pollination
 ===========
 * Fixed a bug where pollination in multiple seasons would not

--- a/src/natcap/invest/ndr/retention.h
+++ b/src/natcap/invest/ndr/retention.h
@@ -156,7 +156,7 @@ void calculate_retention(
         } else if (
             is_close(critical_length_i, critical_length_raster.nodata) or
             is_close(retention_efficiency_i, retention_efficiency_raster.nodata) or
-            flow_dir_i == 0  // "nodata" for flow direction
+            is_close(flow_dir_i, flow_dir_raster.nodata)
           ) {
           // if inputs are nodata, retention is undefined.
           retention_raster.set(x_i, y_i, retention_nodata);

--- a/tests/test_ndr.py
+++ b/tests/test_ndr.py
@@ -300,12 +300,12 @@ class NDRTests(unittest.TestCase):
         # results
         for field, expected_value in [
                 ('p_surface_load', 41.826904),
-                ('p_surface_export', 5.100640),
+                ('p_surface_export', 5.279964),
                 ('n_surface_load', 2977.551914),
-                ('n_surface_export', 350.592891),
+                ('n_surface_export', 318.641924),
                 ('n_subsurface_load', 28.558048),
                 ('n_subsurface_export', 12.609187),
-                ('n_total_export', 360.803969)]:
+                ('n_total_export', 330.571134)]:
             val = result_feature.GetField(field)
             if not numpy.isclose(val, expected_value):
                 mismatch_list.append(


### PR DESCRIPTION
## Description
Fixes #2055
Updating a nodata comparison to compare against the raster's actual nodata value instead of a hard coded value.

I tested this on the sample data and confirmed that the nodata gaps have been resolved.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
