### PR TITLE
Provide user feedback on successful installation or removal of a plugin

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -102,6 +102,9 @@ Workbench
   the file browse button to populate an input, rather than requiring the user
   to "touch" the field again in order to see the validation status.
   (`#2149 <https://github.com/natcap/invest/issues/2149>`_)
+* The "Manage Plugins" modal now presents a message upon successful
+  installation or removal of a plugin.
+  (`#2276 <https://github.com/natcap/invest/issues/2276>`_)
 
 Coastal Vulnerability
 =====================

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -7,7 +7,7 @@ import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 import Spinner from 'react-bootstrap/Spinner';
 import { useTranslation } from 'react-i18next';
-import { MdClose } from 'react-icons/md';
+import { MdCheckCircleOutline, MdClose } from 'react-icons/md';
 
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
@@ -37,6 +37,8 @@ export default function PluginModal(props) {
   const [userAcknowledgment, setUserAcknowledgment] = useState(false);
   const [userAcknowledgmentError, setUserAcknowledgmentError] = useState(false);
   const [pluginSourceMissingError, setPluginSourceMissingError] = useState(false);
+  const [installSuccess, setInstallSuccess] = useState(false);
+  const [removalSuccess, setRemovalSuccess] = useState(false);
 
   const handleModalClose = () => {
     setURL('');
@@ -44,6 +46,8 @@ export default function PluginModal(props) {
     setInstallErr('');
     setUninstallErr('');
     clearFormErrors();
+    setInstallSuccess(false);
+    setRemovalSuccess(false);
     closeModal();
   };
 
@@ -91,6 +95,8 @@ export default function PluginModal(props) {
   };
 
   const addPlugin = () => {
+    setInstallSuccess(false);
+    setRemovalSuccess(false);
     setInstallLoading(true);
     ipcRenderer.invoke(
       ipcMainChannels.ADD_PLUGIN,
@@ -100,6 +106,7 @@ export default function PluginModal(props) {
     ).then(() => {
       setInstallLoading(false);
       updateInvestList();
+      setInstallSuccess(true);
       // clear the input fields
       setURL('');
       setRevision('');
@@ -110,6 +117,8 @@ export default function PluginModal(props) {
   };
 
   const removePlugin = () => {
+    setRemovalSuccess(false);
+    setInstallSuccess(false);
     setUninstallLoading(true);
     openJobs.forEach((job, tabID) => {
       if (job.modelID === pluginToRemove) {
@@ -119,6 +128,7 @@ export default function PluginModal(props) {
     ipcRenderer.invoke(
       ipcMainChannels.REMOVE_PLUGIN, pluginToRemove
     ).then(() => {
+      setRemovalSuccess(true);
       updateInvestList();
       setUninstallLoading(false);
     }).catch((err) => {
@@ -317,6 +327,17 @@ export default function PluginModal(props) {
             {t('This may take several minutes.')}
           </Form.Text>
         </Form.Group>
+          <div aria-live="polite">
+            { installSuccess &&
+              <Form.Text
+                as="span"
+                className="plugin-success"
+              >
+                <MdCheckCircleOutline />
+                {t('Successfully installed plugin')}
+              </Form.Text>
+            }
+          </div>
       </Form>
       <hr />
       <Form aria-labelledby="remove-plugin-form-title">
@@ -359,6 +380,17 @@ export default function PluginModal(props) {
             }
           </Button>
         </Form.Group>
+        <div aria-live="polite">
+          {removalSuccess &&
+            <Form.Text
+              as="span"
+              className="plugin-success"
+            >
+              <MdCheckCircleOutline />
+              {t('Successfully removed plugin')}
+            </Form.Text>
+          }
+        </div>
       </Form>
     </Modal.Body>
   );

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -1,7 +1,8 @@
 :root {
   font-size: 16px;
   --invest-green: #148F68;
-  --digital-red: #B1040E;
+  --digital-green: #008566; /* From Stanford brand guidelines. Better contrast for text than invest-green. */
+  --digital-red: #B1040E; /* From Stanford brand guidelines. */
   --bootstrap-secondary-gray:#6c757d;
 }
 
@@ -782,6 +783,18 @@ input[type=text]::placeholder {
 
 .plugin-user-acknowledgment-error {
   margin-bottom: 1rem;
+}
+
+.plugin-success {
+  color: var(--digital-green);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.plugin-success > svg {
+  height: 1.5rem;
+  width: 1.5rem;
 }
 
 .plugin-form-text {


### PR DESCRIPTION
## Description
Fixes #2276 by adding a "Successfully installed plugin" message to the plugins modal on successful plugin installation.
I also added "Successfully removed plugin" message on successful plugin removal, because why not?

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)

## Screenshots
### Successful installation
<img width="1234" height="904" alt="plugin-install-success_2026-02-03" src="https://github.com/user-attachments/assets/ed5ef140-546b-4e8b-94df-be17911080df" />

### Successful removal
<img width="1235" height="886" alt="plugin-removal-success_2026-02-03" src="https://github.com/user-attachments/assets/d7ad11b2-10ab-4f0e-b6df-a71973a0bb1c" />
