### PR TITLE
Actions: tell `gsutil` where to find Python

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
         env:
-          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy
 
   test-source-distribution:
@@ -269,7 +269,7 @@ jobs:
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         env:
-          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy
 
   validate-resources:
@@ -475,7 +475,7 @@ jobs:
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
         env:
-          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy
 
       # This relies on the file existing on GCP, so it must be run after `make
@@ -565,5 +565,5 @@ jobs:
       - name: Deploy artifacts to GCS
         if: github.event_name != 'pull_request'
         env:
-          CLOUDSDK_GSUTIL_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy


### PR DESCRIPTION
These changes essentially revert some changes we made a few months ago when I mistakenly thought we didn't need to jump through these extra hoops to use `gsutil`. Then Python 3.14 was released.

Fixes #2307 

The deploy steps ran on my fork and I observed no warnings from `gsutil` about missing python or incompatibility.
https://github.com/davemfish/invest/actions/runs/21252240444/job/61156736218

Test failures are due to #2310 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
