### PR TITLE
Reset release schedule back to Tuesday

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -2,11 +2,11 @@ name: Release (Part 1 of 2)
 
 on:
   schedule:
-    # every tuesday (temporarily wednesday) at 6:20pm UTC (10:20am PST / 11:20am PDT)
+    # every tuesday at 6:20pm UTC (10:20am PST / 11:20am PDT)
     # cron doesn't support "first tuesday of the month", so we will use github
     # actions syntax below to skip tuesdays that aren't in the first week.
     # it is recommended not to start on the hour to avoid peak traffic
-    - cron: "20 18 * * 3"
+    - cron: "20 18 * * 2"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Description
Release schedule was temporarily changed to Wednesday to get around the Tuesday brownouts of GitHub's macos-13 runners. Now that we've upgraded to macos-15-intel, we can reset the schedule back to Tuesday.
