### PR TITLE
Note `invest_version` deprecation in HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -64,6 +64,13 @@
 Unreleased Changes
 ------------------
 
+General
+=======
+* Fixed a bug where datastacks missing the ``invest_version`` attribute could not be
+  opened. Additionally, new datastacks created with InVEST will no longer include
+  an ``invest_version``, since tying a datastack to a specific version of InVEST is
+  unnecessary. (`#2092 <https://github.com/natcap/invest/issues/2092>`_)
+
 Habitat Quality
 ===============
 * The aligned LULC outputs are no longer named after the original LULC files.


### PR DESCRIPTION
## Description
Addendum to #2137 (re: issue #2092) 

Forgot to add a note to HISTORY.rst documenting the deprecation of the datastack `invest_version` attribute in the initial PR, but it's worth including! 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
