### PR TITLE
I. #2116 update ndr load type text

### DIFF
--- a/src/natcap/invest/ndr/ndr.py
+++ b/src/natcap/invest/ndr/ndr.py
@@ -98,20 +98,21 @@ MODEL_SPEC = spec.ModelSpec(
                     about=(
                         "Whether the nutrient load in column load_p should be treated as"
                         " nutrient application rate or measured contaminant runoff."
-                        " 'application-rate' | 'measured-runoff'"
+                        " The value for load_type_p may be one of two text strings,"
+                        " either 'application-rate' or 'measured-runoff'."
                     ),
                     required="calc_p",
                     options=[
                         spec.Option(
                             key="application-rate",
                             about=(
-                                "Treat the load values as nutrient application rates"
+                                "Treat the load value as nutrient application rates"
                                 " (e.g. fertilizer, livestock waste, ...).The model will"
                                 " adjust the load using the application rate and"
                                 " retention efficiency: load_p * (1 - eff_p).")),
                         spec.Option(
                             key="measured-runoff",
-                            about="Treat the load values as measured contaminant runoff.")
+                            about="Treat the load value as measured contaminant runoff.")
                     ]
                 ),
                 spec.OptionStringInput(
@@ -119,7 +120,8 @@ MODEL_SPEC = spec.ModelSpec(
                     about=(
                         "Whether the nutrient load in column load_n should be treated as"
                         " nutrient application rate or measured contaminant runoff."
-                        " 'application-rate' | 'measured-runoff'"
+                        " The value for load_type_n may be one of two text strings,"
+                        " either 'application-rate' or 'measured-runoff'."
                     ),
                     required="calc_n",
                     options=[


### PR DESCRIPTION
## Description
Update NDR load type text.

The load type columns are currently `spec.OptionStringInput`, which has a type name of `option`. @newtpatrol commented that this can be confusing for a text input to a CSV. This PR does not handle that. If it's important we could change this to a `spec.StringInput` with a type name of `text` and add validation to ensure only the two sequences are allowed.

@newtpatrol or @jagoldstein any more thoughts on this?

Fixes #2116 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
