### PR TITLE
Workbench logging markup for plugins

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -89,6 +89,9 @@ Plugins
 * If plugin installation fails, the Workbench now cleans up any
   leftover, unusable micromamba environments.
   (`#2104 <https://github.com/natcap/invest/issues/2104>`_)
+* In the Workbench, Python log messages emitted by a plugin model will receive
+  the same styling as core invest models.
+  (`#2130 <https://github.com/natcap/invest/issues/2130>`_)
 
 Annual Water Yield
 ==================

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -352,7 +352,7 @@ def main(user_args=None):
         handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter(
             fmt='%(asctime)s %(name)-18s %(levelname)-8s %(message)s',
-            datefmt='%m/%d/%Y %H:%M:%S ')
+            datefmt='%Y-%m-%d %H:%M:%S ')
         handler.setFormatter(formatter)
 
         # Set the log level based on what the user provides in the available

--- a/workbench/src/main/findBinaries.js
+++ b/workbench/src/main/findBinaries.js
@@ -62,7 +62,7 @@ export function findInvestBinaries(isDevMode) {
 export function findMicromambaExecutable(isDevMode) {
   let micromambaExe;
   if (isDevMode) {
-    micromambaExe = 'micromamba'; // assume that micromamba is available
+    micromambaExe = process.env['MAMBA_EXE'] ?? 'micromamba'
   } else {
     micromambaExe = `"${upath.join(process.resourcesPath, 'micromamba')}"`;
   }

--- a/workbench/src/main/investLogMarkup.js
+++ b/workbench/src/main/investLogMarkup.js
@@ -1,5 +1,10 @@
+const datetimePrefix = /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\s+[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\s+/;
+
 /**
  * Assign a class based on text content.
+ * 
+ * Core invest models log from a logger name starting with natcap.invest
+ * Plugins should model from a logger name starting with invest
  *
  * @param  {string} message - from a python logger
  * @returns {string} - a class name or an empty string
@@ -8,10 +13,16 @@ export default function markupMessage(message) {
   if (/(ERROR|CRITICAL)/.test(message)) {
     return 'invest-log-error';
   }
-  if (/natcap\.invest.*WARNING/.test(message)) {
+  if (
+    new RegExp(`^${datetimePrefix.source}natcap\.invest.*WARNING`).test(message)
+    || new RegExp(`^${datetimePrefix.source}invest.*WARNING`).test(message)
+  ) {
     return 'invest-log-primary-warning';
   }
-  if (/natcap\.invest/.test(message)) {
+  if (
+    new RegExp(`^${datetimePrefix.source}natcap\.invest`).test(message)
+    || new RegExp(`^${datetimePrefix.source}invest`).test(message)
+  ) {
     return 'invest-log-primary';
   }
   return '';

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -84,7 +84,6 @@ export function setupInvestRunHandlers() {
         n_workers: nWorkers,
       }),
     };
-    await writeInvestParameters(payload);
     let cmd;
     let cmdArgs;
     let port;
@@ -114,6 +113,9 @@ export function setupInvestRunHandlers() {
         `-d "${datastackPath}"`];
       port = settingsStore.get('core.port');
     }
+    // Ensure we use the same invest to write the datastack
+    // as will get used to read it when the model runs.
+    await writeInvestParameters(payload, port);
 
     logger.debug(`about to run model with command: ${cmd} ${cmdArgs}`);
 

--- a/workbench/src/main/writeInvestParameters.js
+++ b/workbench/src/main/writeInvestParameters.js
@@ -6,8 +6,7 @@ import { settingsStore } from './settingsStore';
 const logger = getLogger(__filename.split('/').slice(-1)[0]);
 const HOSTNAME = 'http://127.0.0.1';
 
-export default function writeParametersToFile(payload) {
-  const port = settingsStore.get('core.port');
+export default function writeParametersToFile(payload, port) {
   return (
     fetch(`${HOSTNAME}:${port}/api/write_parameter_set_file`, {
       method: 'post',

--- a/workbench/tests/renderer/logtab.test.js
+++ b/workbench/tests/renderer/logtab.test.js
@@ -116,27 +116,39 @@ ValueError: Values in the LULC raster were found that are not represented under 
   });
 });
 
-describe('Unit tests for invest logger message markup', () => {
+describe.only('Unit tests for invest logger message markup', () => {
   test('Warning from natcap.invest gets primary-warning class attribute', () => {
-    const message = '2021-01-15 07:14:37,148 (natcap.invest.carbon) ... WARNING';
+    const message = '2021-01-15 07:14:37 natcap.invest.carbon WARNING ...';
+    const cls = markupMessage(message);
+    expect(cls).toBe('invest-log-primary-warning');
+  });
+
+  test('Warning from invest plugin gets primary-warning class attribute', () => {
+    const message = '2021-01-15 07:14:37 invest_foo.bar WARNING ...';
     const cls = markupMessage(message);
     expect(cls).toBe('invest-log-primary-warning');
   });
 
   test('Error from any module gets error class attribute', () => {
-    const message = '... (osgeo.gdal) ... ERROR';
+    const message = '2021-01-15 07:14:37 osgeo.gdal ERROR ...';
     const cls = markupMessage(message);
     expect(cls).toBe('invest-log-error');
   });
 
   test('Other natcap.invest messages get primary class attribute', () => {
-    const message = '2021-01-15 07:14:37,148 (natcap.invest.carbon) ... INFO';
+    const message = '2021-01-15 07:14:37 natcap.invest.carbon INFO ...';
+    const cls = markupMessage(message);
+    expect(cls).toBe('invest-log-primary');
+  });
+
+  test('Other invest plugin messages get primary class attribute', () => {
+    const message = '2021-01-15 07:14:37 invest_foo.bar INFO ...';
     const cls = markupMessage(message);
     expect(cls).toBe('invest-log-primary');
   });
 
   test('Others get no markup', () => {
-    const message = '2021-01-15 07:14:37,148 (osgeo.gdal) ... INFO';
+    const message = '2021-01-15 07:14:37 osgeo.gdal INFO invest is great';
     const cls = markupMessage(message);
     expect(cls).toBe('');
   });


### PR DESCRIPTION
Log messages from plugins get the same styles applied as messages from core invest models.

Fixes #2130 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
