### PR TITLE
Refactor Crop Production models to use CSVInputs in lieu of DirectoryInput

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -113,6 +113,18 @@ Coastal Vulnerability
   percent; this has been corrected to show that it is a numeric input with
   units of meters/second.
 
+Crop Production
+===============
+* The inputs to both Crop Production models have changed in order to support
+  remote datasets. Instead of a Model Data Directory, the models now expect
+  multiple tables, each of which maps each crop name to its corresponding
+  climate bin raster, observed yield raster, nutrient table, percentile yield
+  table, or regression yield table.
+  (`#2095 <https://github.com/natcap/invest/issues/2095>`_)
+* The ``crop`` column headers in both models' result tables have been renamed
+  to ``crop_name`` for consistency with model inputs.
+  (`#2095 <https://github.com/natcap/invest/issues/2095>`_)
+
 Habitat Quality
 ===============
 * The aligned LULC outputs are no longer named after the original LULC files.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := f98ed4da03e895c886d0daccbe6ae539807f59cc
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 24206046dd395c76d14d498df33cc0149c1c4d30
+GIT_UG_REPO_REV             := 31b30c9c501fa2a1e089e2e5d0a0fbd13593bd5c
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 011c09ad2184690f20fb3e9046fbd6a4aaecb885
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := d8a7397ba5992de7a80260e40956e4c29176383d
+GIT_TEST_DATA_REPO_REV      := aaf6f21a4c9b4ac1a9673830aebe610dc80cedb7
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 011c09ad2184690f20fb3e9046fbd6a4aaecb885
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := aaf6f21a4c9b4ac1a9673830aebe610dc80cedb7
+GIT_TEST_DATA_REPO_REV      := cffe932472a61d25cd5a87db9b84274ec31aa477
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 08a3eef6a794bc1af403ff2f6ef6613934f4ba4c
+GIT_SAMPLE_DATA_REPO_REV    := 58a1398b4ea6634c827eadc553b7f1383abfc384
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := cffe932472a61d25cd5a87db9b84274ec31aa477
+GIT_TEST_DATA_REPO_REV      := f98ed4da03e895c886d0daccbe6ae539807f59cc
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 7cfe0d016d200b81b190ab4345c0488281605a03
+GIT_UG_REPO_REV             := 24206046dd395c76d14d498df33cc0149c1c4d30
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -660,21 +660,15 @@ def execute(args):
             "The following lucodes are in the landcover raster but aren't "
             f"in the landcover to crop table: {lucodes_missing_from_table}")
 
-    bad_crop_name_list = []
-
-    for crop_name in crop_to_landcover_df.index:
-        crop_climate_bin_raster_path = get_full_path_from_crop_table(
-            MODEL_SPEC,
-            CROP_TO_PATH_TABLES.climate_bin,
-            args[CROP_TO_PATH_TABLES.climate_bin],
-            crop_name)
-        if crop_climate_bin_raster_path is None:
-            bad_crop_name_list.append(crop_name)
-    if bad_crop_name_list:
+    LOGGER.info("Checking that crops are supported by the model.")
+    user_provided_crop_names = set(list(crop_to_landcover_df.index))
+    valid_crop_names = set([crop.key for crop in CROP_OPTIONS])
+    invalid_crop_names = user_provided_crop_names.difference(valid_crop_names)
+    if invalid_crop_names:
         raise ValueError(
-            "'The following crop names were provided in "
-            f"{args['landcover_to_crop_table_path']} but no corresponding "
-            f"climate bin raster path could be found: {bad_crop_name_list}")
+            "The following crop names were provided in "
+            f"{args['landcover_to_crop_table_path']} but are not supported "
+            f"by the model: {invalid_crop_names}")
 
     file_suffix = utils.make_suffix_string(args, 'results_suffix')
     output_dir = os.path.join(args['workspace_dir'])
@@ -722,6 +716,10 @@ def execute(args):
             CROP_TO_PATH_TABLES.climate_bin,
             args[CROP_TO_PATH_TABLES.climate_bin],
             crop_name)
+
+        if not crop_climate_bin_raster_path:
+            raise ValueError(
+                f'No climate bin raster path could be found for {crop_name}')
 
         LOGGER.info(
             "Clipping global climate bin raster to landcover bounding box.")

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -1,11 +1,10 @@
 """InVEST Crop Production Percentile Model."""
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 import logging
 import os
 import re
 
 import numpy
-from pandas import NA
 import pygeoprocessing
 import taskgraph
 from osgeo import gdal
@@ -15,7 +14,7 @@ from . import gettext
 from . import spec
 from . import utils
 from . import validation
-from .crop_production_regression import NUTRIENTS
+from .crop_production_regression import NUTRIENTS, CROP_TO_PATH_TABLES, get_full_path_from_crop_table
 from .file_registry import FileRegistry
 from .unit_registry import u
 
@@ -241,13 +240,6 @@ nutrient_units = {
     "vitk":        u.microgram/u.hectogram,  # vitamin K
 }
 
-CropToPathTables = namedtuple(
-    'CropToPathTables', ['climate_bin', 'observed_yield', 'percentile_yield'])
-CROP_TO_PATH_TABLES = CropToPathTables(
-    climate_bin='climate_bin_raster_table',
-    observed_yield='observed_yield_raster_table',
-    percentile_yield='percentile_yield_csv_table',
-)
 
 MODEL_SPEC = spec.ModelSpec(
     model_id="crop_production_percentile",
@@ -704,7 +696,8 @@ def execute(args):
     bad_crop_name_list = []
 
     for crop_name in crop_to_landcover_df.index:
-        crop_climate_bin_raster_path = _get_full_path_from_table(
+        crop_climate_bin_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
             CROP_TO_PATH_TABLES.climate_bin,
             args[CROP_TO_PATH_TABLES.climate_bin],
             crop_name)
@@ -757,7 +750,8 @@ def execute(args):
     for crop_name, row in crop_to_landcover_df.iterrows():
         crop_lucode = row[_EXPECTED_LUCODE_TABLE_HEADER]
         LOGGER.info(f'Processing crop {crop_name}')
-        crop_climate_bin_raster_path = _get_full_path_from_table(
+        crop_climate_bin_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
             CROP_TO_PATH_TABLES.climate_bin,
             args[CROP_TO_PATH_TABLES.climate_bin],
             crop_name)
@@ -778,7 +772,8 @@ def execute(args):
             task_name='crop_climate_bin')
         dependent_task_list.append(crop_climate_bin_task)
 
