### PR TITLE
Set SSL_CERT_FILE to resolve SSL errors in frozen binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ flask_cors
 requests
 geometamaker>=0.2.0
 pydantic
+certifi

--- a/src/natcap/invest/__init__.py
+++ b/src/natcap/invest/__init__.py
@@ -6,6 +6,7 @@ import sys
 from gettext import translation
 
 import babel
+import certifi
 
 LOGGER = logging.getLogger('natcap.invest')
 LOGGER.addHandler(logging.NullHandler())
@@ -20,6 +21,11 @@ except importlib.metadata.PackageNotFoundError:
         # package is not installed.  Log the exception for debugging.
         LOGGER.exception(
             'Could not load natcap.invest (or natcap_invest) version information')
+
+# Needed to reliably open datasets over HTTPS across different
+# systems when running in a pyinstaller frozen environment
+# https://github.com/natcap/invest/issues/2200
+os.environ['SSL_CERT_FILE'] = certifi.where()
 
 # location of our translation message catalog directory
 LOCALE_DIR = os.path.join(


### PR DESCRIPTION
## Description
Fixes #2200 

This technically adds a new dependency to `natcap.invest`, but `certifi` is super widely used and it's always been in our environments as a dependency of other packages, so that doesn't concern me.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
