### PR TITLE
Comment out comment line in autorelease workflow

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 20 * * 5"
+    - cron: "20 21 * * 5"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.repository_owner == 'natcap'
     runs-on: ubuntu-latest
     steps:
-       skip scheduled runs that aren't the first tuesday of the month
+       # skip scheduled runs that aren't the first tuesday of the month
        - name: Check day of month
          run: |
            #if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 9 ]]; then

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 16 * * 1"
+    - cron: "20 16 * * 2"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 16 * * 5"
+    - cron: "20 16 * * 1"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -6,7 +6,7 @@ on:
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 21 * * 5"
+    - cron: "20 16 * * 5"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Description
The autorelease workflow didn't appear at all because of a syntax error causing the workflow to be invalid. I also moved the cron back to 8:20am PST on Tuesday.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
