### PR TITLE
Fix missing validation warnings for boolean types in Workbench

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -79,7 +79,7 @@ Workbench
   weren't populating the model's UI for that argument.
   (`#2075 <https://github.com/natcap/invest/issues/2075>`_)
 * Fixed a bug where there was no visual indication for an invalid switch
-  toggle state, which would prohibit running the model. NDR and 
+  toggle state, which would prohibit running the model. NDR and
   Scenario Generator were the only affected models.
   (`#2074 <https://github.com/natcap/invest/issues/2074>`_)
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -78,6 +78,10 @@ Workbench
 * Fixed a bug where parameter sets containing an argument with a value of 0
   weren't populating the model's UI for that argument.
   (`#2075 <https://github.com/natcap/invest/issues/2075>`_)
+* Fixed a bug where there was no visual indication for an invalid switch
+  toggle state, which would prohibit running the model. NDR and 
+  Scenario Generator were the only affected models.
+  (`#2074 <https://github.com/natcap/invest/issues/2074>`_)
 
 Urban Cooling
 =============

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -218,6 +218,8 @@ export default function ArgInput(props) {
       />
     );
   }
+  // show validation message for boolean (switch) types regardless of touched
+  // because touching them necessarily changes their state.
   else if (validationMessage && argSpec.type === 'boolean') {
     feedback = (
       <Feedback
@@ -227,7 +229,6 @@ export default function ArgInput(props) {
       />
     );
   }
-
 
   let fileSelector = <React.Fragment />;
   if (['csv', 'vector', 'raster', 'directory', 'file'].includes(argSpec.type)) {
@@ -260,8 +261,8 @@ export default function ArgInput(props) {
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
-	isValid={enabled && isValid}
-	isInvalid={enabled && validationMessage}
+        isValid={enabled && isValid}
+        isInvalid={enabled && validationMessage}
         disabled={!enabled}
         bsCustomPrefix="form-switch"
       />

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -209,7 +209,7 @@ export default function ArgInput(props) {
   const className = enabled ? null : 'arg-disable';
 
   let feedback = <React.Fragment />;
-  if (validationMessage && touched && argSpec.type !== 'boolean') {
+  if (validationMessage && touched) {
     feedback = (
       <Feedback
         argkey={argkey}

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -250,6 +250,8 @@ export default function ArgInput(props) {
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
+	isValid={enabled && touched && isValid}
+	isInvalid={enabled && validationMessage}
         disabled={!enabled}
         bsCustomPrefix="form-switch"
       />

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -209,7 +209,7 @@ export default function ArgInput(props) {
   const className = enabled ? null : 'arg-disable';
 
   let feedback = <React.Fragment />;
-  if (validationMessage && touched) {
+  if (validationMessage && touched && argSpec.type !== 'boolean') {
     feedback = (
       <Feedback
         argkey={argkey}
@@ -218,6 +218,16 @@ export default function ArgInput(props) {
       />
     );
   }
+  else if (validationMessage && argSpec.type === 'boolean') {
+    feedback = (
+      <Feedback
+        argkey={argkey}
+        argtype={argSpec.type}
+        message={validationMessage}
+      />
+    );
+  }
+
 
   let fileSelector = <React.Fragment />;
   if (['csv', 'vector', 'raster', 'directory', 'file'].includes(argSpec.type)) {
@@ -250,8 +260,7 @@ export default function ArgInput(props) {
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
-        onFocus={handleFocus}  // to update the Touched property for validation
-	isValid={enabled && touched && isValid}
+	isValid={enabled && isValid}
 	isInvalid={enabled && validationMessage}
         disabled={!enabled}
         bsCustomPrefix="form-switch"

--- a/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgInput/index.jsx
@@ -250,6 +250,7 @@ export default function ArgInput(props) {
         name={argkey}
         checked={value}
         onChange={() => updateArgValues(argkey, !value)}
+        onFocus={handleFocus}  // to update the Touched property for validation
 	isValid={enabled && touched && isValid}
 	isInvalid={enabled && validationMessage}
         disabled={!enabled}

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -606,7 +606,6 @@ input[type=text]::placeholder {
 .form-switch {
   transform:scale(1.5);
   transform-origin:0%;
-  /*margin-left: 1rem;*/
   margin-top: 0.6rem;
 }
 

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -605,7 +605,8 @@ input[type=text]::placeholder {
 /* Default sized toggle switch too small */
 .form-switch {
   transform:scale(1.5);
-  margin-left: 1rem;
+  transform-origin:0%;
+  /*margin-left: 1rem;*/
   margin-top: 0.6rem;
 }
 

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -584,6 +584,57 @@ describe('Misc form validation stuff', () => {
         .toBeNull();
     });
   });
+  
+  test('A required boolean displays validation warning', async () => {
+    const spec = {
+      pyname: 'natcap.invest.dummy',
+      args: {
+        arg1: {
+          name: 'Afoo',
+          type: 'boolean',
+          required: true,
+        },
+        arg2: {
+          name: 'Bfoo',
+          type: 'boolean',
+          required: true,
+        },
+      },
+    };
+    //fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: false });
+    fetchValidation.mockResolvedValue(
+      [[Object.keys(spec.args), VALIDATION_MESSAGE]]
+    );
+
+    const inputFieldOrder = [Object.keys(spec.args)];
+
+    const { findByLabelText } = renderSetupFromSpec(
+                                  spec, inputFieldOrder, { arg1: true, arg2: false } );
+    const arg1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
+    const arg2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
+    const input = await findByLabelText(`${spec.args.arg1.name}`);
+    const input2 = await findByLabelText(`${spec.args.arg2.name}`);
+
+    await waitFor(() => {
+      expect(input).toBeChecked();
+    });
+    await waitFor(() => {
+      expect(input2).not.toBeChecked();
+    });
+
+    // A required input with no value is invalid (red outline for boolean
+    // switch), but feedback does not display until the input has been touched.
+    expect(input2).toHaveClass('is-invalid');
+    expect(queryByText(RegExp(VALIDATION_MESSAGE))).toBeNull();
+
+    // Click checked boolean to unchecked
+    await userEvent.click(arg1);
+    await waitFor(() => {
+      expect(input).toHaveClass('is-invalid');
+    });
+    expect(await findByText(RegExp(VALIDATION_MESSAGE)))
+      .toBeInTheDocument();
+  });
 });
 
 describe('Form drag-and-drop', () => {

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -628,9 +628,8 @@ describe('Misc form validation stuff', () => {
         .toBeInTheDocument();
     });
 
-    // An optional input with no value is valid, but green check
-    // does not display until the input has been touched.
-    expect(input2).not.toHaveClass('is-valid', 'is-invalid');
+    // An optional input with no value is valid
+    expect(input2).toHaveClass('is-valid');
 
     // Now toggle required switch on and validation should pass 
     fetchValidation.mockResolvedValue([]);

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -603,7 +603,7 @@ describe('Misc form validation stuff', () => {
     };
     
     fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), VALIDATION_MESSAGE]]
+      [[["arg1"], VALIDATION_MESSAGE]]
     );
     fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
 
@@ -614,9 +614,12 @@ describe('Misc form validation stuff', () => {
     const input1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
     const input2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
 
+    expect(input1).not.toBeChecked();
+    expect(input2).not.toBeChecked();
+
+    // An optional input with no value is valid
     await waitFor(() => {
-      expect(input1).not.toBeChecked();
-      expect(input2).not.toBeChecked();
+      expect(input2).toHaveClass('is-valid');
     });
 
     await waitFor(() => {
@@ -638,9 +641,6 @@ describe('Misc form validation stuff', () => {
       expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
         .toBeNull();
     });
-    
-    // An optional input with no value is valid
-    expect(input2).toHaveClass('is-valid');
   });
 });
 

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -628,9 +628,6 @@ describe('Misc form validation stuff', () => {
         .toBeInTheDocument();
     });
 
-    // An optional input with no value is valid
-    expect(input2).toHaveClass('is-valid');
-
     // Now toggle required switch on and validation should pass 
     fetchValidation.mockResolvedValue([]);
     await userEvent.click(input1);
@@ -641,6 +638,9 @@ describe('Misc form validation stuff', () => {
       expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
         .toBeNull();
     });
+    
+    // An optional input with no value is valid
+    expect(input2).toHaveClass('is-valid');
   });
 });
 

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -598,59 +598,48 @@ describe('Misc form validation stuff', () => {
           name: 'Bfoo',
           type: 'boolean',
           required: false,
-        },
-        arg3: {
-          name: 'Cfoo',
-          type: 'boolean',
-          required: true,
-        },
+        }
       },
     };
+    
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
-    fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true, arg3: true });
+    fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
 
     const inputFieldOrder = [Object.keys(spec.args)];
 
     const { findByLabelText, queryByText } = renderSetupFromSpec(
-      spec, inputFieldOrder, { arg1: true, arg2: false, arg3: false } );
+      spec, inputFieldOrder, { arg1: false, arg2: false } );
     const input1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
     const input2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
-    const input3 = await findByLabelText((content) => content.startsWith(spec.args.arg3.name));
 
     await waitFor(() => {
-      expect(input1).toBeChecked();
+      expect(input1).not.toBeChecked();
       expect(input2).not.toBeChecked();
-      expect(input3).not.toBeChecked();
     });
 
-    // invalid because of VALIDATION_MESSAGE
-    expect(input1).toHaveClass('is-invalid');
-    // An optional input with no value is valid, but green check
-    // does not display until the input has been touched.
-    expect(input2).not.toHaveClass('is-valid', 'is-invalid');
-    // Required boolean switch should be invalid
-    expect(input3).toHaveClass('is-invalid');
-
-    // Click required checked boolean to unchecked
-    await userEvent.click(input1);
     await waitFor(() => {
       expect(input1).toHaveClass('is-invalid');
     });
     const input1Group = input1.closest('.input-group');
     await waitFor(() => {
-      expect(within(input1Group).findByText(RegExp(VALIDATION_MESSAGE)))
+      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
         .toBeInTheDocument();
     });
-    fetchValidation.mockResolvedValue([]); // now make input valid
-    await userEvent.click(input3);
+
+    // An optional input with no value is valid, but green check
+    // does not display until the input has been touched.
+    expect(input2).not.toHaveClass('is-valid', 'is-invalid');
+
+    // Now toggle required switch on and validation should pass 
+    fetchValidation.mockResolvedValue([]);
+    await userEvent.click(input1);
     await waitFor(() => {
-      expect(input3).toHaveClass('is-valid');
+      expect(input1).toHaveClass('is-valid');
     });
-    const input3Group = input3.closest('.input-group');
     await waitFor(() => {
-      expect(within(input3Group).findByText(RegExp(VALIDATION_MESSAGE)))
+      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
         .toBeNull();
     });
   });

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -584,6 +584,65 @@ describe('Misc form validation stuff', () => {
         .toBeNull();
     });
   });
