### PR TITLE
Fix bug with ArcGIS GRID rasters during build_datastack_archive

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -70,6 +70,10 @@ General
 * Updated readme to fix broken links, and also add links to repositories
   containing older source code and downloads, for future reference.
   (`#2029 <https://github.com/natcap/invest/issues/2029>`_)
+* Fixed a bug in ``build_datastack_archive`` where the raster filepath
+  included in a datastack JSON for an ArcGIS GRID would be unusable.
+  (`#2103 <https://github.com/natcap/invest/issues/2103>`_)
+
 
 Workbench
 =========

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -829,6 +829,11 @@ def copy_spatial_files(spatial_filepath, target_dir):
         spatial_file = None
         return target_filepath
     for member_file in spatial_file.GetFileList():
+        # If the file is an ArcGIS Binary/Grid format but the given filepath
+        # was _not_ the parent directory -- it can be an '.adf' file --
+        # just skip the parent directory.
+        if os.path.isdir(member_file):
+            continue
         target_basename = os.path.basename(member_file)
         target_filepath = os.path.join(target_dir, target_basename)
         if source_basename == target_basename:

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -819,13 +819,16 @@ def copy_spatial_files(spatial_filepath, target_dir):
     source_basename = os.path.basename(spatial_filepath)
     return_filepath = None
 
+    # For ArcGIS Binary/Grid format the filepath will likely be a directory.
+    # Even though we don't strictly need to, open the file to make
+    # sure it is a gdal dataset before copying an entire directory tree.
     spatial_file = gdal.OpenEx(spatial_filepath)
+    if os.path.isdir(spatial_filepath):
+        target_filepath = os.path.join(target_dir, source_basename)
+        shutil.copytree(spatial_filepath, target_filepath)
+        spatial_file = None
+        return target_filepath
     for member_file in spatial_file.GetFileList():
-        # ArcGIS Binary/Grid format includes the directory in the file listing.
-        # The parent directory isn't strictly needed, so we can just skip it.
-        if os.path.isdir(member_file):
-            continue
-
         target_basename = os.path.basename(member_file)
         target_filepath = os.path.join(target_dir, target_basename)
         if source_basename == target_basename:

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -156,7 +156,6 @@ class DatastackArchiveTests(unittest.TestCase):
 
     def test_collect_rasters(self):
         """Datastack: test collect GDAL rasters."""
-        import natcap.invest.models
         from natcap.invest import datastack
         for raster_filename in (
                 'dem',  # This is a multipart raster


### PR DESCRIPTION
If a spatial filepath is a directory, copy the entire directory tree to the target location for archiving. That way the filepath returned for inclusion in a datastack JSON matches the same filename that the user passed in. Otherwise we were choosing an arbitrary "member file" for the JSON, and sometimes it was an unreadable sidecar file.

Fixes #2103

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
