### PR TITLE
Release 3.17.0 update sample data, test data, UG hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GIT_TEST_DATA_REPO_REV      := 36a447cc132079ed74952bd66bc0c0856d7da7b8
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide
-GIT_UG_REPO_REV             := 4211f346725316c66f74eec5000cd9d1213e0589
+GIT_UG_REPO_REV             := 0efe6219d3b2fce36bc5b89c51d7d5c7a248bd7c
 
 ENV = "./env"
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
## Description
Update hashes in makefile for:
- UG: merged main --> release/3.17.0
- Sample data: Was seemingly behind latest commit in [release/3.17.0 branch](https://bitbucket.org/natcap/invest-sample-data/commits/branch/release%2F3.17.0)
- Test data: Was seemingly behind latest commit in [release/3.17.0 branch](https://bitbucket.org/natcap/invest-test-data/commits/branch/release%2F3.17.0)

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