+  
+  test('A required boolean displays validation warning', async () => {
+    const spec = {
+      pyname: 'natcap.invest.dummy',
+      args: {
+        arg1: {
+          name: 'Afoo',
+          type: 'boolean',
+          required: true,
+        },
+        arg2: {
+          name: 'Bfoo',
+          type: 'boolean',
+          required: false,
+        }
+      },
+    };
+    
+    fetchValidation.mockResolvedValue(
+      [[Object.keys(spec.args), VALIDATION_MESSAGE]]
+    );
+    fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
+
+    const inputFieldOrder = [Object.keys(spec.args)];
+
+    const { findByLabelText, queryByText } = renderSetupFromSpec(
+      spec, inputFieldOrder, { arg1: false, arg2: false } );
+    const input1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
+    const input2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
+
+    await waitFor(() => {
+      expect(input1).not.toBeChecked();
+      expect(input2).not.toBeChecked();
+    });
+
+    await waitFor(() => {
+      expect(input1).toHaveClass('is-invalid');
+    });
+    const input1Group = input1.closest('.input-group');
+    await waitFor(() => {
+      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
+        .toBeInTheDocument();
+    });
+
+    // An optional input with no value is valid, but green check
+    // does not display until the input has been touched.
+    expect(input2).not.toHaveClass('is-valid', 'is-invalid');
+
+    // Now toggle required switch on and validation should pass 
+    fetchValidation.mockResolvedValue([]);
+    await userEvent.click(input1);
+    await waitFor(() => {
+      expect(input1).toHaveClass('is-valid');
+    });
+    await waitFor(() => {
+      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
+        .toBeNull();
+    });
+  });
 });
 
 describe('Form drag-and-drop', () => {

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -584,65 +584,6 @@ describe('Misc form validation stuff', () => {
         .toBeNull();
     });
   });
