### PR TITLE
Restore filtering autorelease to only the first week of the month

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -27,12 +27,11 @@ jobs:
       # skip scheduled runs that aren't the first tuesday of the month
       - name: Check day of month
         run: |
-          #if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 9 ]]; then
-          #  echo "RUN=true" >> $GITHUB_ENV
-          #else
-          #  echo "RUN=false" >> $GITHUB_ENV
-          #fi
-          echo "RUN=true" >> $GITHUB_ENV
+          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" || $(date +%d) -le 7 ]]; then
+            echo "RUN=true" >> $GITHUB_ENV
+          else
+            echo "RUN=false" >> $GITHUB_ENV
+          fi
 
       - uses: actions/checkout@v4
         if: env.RUN == 'true'


### PR DESCRIPTION
## Description
Uncomment code that we had commented out for 3.16.2

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
