### PR TITLE
Address common problems with puppeteer test on GHA MacOS runners

### DIFF
--- a/workbench/tests/binary_tests/puppet.test.js
+++ b/workbench/tests/binary_tests/puppet.test.js
@@ -117,6 +117,10 @@ beforeEach(() => {
       // disable gpu because macos runners display:
       // ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer
       '--disable-gpu',
+      // Some other recommendations for errors we've seen on macos
+      // https://github.com/puppeteer/puppeteer/issues/12857
+      '--enable-features=NetworkServiceInProcess2',
+      '--no-sandbox',
     ],
     {
       shell: true,


### PR DESCRIPTION
These chromium flags seem to help avoid some OS-level warnings we were seeing consistently. Those issues may have contributed to slower startup for the app and more likely timeouts of the test.

Fixes #2315 

So far I've run the checks on this branch three times and they are 3/3 passing.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