-  
-  test('A required boolean displays validation warning', async () => {
-    const spec = {
-      pyname: 'natcap.invest.dummy',
-      args: {
-        arg1: {
-          name: 'Afoo',
-          type: 'boolean',
-          required: true,
-        },
-        arg2: {
-          name: 'Bfoo',
-          type: 'boolean',
-          required: false,
-        }
-      },
-    };
-    
-    fetchValidation.mockResolvedValue(
-      [[Object.keys(spec.args), VALIDATION_MESSAGE]]
-    );
-    fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
-
-    const inputFieldOrder = [Object.keys(spec.args)];
-
-    const { findByLabelText, queryByText } = renderSetupFromSpec(
-      spec, inputFieldOrder, { arg1: false, arg2: false } );
-    const input1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
-    const input2 = await findByLabelText((content) => content.startsWith(spec.args.arg2.name));
-
-    await waitFor(() => {
-      expect(input1).not.toBeChecked();
-      expect(input2).not.toBeChecked();
-    });
-
-    await waitFor(() => {
-      expect(input1).toHaveClass('is-invalid');
-    });
-    const input1Group = input1.closest('.input-group');
-    await waitFor(() => {
-      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
-        .toBeInTheDocument();
-    });
-
-    // An optional input with no value is valid, but green check
-    // does not display until the input has been touched.
-    expect(input2).not.toHaveClass('is-valid', 'is-invalid');
-
-    // Now toggle required switch on and validation should pass 
-    fetchValidation.mockResolvedValue([]);
-    await userEvent.click(input1);
-    await waitFor(() => {
-      expect(input1).toHaveClass('is-valid');
-    });
-    await waitFor(() => {
-      expect(within(input1Group).queryByText(RegExp(VALIDATION_MESSAGE)))
-        .toBeNull();
-    });
-  });
 });
 
 describe('Form drag-and-drop', () => {


### PR DESCRIPTION
## Description
Boolean or Switch type validation was not set like the rest of the Workbench inputs. Specifically boolean types were excluded from receiving validation messages and also did not include `isValid` or `isInvalid`. Also adding `onFocus` to boolean types so that they benefit from `touched` being updated like the other inputs.

I don't quite have the testing working properly and could use some feedback for testing this. But, now, if a switch / boolean is required and unchecked it should show a red circle outline around the switch. When touching and unselecting, if it's invalid it should display the validation message.

NOTE: currently when not valid, there is some CSS markup that pushes the switch left, which doesn't look great. Could use some quick tips on where to make this adjustment.

Fixes #2074

<img width="493" height="137" alt="image" src="https://github.com/user-attachments/assets/792f496f-ed9f-49e8-81f5-840c8cbd80a4" />

<img width="602" height="175" alt="image" src="https://github.com/user-attachments/assets/33959b7b-c04d-44f0-9550-a8260c99ef47" />

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
