### PR TITLE
Define AUTORELEASE_BRANCH for scheduled releases

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 18 * * 2"
+    - cron: "20 18 * * 4"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Description
Fixes #2093

Define `AUTORELEASE_BRANCH` using `$VERSION` rather than `inputs.version` so that it's defined for both scheduled and manually triggered runs.

Bumped the cron schedule to Thursdays to give us time to review, and since I'll be out tomorrow.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