-        climate_percentile_yield_table_path = _get_full_path_from_table(
+        climate_percentile_yield_table_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
             CROP_TO_PATH_TABLES.percentile_yield,
             args[CROP_TO_PATH_TABLES.percentile_yield],
             crop_name)
@@ -862,7 +857,8 @@ def execute(args):
             dependent_task_list.append(create_percentile_production_task)
 
         LOGGER.info(f'Calculate observed yield for {crop_name}')
-        global_observed_yield_raster_path = _get_full_path_from_table(
+        global_observed_yield_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
             CROP_TO_PATH_TABLES.observed_yield,
             args[CROP_TO_PATH_TABLES.observed_yield],
             crop_name)
@@ -1287,43 +1283,6 @@ def aggregate_to_polygons(
                         ',%s' % total_nutrient_table[
                             nutrient_id][model_type][id_index])
             aggregate_table.write('\n')
-
-
-def _get_full_path_from_table(
-        table_id: str, table_path: str, crop_name: str) -> str | None:
-    """Given a crop-to-path table, look up a path and expand it if appropriate.
-
-    Args:
-        table_id (str): the id of the table as defined in the model spec.
-            One of ``CROP_TO_PATH_TABLES``.
-        table_path (str): the path to the table as defined in the model args.
-        crop_name (str): the name of the crop to look up in the table.
-            One of ``CROP_OPTIONS``.
-
-    Returns:
-        One of the following:
-            The full path (str), as an absolute path if it's local, or
-                normalized if it's remote.
-            ``None`` if ``crop_name`` is not in the table, or if the path
-                found in the table is empty or not a string.
-
-    Raises:
-        ``KeyError`` if ``table_id`` is not one of ``CROP_TO_PATH_TABLES``.
-    """
-    if table_id not in CROP_TO_PATH_TABLES:
-        raise KeyError(f'table_id {table_id} is not valid')
-    df = MODEL_SPEC.get_input(table_id).get_validated_dataframe(table_path)
-    try:
-        path_str = df.at[crop_name, 'path']
-    except KeyError:
-        return None
-    if (path_str is NA) or (not path_str) or (type(path_str) is not str):
-        return None
-    gdal_path = utils._GDALPath.from_uri(path_str)
-    if gdal_path.is_local:
-        return utils.expand_path(path_str, table_path)
-    else:
-        return gdal_path.to_normalized_path()
 
 
 # This decorator ensures the input arguments are formatted for InVEST

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -15,8 +15,7 @@ from . import spec
 from . import utils
 from . import validation
 from .crop_production_regression import (
-    NUTRIENTS, NUTRIENT_UNITS, CROP_TO_PATH_TABLES,
-    CROP_TO_PATH_TABLE_PATH_DESC, TABLE_PROVIDED_MSG,
+    NUTRIENTS, NUTRIENT_UNITS, CROP_TO_PATH_TABLES, LULC_RASTER_INPUT,
     get_full_path_from_crop_table)
 from .file_registry import FileRegistry
 from .unit_registry import u
