### PR TITLE
Don't limit percent inputs to [0, 100] by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -80,6 +80,28 @@ Plugins
   leftover, unusable micromamba environments.
   (`#2104 <https://github.com/natcap/invest/issues/2104>`_)
 
+Annual Water Yield
+==================
+* The discount rate parameter was previously incorrectly restricted to the
+  range [0, 100]. Now there is no minimum or maximum value.
+
+Carbon
+======
+* The discount rate and price change parameters were previously incorrectly
+  restricted to the range [0, 100]. Now there is no minimum or maximum value.
+
+Coastal Blue Carbon
+===================
+* The discount rate and price change parameters were previously incorrectly
+  restricted to the range [0, 100]. Now there is no minimum or maximum value.
+
+Coastal Vulnerability
+=====================
+* The WWIII ``v10pct_[SECTOR]`` field was incorrectly documented as a unitless
+  percent; this has been corrected to show that it is a numeric input with
+  units of meters/second.
+
+
 3.16.2 (2025-08-13)
 -------------------
 

--- a/src/natcap/invest/coastal_vulnerability.py
+++ b/src/natcap/invest/coastal_vulnerability.py
@@ -215,7 +215,8 @@ MODEL_SPEC = spec.ModelSpec(
                         "Proportion of the highest 10% of wind speeds in the record of"
                         " interest that blow in the direction of each sector."
                     ),
-                    units=None
+                    units=None,
+                    expression="0 <= value <= 100"
                 ),
                 spec.NumberInput(
                     id="rei_v[SECTOR]",
@@ -231,7 +232,8 @@ MODEL_SPEC = spec.ModelSpec(
                         "Proportion of the highest 10% of wave power values on record"
                         " that are in each sector."
                     ),
-                    units=None
+                    units=None,
+                    expression="0 <= value <= 100"
                 ),
                 spec.NumberInput(
                     id="wavp_[SECTOR]",
@@ -241,13 +243,13 @@ MODEL_SPEC = spec.ModelSpec(
                     ),
                     units=u.kilowatt / u.meter
                 ),
-                spec.PercentInput(
+                spec.NumberInput(
                     id="v10pct_[SECTOR]",
                     about=gettext(
                         "Average of the highest 10% of wind speeds that are centered on"
                         " each main sector direction X."
                     ),
-                    units=None
+                    units=u.meter / u.second
                 )
             ],
             projected=None

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -366,7 +366,11 @@ MODEL_SPEC = spec.ModelSpec(
                             about=None,
                             options=CROP_OPTIONS
                         ),
-                        spec.PercentInput(id="percentrefuse", about=None, units=None),
+                        spec.PercentInput(
+                            id="percentrefuse",
+                            about=None,
+                            units=None,
+                            expression="0 <= value <= 100"),
                         *[spec.NumberInput(id=nutrient, units=units)
                             for nutrient, units in nutrient_units.items()]
                     ],

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -178,7 +178,12 @@ MODEL_SPEC = spec.ModelSpec(
                             about=None,
                             options=CROPS
                         ),
-                        spec.PercentInput(id="percentrefuse", about=None, units=None),
+                        spec.PercentInput(
+                            id="percentrefuse",
+                            about=None,
+                            units=None,
+                            expression="0 <= value <= 100"
+                        ),
                         *[
                             spec.NumberInput(id=nutrient, about=about, units=units)
                             for nutrient, about, units in NUTRIENTS

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1102,8 +1102,10 @@ class RatioInput(NumberInput):
 class PercentInput(NumberInput):
     """A percent input, or parameter, of an invest model.
 
-    A percent is a proportion expressed as a value from 0 to 100 (in contrast to
-    a ratio, which ranges from 0 to 1). Values are restricted to the range [0, 100].
+    A percent is a proportion expressed as a value from 0% to 100% (in contrast
+    to a ratio, which ranges from 0 to 1). By default there is no restriction on
+    the range a percent value can take, so values may be less than 0 or greater
+    than 100. Use the ``expression`` parameter to enforce a value range.
     """
     type: typing.ClassVar[str] = 'percent'
 

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1121,7 +1121,6 @@ class PercentInput(NumberInput):
         message = super().validate(value)
         if message:
             return message
-        as_float = float(value)
 
 
 class BooleanInput(Input):

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -1122,10 +1122,6 @@ class PercentInput(NumberInput):
         if message:
             return message
         as_float = float(value)
-        if as_float < 0 or as_float > 100:
-            return get_message('NOT_WITHIN_RANGE').format(
-                value=as_float,
-                range='[0, 100]')
 
 
 class BooleanInput(Input):

--- a/src/natcap/invest/urban_cooling_model.py
+++ b/src/natcap/invest/urban_cooling_model.py
@@ -187,7 +187,8 @@ MODEL_SPEC = spec.ModelSpec(
             ),
             required="do_productivity_valuation",
             allowed="do_productivity_valuation",
-            units=None
+            units=None,
+            expression="0 <= value <= 100"
         ),
         spec.VectorInput(
             id="building_vector_path",


### PR DESCRIPTION
## Description
Fixes #2160 

I removed the default range limit for percent inputs. I reviewed all percent inputs across invest and found a few other that also shouldn't be limited to [0, 100]. For those that should be limited to [0, 100], I added an `expression` to enforce that.

We should separately review all ratio inputs and check if there's any that shouldn't be limited to [0, 1].

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
