### PR TITLE
Loosen scheduler dates to run today.

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 16 * * 5"
+    - cron: "20 18 * * 5"
   workflow_dispatch:
     inputs:
       version:
@@ -27,7 +27,7 @@ jobs:
       # skip scheduled runs that aren't the first tuesday of the month
       - name: Check day of month
         run: |
-          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 7 ]]; then
+          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 9 ]]; then
             echo "RUN=true" >> $GITHUB_ENV
           else
             echo "RUN=false" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Scheduler failed to start because today's the 8th. Temporarily bump this restriction and also bump cron to run at 11:20am PT TODAY.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