@@ -226,18 +225,7 @@ MODEL_SPEC = spec.ModelSpec(
         spec.WORKSPACE,
         spec.SUFFIX,
         spec.N_WORKERS,
-        spec.SingleBandRasterInput(
-            id="landcover_raster_path",
-            name=gettext("land use/land cover"),
-            about=gettext(
-                "Map of land use/land cover codes. Each land use/land cover type must be"
-                " assigned a unique integer code."
-            ),
-            data_type=int,
-            units=None,
-            projected=True,
-            projection_units=u.meter
-        ),
+        LULC_RASTER_INPUT,
         spec.CSVInput(
             id="landcover_to_crop_table_path",
             name=gettext("LULC to Crop Table"),
@@ -266,8 +254,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Climate Bin Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" climate bin raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}"
+                " climate bin raster."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -290,8 +281,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Observed Yield Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" observed yield raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}."
+                " observed yield raster."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -314,8 +308,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Percentile Yield CSV Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" percentile yield table. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}"
+                " percentile yield table."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -359,7 +356,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Crop Nutrient Table"),
             about=gettext(
                 "A table that lists amounts of nutrients in each crop."
-                f" {TABLE_PROVIDED_MSG}"
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -14,7 +14,7 @@ from . import gettext
 from . import spec
 from . import utils
 from . import validation
-from .crop_production_regression import NUTRIENTS, CROP_TO_PATH_TABLES, get_full_path_from_crop_table
+from .crop_production_regression import NUTRIENTS, NUTRIENT_UNITS, CROP_TO_PATH_TABLES, get_full_path_from_crop_table
 from .file_registry import FileRegistry
 from .unit_registry import u
 
@@ -204,43 +204,6 @@ CROP_OPTIONS = [
     spec.Option(key="yautia", about=gettext("Yautia"))
 ]
 
-nutrient_units = {
-    "protein":     u.gram/u.hectogram,
-    "lipid":       u.gram/u.hectogram,       # total lipid
-    "energy":      u.kilojoule/u.hectogram,
-    "ca":          u.milligram/u.hectogram,  # calcium
-    "fe":          u.milligram/u.hectogram,  # iron
-    "mg":          u.milligram/u.hectogram,  # magnesium
-    "ph":          u.milligram/u.hectogram,  # phosphorus
-    "k":           u.milligram/u.hectogram,  # potassium
-    "na":          u.milligram/u.hectogram,  # sodium
-    "zn":          u.milligram/u.hectogram,  # zinc
-    "cu":          u.milligram/u.hectogram,  # copper
-    "fl":          u.microgram/u.hectogram,  # fluoride
-    "mn":          u.milligram/u.hectogram,  # manganese
-    "se":          u.microgram/u.hectogram,  # selenium
-    "vita":        u.IU/u.hectogram,         # vitamin A
-    "betac":       u.microgram/u.hectogram,  # beta carotene
-    "alphac":      u.microgram/u.hectogram,  # alpha carotene
-    "vite":        u.milligram/u.hectogram,  # vitamin e
-    "crypto":      u.microgram/u.hectogram,  # cryptoxanthin
-    "lycopene":    u.microgram/u.hectogram,  # lycopene
-    "lutein":      u.microgram/u.hectogram,  # lutein + zeaxanthin
-    "betat":       u.milligram/u.hectogram,  # beta tocopherol
-    "gammat":      u.milligram/u.hectogram,  # gamma tocopherol
-    "deltat":      u.milligram/u.hectogram,  # delta tocopherol
-    "vitc":        u.milligram/u.hectogram,  # vitamin C
-    "thiamin":     u.milligram/u.hectogram,
-    "riboflavin":  u.milligram/u.hectogram,
-    "niacin":      u.milligram/u.hectogram,
-    "pantothenic": u.milligram/u.hectogram,  # pantothenic acid
-    "vitb6":       u.milligram/u.hectogram,  # vitamin B6
-    "folate":      u.microgram/u.hectogram,
-    "vitb12":      u.microgram/u.hectogram,  # vitamin B12
-    "vitk":        u.microgram/u.hectogram,  # vitamin K
-}
-
-
 MODEL_SPEC = spec.ModelSpec(
     model_id="crop_production_percentile",
     model_title=gettext("Crop Production: Percentile"),
@@ -400,10 +363,9 @@ MODEL_SPEC = spec.ModelSpec(
                 spec.PercentInput(
                     id="percentrefuse",
                     about=None,
-                    units=None,
                     expression="0 <= value <= 100"),
                 *[spec.NumberInput(id=nutrient, units=units)
-                    for nutrient, units in nutrient_units.items()]
+                    for nutrient, units in NUTRIENT_UNITS.items()]
             ],
             index_col="crop_name"
         ),
@@ -610,7 +572,7 @@ _INTERMEDIATE_OUTPUT_DIR = 'intermediate_output'
 
 _YIELD_PERCENTILE_FIELD_PATTERN = 'yield_([^_]+)'
 
-_EXPECTED_NUTRIENT_TABLE_HEADERS = list(nutrient_units.keys())
+_EXPECTED_NUTRIENT_TABLE_HEADERS = list(NUTRIENT_UNITS.keys())
 _EXPECTED_LUCODE_TABLE_HEADER = 'lucode'
 _NODATA_YIELD = -1
 

--- a/src/natcap/invest/crop_production_percentile.py
+++ b/src/natcap/invest/crop_production_percentile.py
@@ -14,7 +14,10 @@ from . import gettext
 from . import spec
 from . import utils
 from . import validation
-from .crop_production_regression import NUTRIENTS, NUTRIENT_UNITS, CROP_TO_PATH_TABLES, get_full_path_from_crop_table
+from .crop_production_regression import (
+    NUTRIENTS, NUTRIENT_UNITS, CROP_TO_PATH_TABLES,
+    CROP_TO_PATH_TABLE_PATH_DESC, TABLE_PROVIDED_MSG,
+    get_full_path_from_crop_table)
 from .file_registry import FileRegistry
 from .unit_registry import u
 
@@ -263,7 +266,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Climate Bin Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " climate bin raster."
+                f" climate bin raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(
@@ -286,7 +290,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Observed Yield Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " observed yield raster."
+                f" observed yield raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -309,7 +314,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Percentile Yield CSV Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " percentile yield table."
+                f" percentile yield table. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(
@@ -353,6 +359,7 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Crop Nutrient Table"),
             about=gettext(
                 "A table that lists amounts of nutrients in each crop."
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -114,6 +114,13 @@ CROP_TO_PATH_TABLES = CropToPathTables(
     regression_yield='regression_yield_csv_table',
 )
 
+CROP_TO_PATH_TABLE_PATH_DESC = ("Each ``path`` may be either a *relative*"
+                                " path pointing to a local file, or a URL"
+                                " pointing to a remote file.")
+
+TABLE_PROVIDED_MSG = ("You do not need to create this table; it is provided"
+                      " for you in the sample data.")
+
 MODEL_SPEC = spec.ModelSpec(
     model_id="crop_production_regression",
     model_title=gettext("Crop Production: Regression"),
@@ -196,7 +203,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Climate Bin Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " climate bin raster."
+                f" climate bin raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(
@@ -219,7 +227,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Observed Yield Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " observed yield raster."
+                f" observed yield raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(
@@ -242,7 +251,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Regression Yield CSV Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                " regression yield table."
+                f" regression yield table. {CROP_TO_PATH_TABLE_PATH_DESC}"
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(
@@ -276,6 +286,7 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Crop Nutrient Table"),
             about=gettext(
                 "A table that lists amounts of nutrients in each crop."
+                f" {TABLE_PROVIDED_MSG}"
             ),
             columns=[
                 spec.OptionStringInput(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -2,6 +2,7 @@
 from collections import defaultdict, namedtuple
 import logging
 import os
+import typing
 
 import numpy
 import pygeoprocessing
@@ -1204,7 +1205,7 @@ def aggregate_regression_results_to_polygons(
 
 def get_full_path_from_crop_table(
         model_spec: spec.ModelSpec, table_id: str, table_path: str,
-        crop_name: str) -> str | None:
+        crop_name: str) -> typing.Union[str, None]:
     """Given a crop-to-path table, look up a path and expand it if appropriate.
 
     Args:

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -115,12 +115,18 @@ CROP_TO_PATH_TABLES = CropToPathTables(
     regression_yield='regression_yield_csv_table',
 )
 
-CROP_TO_PATH_TABLE_PATH_DESC = ("Each ``path`` may be either a *relative*"
-                                " path pointing to a local file, or a URL"
-                                " pointing to a remote file.")
-
-TABLE_PROVIDED_MSG = ("You do not need to create this table; it is provided"
-                      " for you in the sample data.")
+LULC_RASTER_INPUT = spec.SingleBandRasterInput(
+    id="landcover_raster_path",
+    name=gettext("land use/land cover"),
+    about=gettext(
+        "Map of land use/land cover codes. Each land use/land cover type must"
+        " be assigned a unique integer code."
+    ),
+    data_type=int,
+    units=None,
+    projected=True,
+    projection_units=u.meter
+)
 
 MODEL_SPEC = spec.ModelSpec(
     model_id="crop_production_regression",
@@ -138,18 +144,7 @@ MODEL_SPEC = spec.ModelSpec(
         spec.WORKSPACE,
         spec.SUFFIX,
         spec.N_WORKERS,
-        spec.SingleBandRasterInput(
-            id="landcover_raster_path",
-            name=gettext("land use/land cover"),
-            about=gettext(
-                "Map of land use/land cover codes. Each land use/land cover type must be"
-                " assigned a unique integer code."
-            ),
-            data_type=int,
-            units=None,
-            projected=True,
-            projection_units=u.meter
-        ),
+        LULC_RASTER_INPUT,
         spec.CSVInput(
             id="landcover_to_crop_table_path",
             name=gettext("LULC to crop table"),
@@ -204,8 +199,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Climate Bin Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" climate bin raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}"
+                " climate bin raster."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -228,8 +226,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Observed Yield Raster Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" observed yield raster. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}"
+                " observed yield raster."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -252,8 +253,11 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Regression Yield CSV Table"),
             about=gettext(
                 "A table that maps each crop name to the corresponding"
-                f" regression yield table. {CROP_TO_PATH_TABLE_PATH_DESC}"
-                f" {TABLE_PROVIDED_MSG}"
+                " regression yield table."
+                " Each path may be either a relative path pointing to a local"
+                " file, or a URL pointing to a remote file."
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(
@@ -287,7 +291,8 @@ MODEL_SPEC = spec.ModelSpec(
             name=gettext("Crop Nutrient Table"),
             about=gettext(
                 "A table that lists amounts of nutrients in each crop."
-                f" {TABLE_PROVIDED_MSG}"
+                " You do not need to create this table; it is provided for you"
+                " in the sample data."
             ),
             columns=[
                 spec.OptionStringInput(

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -19,7 +19,7 @@ from .file_registry import FileRegistry
 
 LOGGER = logging.getLogger(__name__)
 
-CROPS = [
+CROP_OPTIONS = [
     spec.Option(key="barley", about=gettext("Barley")),
     spec.Option(key="maize", about=gettext("Maize")),
     spec.Option(key="oilpalm", about=gettext("Oil palm fruit")),
@@ -68,6 +68,42 @@ NUTRIENTS = [
     ("vitk", "vitamin K", u.microgram/u.hectogram)
 ]
 
+NUTRIENT_UNITS = {
+    "protein":     u.gram/u.hectogram,
+    "lipid":       u.gram/u.hectogram,       # total lipid
+    "energy":      u.kilojoule/u.hectogram,
+    "ca":          u.milligram/u.hectogram,  # calcium
+    "fe":          u.milligram/u.hectogram,  # iron
+    "mg":          u.milligram/u.hectogram,  # magnesium
+    "ph":          u.milligram/u.hectogram,  # phosphorus
+    "k":           u.milligram/u.hectogram,  # potassium
+    "na":          u.milligram/u.hectogram,  # sodium
+    "zn":          u.milligram/u.hectogram,  # zinc
+    "cu":          u.milligram/u.hectogram,  # copper
+    "fl":          u.microgram/u.hectogram,  # fluoride
+    "mn":          u.milligram/u.hectogram,  # manganese
+    "se":          u.microgram/u.hectogram,  # selenium
+    "vita":        u.IU/u.hectogram,         # vitamin A
+    "betac":       u.microgram/u.hectogram,  # beta carotene
+    "alphac":      u.microgram/u.hectogram,  # alpha carotene
+    "vite":        u.milligram/u.hectogram,  # vitamin e
+    "crypto":      u.microgram/u.hectogram,  # cryptoxanthin
+    "lycopene":    u.microgram/u.hectogram,  # lycopene
+    "lutein":      u.microgram/u.hectogram,  # lutein + zeaxanthin
+    "betat":       u.milligram/u.hectogram,  # beta tocopherol
+    "gammat":      u.milligram/u.hectogram,  # gamma tocopherol
+    "deltat":      u.milligram/u.hectogram,  # delta tocopherol
+    "vitc":        u.milligram/u.hectogram,  # vitamin C
+    "thiamin":     u.milligram/u.hectogram,
+    "riboflavin":  u.milligram/u.hectogram,
+    "niacin":      u.milligram/u.hectogram,
+    "pantothenic": u.milligram/u.hectogram,  # pantothenic acid
+    "vitb6":       u.milligram/u.hectogram,  # vitamin B6
+    "folate":      u.microgram/u.hectogram,
+    "vitb12":      u.microgram/u.hectogram,  # vitamin B12
+    "vitk":        u.microgram/u.hectogram,  # vitamin K
+}
+
 CropToPathTables = namedtuple(
     'CropToPathTables', ['climate_bin', 'observed_yield',
                          'percentile_yield', 'regression_yield'])
@@ -84,7 +120,10 @@ MODEL_SPEC = spec.ModelSpec(
     userguide="crop_production.html",
     input_field_order=[
         ["workspace_dir", "results_suffix"],
-        ["model_data_path", "landcover_raster_path", "landcover_to_crop_table_path",
+        [CROP_TO_PATH_TABLES.regression_yield,
+         CROP_TO_PATH_TABLES.observed_yield,
+         CROP_TO_PATH_TABLES.climate_bin, "crop_nutrient_table"],
+        ["landcover_raster_path", "landcover_to_crop_table_path",
          "fertilization_rate_table_path", "aggregate_polygon_path"]
     ],
     inputs=[
@@ -115,7 +154,7 @@ MODEL_SPEC = spec.ModelSpec(
                 spec.OptionStringInput(
                     id="crop_name",
                     about=None,
-                    options=CROPS
+                    options=CROP_OPTIONS
                 )
             ],
             index_col="crop_name"
@@ -128,7 +167,7 @@ MODEL_SPEC = spec.ModelSpec(
                 spec.OptionStringInput(
                     id="crop_name",
                     about=gettext("One of the supported crop types."),
-                    options=CROPS
+                    options=CROP_OPTIONS
                 ),
                 spec.NumberInput(
                     id="nitrogen_rate",
@@ -152,85 +191,107 @@ MODEL_SPEC = spec.ModelSpec(
             id="aggregate_polygon_path",
             required=False
         )),
-        spec.DirectoryInput(
-            id="model_data_path",
-            name=gettext("model data"),
-            about=gettext("The Crop Production datasets provided with the model."),
-            contents=[
-                spec.DirectoryInput(
-                    id="climate_regression_yield_tables",
+        spec.CSVInput(
+            id=CROP_TO_PATH_TABLES.climate_bin,
+            name=gettext("Climate Bin Raster Table"),
+            about=gettext(
+                "A table that maps each crop name to the corresponding"
+                " climate bin raster."
+            ),
+            columns=[
+                spec.OptionStringInput(
+                    id="crop_name",
                     about=None,
-                    contents=[
-                        spec.CSVInput(
-                            id="[CROP]_regression_yield_table.csv",
-                            about=None,
-                            columns=[
-                                spec.IntegerInput(id="climate_bin", about=None),
-                                spec.NumberInput(
-                                    id="yield_ceiling",
-                                    about=None,
-                                    units=u.metric_ton / u.hectare
-                                ),
-                                spec.NumberInput(id="b_nut", about=None, units=u.none),
-                                spec.NumberInput(id="b_k2o", about=None, units=u.none),
-                                spec.NumberInput(id="c_n", about=None, units=u.none),
-                                spec.NumberInput(id="c_p2o5", about=None, units=u.none),
-                                spec.NumberInput(id="c_k2o", about=None, units=u.none)
-                            ],
-                            index_col="climate_bin"
-                        )
-                    ]
+                    options=CROP_OPTIONS
+                ),
+                spec.SingleBandRasterInput(
+                    id="path",
+                    about=None,
+                    data_type=int,
+                    units=None,
+                    projected=None
+                )
+            ],
+            index_col="crop_name"
+        ),
+        spec.CSVInput(
+            id=CROP_TO_PATH_TABLES.observed_yield,
+            name=gettext("Observed Yield Raster Table"),
+            about=gettext(
+                "A table that maps each crop name to the corresponding"
+                " observed yield raster."
+            ),
+            columns=[
+                spec.OptionStringInput(
+                    id="crop_name",
+                    about=None,
+                    options=CROP_OPTIONS
+                ),
+                spec.SingleBandRasterInput(
+                    id="path",
+                    about=None,
+                    data_type=float,
+                    units=u.metric_ton / u.hectare,
+                    projected=None
+                )
+            ],
+            index_col="crop_name"
+        ),
+        spec.CSVInput(
+            id=CROP_TO_PATH_TABLES.regression_yield,
+            name=gettext("Regression Yield CSV Table"),
+            about=gettext(
+                "A table that maps each crop name to the corresponding"
+                " regression yield table."
+            ),
+            columns=[
+                spec.OptionStringInput(
+                    id="crop_name",
+                    about=None,
+                    options=CROP_OPTIONS
                 ),
                 spec.CSVInput(
-                    id="crop_nutrient.csv",
+                    id="path",
                     about=None,
                     columns=[
-                        spec.OptionStringInput(
-                            id="crop",
+                        spec.IntegerInput(id="climate_bin", about=None),
+                        spec.NumberInput(
+                            id="yield_ceiling",
                             about=None,
-                            options=CROPS
+                            units=u.metric_ton / u.hectare
                         ),
-                        spec.PercentInput(
-                            id="percentrefuse",
-                            about=None,
-                            units=None,
-                            expression="0 <= value <= 100"
-                        ),
-                        *[
-                            spec.NumberInput(id=nutrient, about=about, units=units)
-                            for nutrient, about, units in NUTRIENTS
-                        ]
+                        spec.NumberInput(id="b_nut", about=None, units=u.none),
+                        spec.NumberInput(id="b_k2o", about=None, units=u.none),
+                        spec.NumberInput(id="c_n", about=None, units=u.none),
+                        spec.NumberInput(id="c_p2o5", about=None, units=u.none),
+                        spec.NumberInput(id="c_k2o", about=None, units=u.none)
                     ],
-                    index_col="crop"
-                ),
-                spec.DirectoryInput(
-                    id="extended_climate_bin_maps",
-                    about=gettext("Maps of climate bins for each crop."),
-                    contents=[
-                        spec.SingleBandRasterInput(
-                            id="extendedclimatebins[CROP]",
-                            about=None,
-                            data_type=int,
-                            units=None,
-                            projected=None
-                        )
-                    ]
-                ),
-                spec.DirectoryInput(
-                    id="observed_yield",
-                    about=gettext("Maps of actual observed yield for each crop."),
-                    contents=[
-                        spec.SingleBandRasterInput(
-                            id="[CROP]_observed_yield.tif",
-                            about=None,
-                            data_type=float,
-                            units=u.metric_ton / u.hectare,
-                            projected=None
-                        )
-                    ]
+                    index_col="climate_bin"
                 )
-            ]
-        )
+            ],
+            index_col="crop_name"
+        ),
+        spec.CSVInput(
+            id="crop_nutrient_table",
+            name=gettext("Crop Nutrient Table"),
+            about=gettext(
+                "A table that lists amounts of nutrients in each crop."
+            ),
+            columns=[
+                spec.OptionStringInput(
+                    id="crop_name",
+                    about=None,
+                    options=CROP_OPTIONS
+                ),
+                spec.PercentInput(
+                    id="percentrefuse",
+                    about=None,
+                    expression="0 <= value <= 100"),
+                *[spec.NumberInput(id=nutrient, units=units)
+                    for nutrient, units in NUTRIENT_UNITS.items()]
+            ],
+            index_col="crop_name"
+        ),
     ],
     outputs=[
         spec.CSVOutput(
@@ -269,7 +330,7 @@ MODEL_SPEC = spec.ModelSpec(
             path="result_table.csv",
             about=gettext("Table of results aggregated by crop"),
             columns=[
-                spec.StringOutput(id="crop", about=gettext("Name of the crop")),
+                spec.StringOutput(id="crop_name", about=gettext("Name of the crop")),
                 spec.NumberOutput(
                     id="area (ha)",
                     about=gettext("Area covered by the crop"),
@@ -294,7 +355,7 @@ MODEL_SPEC = spec.ModelSpec(
                     for x in ["modeled", "observed"]
                 ]
             ],
-            index_col="crop"
+            index_col="crop_name"
         ),
         spec.SingleBandRasterOutput(
             id="[CROP]_observed_production",
@@ -350,7 +411,7 @@ MODEL_SPEC = spec.ModelSpec(
             id="[CROP]_clipped_observed_yield",
             path="intermediate_output/[CROP]_clipped_observed_yield.tif",
             about=gettext(
-                "Observed yield for the given crop, clipped to the extend of the"
+                "Observed yield for the given crop, clipped to the extent of the"
                 " landcover map"
             ),
             data_type=float,
@@ -403,7 +464,6 @@ MODEL_SPEC = spec.ModelSpec(
     aliases=("cpr",),
 )
 
-
 _INTERMEDIATE_OUTPUT_DIR = 'intermediate_output'
 
 _REGRESSION_TABLE_PATTERN = os.path.join(
@@ -443,10 +503,11 @@ def execute(args):
             converts landcover types to crop names that has two headers:
 
             * lucode: integer value corresponding to a landcover code in
-              `args['landcover_raster_path']`.
+                `args['landcover_raster_path']`.
             * crop_name: a string that must match one of the crops in
-              args['model_data_path']/climate_regression_yield_tables/[cropname]_*
-              A ValueError is raised if strings don't match.
+                CROP_OPTIONS. A ValueError is raised if no corresponding
+                climate bin raster path is found in the Climate Bin Raster
+                Table.
 
         args['fertilization_rate_table_path'] (string): path to CSV table
             that contains fertilization rates for the crops in the simulation,
@@ -458,17 +519,16 @@ def execute(args):
         args['aggregate_polygon_path'] (string): path to polygon vector
             that will be used to aggregate crop yields and total nutrient
             value. (optional, if value is None, then skipped)
-        args['model_data_path'] (string): path to the InVEST Crop Production
-            global data directory.  This model expects that the following
-            directories are subdirectories of this path:
-
-            * climate_bin_maps (contains [cropname]_climate_bin.tif files)
-            * climate_percentile_yield (contains
-              [cropname]_percentile_yield_table.csv files)
-
-            Please see the InVEST user's guide chapter on crop production for
-            details about how to download these data.
-
+        args['regression_yield_csv_table'] (string): path to a table that maps
+            each crop name to a path to its corresponding regression yield
+            table.
+        args['climate_bin_raster_table'] (string): path to a table that maps
+            each crop name to a path to its corresponding climate bin raster.
+        args['observed_yield_raster_table'] (string): path to a table that maps
+            each crop name to a path to its corresponding observed yield
+            raster.
+        args['crop_nutrient_table'] (string): path to a table that lists
+            amounts of nutrients in each crop.
     Returns:
         File registry dictionary mapping MODEL_SPEC output ids to absolute paths
 
@@ -494,6 +554,11 @@ def execute(args):
 
     LOGGER.info(
         "Checking if the landcover raster is missing lucodes")
+
+    # It might seem backwards to read the landcover_to_crop_table into a
+    # DataFrame called crop_to_landcover_df, but since the table is indexed
+    # by crop_name, it makes sense for the code to treat it as a mapping from
+    # crop name to LULC code.
     crop_to_landcover_df = MODEL_SPEC.get_input(
         'landcover_to_crop_table_path').get_validated_dataframe(
         args['landcover_to_crop_table_path'])
@@ -529,15 +594,20 @@ def execute(args):
             f"in the landcover to crop table: {lucodes_missing_from_table}")
 
     LOGGER.info("Checking that crops correspond to known types.")
+    bad_crop_name_list = []
     for crop_name in crop_to_landcover_df.index:
-        crop_regression_yield_table_path = os.path.join(
-            args['model_data_path'],
-            _REGRESSION_TABLE_PATTERN % crop_name)
-        if not os.path.exists(crop_regression_yield_table_path):
-            raise ValueError(
-                f"Expected regression yield table called "
-                f"{crop_regression_yield_table_path} for crop {crop_name} "
-                f"specified in {args['landcover_to_crop_table_path']}")
+        crop_climate_bin_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
+            CROP_TO_PATH_TABLES.climate_bin,
+            args[CROP_TO_PATH_TABLES.climate_bin],
+            crop_name)
+        if crop_climate_bin_raster_path is None:
+            bad_crop_name_list.append(crop_name)
+    if bad_crop_name_list:
+        raise ValueError(
+            "'The following crop names were provided in "
+            f"{args['landcover_to_crop_table_path']} but no corresponding "
+            f"climate bin raster path could be found: {bad_crop_name_list}")
 
     landcover_raster_info = pygeoprocessing.get_raster_info(
         args['landcover_raster_path'])
@@ -563,10 +633,12 @@ def execute(args):
 
     for crop_name, row in crop_to_landcover_df.iterrows():
         crop_lucode = row[_EXPECTED_LUCODE_TABLE_HEADER]
-        LOGGER.info("Processing crop %s", crop_name)
-        crop_climate_bin_raster_path = os.path.join(
-            args['model_data_path'],
-            _EXTENDED_CLIMATE_BIN_FILE_PATTERN % crop_name)
+        LOGGER.info(f'Processing crop {crop_name}')
+        crop_climate_bin_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
+            CROP_TO_PATH_TABLES.climate_bin,
+            args[CROP_TO_PATH_TABLES.climate_bin],
+            crop_name)
 
         # Use file_registry for clipped climate bin raster path
         crop_climate_bin_raster_info = pygeoprocessing.get_raster_info(
@@ -582,11 +654,16 @@ def execute(args):
             task_name='crop_climate_bin')
         dependent_task_list.append(crop_climate_bin_task)
 
-        crop_regression_df = MODEL_SPEC.get_input('model_data_path').get_contents(
-                'climate_regression_yield_tables').get_contents(
-                '[CROP]_regression_yield_table.csv').get_validated_dataframe(
-                    os.path.join(args['model_data_path'],
-                         _REGRESSION_TABLE_PATTERN % crop_name))
+        climate_regression_yield_table_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
+            CROP_TO_PATH_TABLES.regression_yield,
+            args[CROP_TO_PATH_TABLES.regression_yield],
+            crop_name)
+
+        crop_regression_df = MODEL_SPEC.get_input(
+            CROP_TO_PATH_TABLES.regression_yield).get_column(
+                'path').get_validated_dataframe(
+                    climate_regression_yield_table_path)
         for _, row in crop_regression_df.iterrows():
             for header in _EXPECTED_REGRESSION_TABLE_HEADERS:
                 if numpy.isnan(row[header]):
@@ -725,10 +802,12 @@ def execute(args):
             task_name='calc_min_of_NKP')
         dependent_task_list.append(calc_min_NKP_task)
 
-        LOGGER.info("Calculate observed yield for %s", crop_name)
-        global_observed_yield_raster_path = os.path.join(
-            args['model_data_path'],
-            _GLOBAL_OBSERVED_YIELD_FILE_PATTERN % crop_name)
+        LOGGER.info(f'Calculate observed yield for {crop_name}')
+        global_observed_yield_raster_path = get_full_path_from_crop_table(
+            MODEL_SPEC,
+            CROP_TO_PATH_TABLES.observed_yield,
+            args[CROP_TO_PATH_TABLES.observed_yield],
+            crop_name)
         global_observed_yield_raster_info = (
             pygeoprocessing.get_raster_info(
                 global_observed_yield_raster_path))
@@ -787,11 +866,14 @@ def execute(args):
             task_name='calculate_observed_production_%s' % crop_name)
         dependent_task_list.append(calculate_observed_production_task)
 
-    # both 'crop_nutrient.csv' and 'crop' are known data/header values for
-    # this model data.
-    nutrient_df = MODEL_SPEC.get_input('model_data_path').get_contents(
-        'crop_nutrient.csv').get_validated_dataframe(
-            os.path.join(args['model_data_path'], 'crop_nutrient.csv'))
+    nutrient_gdal_path = utils._GDALPath.from_uri(args['crop_nutrient_table'])
+    if nutrient_gdal_path.is_local:
+        nutrient_table_path = os.path.join(args['crop_nutrient_table'])
+    else:
+        nutrient_table_path = nutrient_gdal_path.to_normalized_path()
+
+    nutrient_df = MODEL_SPEC.get_input(
+        'crop_nutrient_table').get_validated_dataframe(nutrient_table_path)
 
     LOGGER.info("Generating report table")
     crop_names = list(crop_to_landcover_df.index)
@@ -938,7 +1020,7 @@ def tabulate_regression_results(
 
     with open(target_table_path, 'w') as result_table:
         result_table.write(
-            'crop,area (ha),' + 'production_observed,production_modeled,' +
+            'crop_name,area (ha),' + 'production_observed,production_modeled,' +
             ','.join(nutrient_headers) + '\n')
         for crop_name in sorted(crop_names):
             result_table.write(crop_name)

--- a/src/natcap/invest/crop_production_regression.py
+++ b/src/natcap/invest/crop_production_regression.py
@@ -466,16 +466,8 @@ MODEL_SPEC = spec.ModelSpec(
 
 _INTERMEDIATE_OUTPUT_DIR = 'intermediate_output'
 
-_REGRESSION_TABLE_PATTERN = os.path.join(
-    'climate_regression_yield_tables', '%s_regression_yield_table.csv')
-
 _EXPECTED_REGRESSION_TABLE_HEADERS = [
     'yield_ceiling', 'b_nut', 'b_k2o', 'c_n', 'c_p2o5', 'c_k2o']
-
-_GLOBAL_OBSERVED_YIELD_FILE_PATTERN = os.path.join(
-    'observed_yield', '%s_yield_map.tif')  # crop_name
-_EXTENDED_CLIMATE_BIN_FILE_PATTERN = os.path.join(
-    'extended_climate_bin_maps', 'extendedclimatebins%s.tif')  # crop_name
 
 _EXPECTED_NUTRIENT_TABLE_HEADERS = [
     'protein', 'lipid', 'energy', 'ca', 'fe', 'mg', 'ph', 'k', 'na', 'zn',

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -736,7 +736,7 @@ class CSVInput(FileInput):
         allowed_types = {
             BooleanInput, IntegerInput, NumberInput, OptionStringInput,
             PercentInput, RasterOrVectorInput, RatioInput, FileInput,
-            SingleBandRasterInput, StringInput, VectorInput}
+            SingleBandRasterInput, StringInput, VectorInput, CSVInput}
         for row in (self.rows or []):
             if type(row) not in allowed_types:
                 raise ValueError(f'Row {row} is not an allowed type')

--- a/tests/crop_production/data_helpers.py
+++ b/tests/crop_production/data_helpers.py
@@ -5,8 +5,8 @@ import pandas
 def sample_nutrient_df():
     """Generate a sample nutrient DataFrame for crops.
 
-    This function creates a small DataFrame containing example nutrient 
-    and production data for crops such as corn and soybean. It can be 
+    This function creates a small DataFrame containing example nutrient
+    and production data for crops such as corn and soybean. It can be
     used for testing nutrient calculations and validating model outputs.
 
     Returns:
@@ -15,7 +15,7 @@ def sample_nutrient_df():
     """
 
     return pandas.DataFrame([
-        {'crop': 'corn', 'area (ha)': 21.0, 'production_observed': 0.2,
+        {'crop_name': 'corn', 'area (ha)': 21.0, 'production_observed': 0.2,
          'percentrefuse': 7, 'protein': 42., 'lipid': 8, 'energy': 476.,
          'ca': 27.0, 'fe': 15.7, 'mg': 280.0, 'ph': 704.0, 'k': 1727.0,
          'na': 2.0, 'zn': 4.9, 'cu': 1.9, 'fl': 8, 'mn': 2.9, 'se': 0.1,
@@ -25,7 +25,7 @@ def sample_nutrient_df():
          'riboflavin': 1.8, 'niacin': 8.2, 'pantothenic': 0.9,
          'vitb6': 1.4, 'folate': 385.0, 'vitb12': 2.0, 'vitk': 41.0},
 
-        {'crop': 'soybean', 'area (ha)': 5., 'production_observed': 4.,
+        {'crop_name': 'soybean', 'area (ha)': 5., 'production_observed': 4.,
          'percentrefuse': 9, 'protein': 33., 'lipid': 2., 'energy': 99.,
          'ca': 257., 'fe': 15.7, 'mg': 280., 'ph': 704.0, 'k': 197.0,
          'na': 2., 'zn': 4.9, 'cu': 1.6, 'fl': 3., 'mn': 5.2, 'se': 0.3,
@@ -34,7 +34,7 @@ def sample_nutrient_df():
          'gammat': 2.3, 'deltat': 1.2, 'vitc': 3.0, 'thiamin': 0.42,
          'riboflavin': 0.82, 'niacin': 12.2, 'pantothenic': 0.92,
          'vitb6': 5.4, 'folate': 305., 'vitb12': 3., 'vitk': 42.},
-         ]).set_index('crop')
+         ]).set_index('crop_name')
 
 
 def tabulate_regr_results_table():
@@ -50,7 +50,7 @@ def tabulate_regr_results_table():
     """
 
     return pandas.DataFrame([
-        {'crop': 'corn', 'area (ha)': 20.0,
+        {'crop_name': 'corn', 'area (ha)': 20.0,
          'production_observed': 80.0, 'production_modeled': 40.0,
          'protein_modeled': 15624000.0, 'protein_observed': 31248000.0,
          'lipid_modeled': 2976000.0, 'lipid_observed': 5952000.0,
@@ -85,7 +85,7 @@ def tabulate_regr_results_table():
          'folate_modeled': 143220000.0, 'folate_observed': 286440000.0,
          'vitb12_modeled': 744000.0, 'vitb12_observed': 1488000.0,
          'vitk_modeled': 15252000.0, 'vitk_observed': 30504000.0},
-        {'crop': 'soybean', 'area (ha)': 40.0,
+        {'crop_name': 'soybean', 'area (ha)': 40.0,
          'production_observed': 120.0, 'production_modeled': 70.0,
          'protein_modeled': 21021000.0, 'protein_observed': 36036000.0,
          'lipid_modeled': 1274000.0, 'lipid_observed': 2184000.0,
@@ -135,7 +135,7 @@ def tabulate_pctl_results_table():
     """
 
     return pandas.DataFrame({
-        "crop": ["corn", "soybean"], "area (ha)": [2, 4],
+        "crop_name": ["corn", "soybean"], "area (ha)": [2, 4],
         "production_observed": [4, 7], "production_25": [1.25, 2.25],
         "production_50": [2.5, 4.5], "production_75": [3.75, 6.75],
         "protein_25": [488250, 675675], "protein_50": [976500, 1351350],

--- a/tests/test_crop_production.py
+++ b/tests/test_crop_production.py
@@ -9,7 +9,7 @@ from osgeo import gdal, ogr, osr
 import pandas
 import pygeoprocessing
 from shapely.geometry import Polygon
-from natcap.invest.crop_production_percentile import CROP_TO_PATH_TABLES
+from natcap.invest.crop_production_regression import CROP_TO_PATH_TABLES
 
 gdal.UseExceptions()
 MODEL_DATA_PATH = os.path.join(

--- a/tests/test_crop_production.py
+++ b/tests/test_crop_production.py
@@ -195,7 +195,7 @@ class CropProductionTests(unittest.TestCase):
         shutil.rmtree(self.workspace_dir)
 
     def test_crop_production_percentile(self):
-        """Crop Production: test crop production percentile regression."""
+        """Crop Production Percentile: validate results."""
         from natcap.invest import crop_production_percentile
 
         args = _get_default_args_percentile()
@@ -259,7 +259,7 @@ class CropProductionTests(unittest.TestCase):
                                           rtol=0, atol=0.1)
 
     def test_crop_production_percentile_no_nodata(self):
-        """Crop Production: test percentile model with undefined nodata raster.
+        """Crop Production Percentile: landcover raster without defined nodata.
 
         Test with a landcover raster input that has no nodata value
         defined.
@@ -308,20 +308,24 @@ class CropProductionTests(unittest.TestCase):
         pandas.testing.assert_frame_equal(
             expected_result_table, result_table, check_dtype=False)
 
-    def test_crop_production_percentile_bad_crop(self):
-        """Crop Production: test crop production with a bad crop name."""
+    def test_crop_production_percentile_invalid_crop_name(self):
+        """Crop Production Percentile: invalid user-specified crop name."""
         from natcap.invest import crop_production_percentile
 
         args = _get_default_args_percentile()
         args['workspace_dir'] = self.workspace_dir
         args['landcover_to_crop_table_path'] = os.path.join(
-                TEST_INPUTS_PATH, 'landcover_to_badcrop_table.csv')
+                TEST_INPUTS_PATH, 'landcover_to_invalid_crop_percentile.csv')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as context:
             crop_production_percentile.execute(args)
+        self.assertTrue("The following crop names were provided in "
+                        f"{args['landcover_to_crop_table_path']} but "
+                        "are not supported by the model: {'durian'}"
+                        in str(context.exception))
 
     def test_crop_production_percentile_missing_climate_bin(self):
-        """Crop Production: test crop percentile with a missing climate bin."""
+        """Crop Production Percentile: missing climate bin path."""
         from natcap.invest import crop_production_percentile
 
         args = _get_default_args_percentile()
@@ -331,23 +335,27 @@ class CropProductionTests(unittest.TestCase):
 
         with self.assertRaises(ValueError) as context:
             crop_production_percentile.execute(args)
-        self.assertTrue("no corresponding climate bin raster path"
-                        " could be found: ['wheat']" in str(context.exception))
+        self.assertTrue('No climate bin raster path could be found for wheat'
+                        in str(context.exception))
 
-    def test_crop_production_regression_bad_crop(self):
-        """Crop Production: test crop regression with a bad crop name."""
+    def test_crop_production_regression_invalid_crop_name(self):
+        """Crop Production Regression: invalid user-specified crop name."""
         from natcap.invest import crop_production_regression
 
         args = _get_default_args_regression()
         args['workspace_dir'] = self.workspace_dir
         args['landcover_to_crop_table_path'] = os.path.join(
-                TEST_INPUTS_PATH, 'landcover_to_badcrop_table.csv')
+                TEST_INPUTS_PATH, 'landcover_to_invalid_crop_regression.csv')
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as context:
             crop_production_regression.execute(args)
+        self.assertTrue("The following crop names were provided in "
+                        f"{args['landcover_to_crop_table_path']} but "
+                        "are not supported by the model: {'avocado'}"
+                        in str(context.exception))
 
     def test_crop_production_regression_missing_climate_bin(self):
-        """Crop Production: test crop regression with a missing climate bin."""
+        """Crop Production Regression: missing climate bin path."""
         from natcap.invest import crop_production_regression
 
         args = _get_default_args_regression()
@@ -357,11 +365,11 @@ class CropProductionTests(unittest.TestCase):
 
         with self.assertRaises(ValueError) as context:
             crop_production_regression.execute(args)
-        self.assertTrue("no corresponding climate bin raster path"
-                        " could be found: ['wheat']" in str(context.exception))
+        self.assertTrue('No climate bin raster path could be found for wheat'
+                        in str(context.exception))
 
     def test_crop_production_regression(self):
-        """Crop Production: test crop production regression model."""
+        """Crop Production Regression: validate results."""
         from natcap.invest import crop_production_regression
 
         args = _get_default_args_regression()
@@ -422,7 +430,7 @@ class CropProductionTests(unittest.TestCase):
                                           rtol=0, atol=0.001)
 
     def test_crop_production_regression_no_nodata(self):
-        """Crop Production: test regression model with undefined nodata raster.
+        """Crop Production Regression: landcover raster without defined nodata.
 
         Test with a landcover raster input that has no nodata value
         defined.


### PR DESCRIPTION
## Description
Resolves #2095 by refactoring Crop Production models (Percentile and Regression) to use CSVInputs in lieu of a DirectoryInput for model data.

Also renames existing `crop` table headers to `crop_name`, for consistency.

Note the "Validate Sampledata & User Guide" and "Build binaries" checks will fail until the UG PR is merged. 

## Checklist
- [x] Update Crop Production Percentile model
- [x] Update Crop Production Percentile tests (currently working with locally modified test data)
- [x] Update Crop Production Regression model
- [x] Update Crop Production Regression tests
- [x] Update sample data (see [invest-sample-data PR #46](https://bitbucket.org/natcap/invest-sample-data/pull-requests/46))
- [x] Update test data (see [invest-test-data PR #38](https://bitbucket.org/natcap/invest-test-data/pull-requests/38))
- [x] Update HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [x] Update the user's guide (see [UG PR #201](https://github.com/natcap/invest.users-guide/pull/201))
- [x] Test the Workbench UI (if relevant)
