### PR TITLE
unpin micromamba and use conda-forge package names

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -64,7 +64,6 @@ runs:
         init-shell: bash
         cache-environment: true
         cache-environment-key: ${{ runner.os }}${{ runner.arch }}-${{ env.WEEK }}-${{ hashFiles('environment.yml') }}
-        micromamba-version: 2.3.1-0  # version 2.3.2 caused https://github.com/natcap/invest/issues/2139
 
     - name: List conda environment
       shell: bash -l {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Set up python environment
         uses: ./.github/actions/setup_env
         with:
-          requirements-files: requirements.txt requirements-dev.txt
+          requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
           requirements: |
             ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
             python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,7 +202,7 @@ jobs:
 
       - uses: ./.github/actions/setup_env
         with:
-          requirements-files: requirements.txt
+          requirements-files: requirements.txt constraints_tests.txt
           requirements: |
             ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
             python=${{ matrix.python-version }}

--- a/constraints_tests.txt
+++ b/constraints_tests.txt
@@ -5,3 +5,7 @@
 # A gdal bug caused our test suite to fail, but this issue is unlikely to
 # occur with regular use of invest. https://github.com/OSGeo/gdal/issues/8497
 gdal!=3.6.*,!=3.7.*
+
+# docutils version 0.22.1 crashes installation
+# https://sourceforge.net/p/docutils/bugs/513/
+docutils<0.22.1

--- a/constraints_tests.txt
+++ b/constraints_tests.txt
@@ -4,4 +4,4 @@
 
 # A gdal bug caused our test suite to fail, but this issue is unlikely to
 # occur with regular use of invest. https://github.com/OSGeo/gdal/issues/8497
-GDAL!=3.6.*,!=3.7.*
+gdal!=3.6.*,!=3.7.*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ pypiwin32; sys_platform == 'win32'  # pip-only
 
 # 60.7.0 exception because of https://github.com/pyinstaller/pyinstaller/issues/6564
 setuptools>=8.0,!=60.7.0
-PyInstaller>=6.9.0
+pyinstaller>=6.9.0
 setuptools_scm>=6.4.0
 requests
 coverage

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-Sphinx>=1.3.1,!=1.7.1
+sphinx>=1.3.1,!=1.7.1
 sphinx-rtd-theme
 sphinx-intl
 sphinx-reredirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,11 @@
 # scripts/convert-requirements-to-conda-yml.py as though it can only be found
 # on pip.
 
-GDAL>=3.4.2
-Pyro5
+gdal>=3.4.2
+pyro5
 pandas>=1.2.1
 numpy>=1.11.0,!=1.16.0
-Rtree>=0.8.2,!=0.9.1
+rtree>=0.8.2,!=0.9.1
 shapely>=2.0.0
 scipy>=1.9.0,!=1.12.*
 pygeoprocessing>=2.4.6
@@ -22,8 +22,8 @@ taskgraph>=0.11.0
 psutil>=5.6.6
 chardet>=3.0.4
 pint
-Babel
-Flask
+babel
+flask
 flask_cors
 requests
 geometamaker>=0.2.0


### PR DESCRIPTION
## Description
The breaking issue with micromamba 2.3.2 was that the package solver became case-sensitive (see https://github.com/mamba-org/mamba/issues/4064). Some of our requirements use the package name from PyPI, which sometimes contains capital letters like `GDAL`. Pip is case-insensitive, but micromamba now is not (at least for version 2.3.2). I'm unpinning micromamba and standardizing our requirements to use the conda-forge names (which are generally all uncapitalized).

There is currently an unrelated issue with the latest release of `docutils`, so I pinned it in the constraints file.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
