### PR TITLE
Specify `NoData` when calculating CC if CC method = `intensity`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,12 @@
   Unreleased Changes
   ------------------
 
+Urban Cooling
+=============
+* Fixed a bug where ``NoData`` in ``cc`` was not correctly set if the Cooling
+  Capacity Calculation Method was set to ``intensity``
+  (`#2079 <https://github.com/natcap/invest/issues/2079>`_).
+
 3.16.1 (2025-07-01)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -74,7 +74,7 @@ Urban Cooling
 =============
 * Model validation now requires that the "UHI effect" is >= 0 degrees Celsius,
   meaning that the urban air temperature is greater than the rural reference
-  temperature. (`#2076 <https://github.com/natcap/invest/issues/2076>`_
+  temperature. (`#2076 <https://github.com/natcap/invest/issues/2076>`_)
 * Fixed a bug where ``NoData`` in ``cc`` was not correctly set if the Cooling
   Capacity Calculation Method was set to ``intensity``
   (`#2079 <https://github.com/natcap/invest/issues/2079>`_).

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -706,7 +706,8 @@ def execute(args):
             kwargs=dict(
                 op=calc_cc_op_intensity,
                 rasters=[task_path_prop_map['building_intensity'][1]],
-                target_path=cc_raster_path),
+                target_path=cc_raster_path,
+                target_nodata=TARGET_NODATA),
             target_path_list=[cc_raster_path],
             dependent_task_list=[
                 task_path_prop_map['building_intensity'][0]],


### PR DESCRIPTION
## Description
`NoData` was not explicitly specified when calculating cooling capacity (in `raster_map` operation), leading to default float nodata value in the output cc raster. However `3.4e38` did not register as `NoData` in the calculation of `HM.tif`, which ultimately caused issues with `T_air.tif` (as `HM` is used in the calculation of `T_air`).

This is similar to a Stormwater bug that was also reported on the forum (#1850).

Fixes #2079

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
