### PR TITLE
Workbench UI: Populate values of `0`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -69,6 +69,9 @@ Workbench
 =========
 * Fixed a bug where the Workbench showed the incorrect status of a recently
   completed model run. (`#2072 <https://github.com/natcap/invest/issues/2072>`_)
+* Fixed a bug where parameter sets containing an argument with a value of 0
+  weren't populating the model's UI for that argument.
+  (`#2075 <https://github.com/natcap/invest/issues/2075>`_)
 
 3.16.1 (2025-07-01)
 -------------------

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -65,7 +65,7 @@ function initializeArgValues(argsSpec, inputFieldOrder, argsDict) {
       }
       argsDropdownOptions[argkey] = argsSpec[argkey].options;
     } else {
-      value = argsDict[argkey] || '';
+      value = argsDict[argkey] === 0 ? "0" : argsDict[argkey] || '';
     }
     argsValues[argkey] = {
       value: value,


### PR DESCRIPTION
## Description
Fixes #2075 

Parameter sets containing an argument with a value of 0 weren't populating the model's UI for that argument. Since zero is falsey, `argsDict[argkey]` was evaluating to `False` in these cases and being replaced with an empty string. 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~- [ ] Updated the user's guide (if needed)~
- [x] Tested the Workbench UI (if relevant)
