### PR TITLE
UCM: added constraint that UHI parameter must be >= 0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,13 @@ Workbench
 * Fixed a bug where the Workbench showed the incorrect status of a recently
   completed model run. (`#2072 <https://github.com/natcap/invest/issues/2072>`_)
 
+Urban Cooling
+=============
+* Model validation now requires that the "UHI effect" is >= 0 degrees Celsius,
+  meaning that the urban air temperature is greater than the rural reference
+  temperature. (`#2076 <https://github.com/natcap/invest/issues/2076>`_)
+
+
 3.16.1 (2025-07-01)
 -------------------
 

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -161,9 +161,12 @@ MODEL_SPEC = spec.ModelSpec(
             about=gettext(
                 "The magnitude of the urban heat island effect, i.e., the difference"
                 " between the rural reference temperature and the maximum temperature"
-                " observed in the city."
+                " observed in the city. This model is designed for cases where"
+                " UHI is positive, meaning the urban air temperature is greater"
+                " than the rural reference temperature."
             ),
-            units=u.degree_Celsius
+            units=u.degree_Celsius,
+            expression="value >= 0"
         ),
         spec.BooleanInput(
             id="do_energy_valuation",


### PR DESCRIPTION
The model is really only designed for positive UHI values, so we should add validation to this parameter. If a Python user really wants to see what happens when they pass a negative value, I think that's okay.

Fixes #2076 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
