### PR TITLE
More robust logic to parse release notes from HISTORY.rst

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -107,7 +107,8 @@ jobs:
                       if line.startswith(os.environ['VERSION']):
                           do_write = True
                       # match the header pattern X.XX.X (XXXX-XX-XX)
-                      elif re.match(r'\d+\.\d+\.\d+ \(\d{4}-\d{2}-\d{2}\)', line):
+                      # using \w to allow for alpha and post releases
+                      elif re.match(r'\d+\.\d+\.\w+ \(\d{4}-\d{2}-\d{2}\)', line):
                           do_write = False
                       if do_write:
                           notes.write(line)


### PR DESCRIPTION
## Description
Fixes #2119 

Instead of using blank lines to identify the end of the section, print lines from the version string until the next line that looks like a header.

I have tested the python script locally, but not in the workflow environment.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
