### PR TITLE
Use bool rather than int in ManagedRaster cython constructor

### DIFF
--- a/src/natcap/invest/scenic_quality/viewshed.pyx
+++ b/src/natcap/invest/scenic_quality/viewshed.pyx
@@ -352,11 +352,12 @@ def viewshed(dem_raster_path_band,
 
     # LRU-cached rasters for easier access to individual pixels.
     cdef ManagedRaster dem_managed_raster = (
-            ManagedRaster(dem_raster_path_band[0].encode('utf-8'), dem_raster_path_band[1], 0))
+            ManagedRaster(dem_raster_path_band[0].encode('utf-8'),
+            dem_raster_path_band[1], False))
     cdef ManagedRaster aux_managed_raster = (
-        ManagedRaster(aux_filepath.encode('utf-8'), 1, 1))
+        ManagedRaster(aux_filepath.encode('utf-8'), 1, True))
     cdef ManagedRaster visibility_managed_raster = (
-            ManagedRaster(visibility_filepath.encode('utf-8'), 1, 1))
+            ManagedRaster(visibility_filepath.encode('utf-8'), 1, True))
 
     # get the pixel size in terms of meters.
     dem_srs = osr.SpatialReference()


### PR DESCRIPTION
## Description
Fixes #2239 

I think this issue resulted from some change in cython 3.2.0, which was released today. Scenic Quality is the only model still using the ManagedRaster cython interface (all others use it directly from C++). I see no downside to switching these over to bools.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
