### PR TITLE
Try writing to GITHUB_ENV file in append mode

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           import os
           major, minor, bugfix, *_ = os.environ['CURRENT_VERSION'].split('.')
-          with open(os.environ['GITHUB_ENV']) as env_file:
+          with open(os.environ['GITHUB_ENV'], "a") as env_file:
             env_file.write(f'VERSION={major}.{minor}.{int(bugfix) + 1}')
 
       - name: Configure git


### PR DESCRIPTION
## Description
Attempts to solve a write error to the GITHUB_ENV file during a scheduled run of the autorelease part 1 workflow. Opening the file in append mode, hoping that will do the trick.

@emlys , let me know if there's a way to test this without waiting for day of release. Which is fine too.

Fixes #1912 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
