### PR TITLE
Various fixes for autopr branch creation

### DIFF
--- a/.github/workflows/autopr-create.yml
+++ b/.github/workflows/autopr-create.yml
@@ -3,11 +3,13 @@ name: "AutoPR: Create PRs into release branches"
 env:
     SOURCE_BRANCH: main
 on:
-    pull_request:
-        types: [closed]
-        branches:
-            # Triggered when PR into this branch is closed.
-            - main
+    #pull_request:
+    #    types: [closed]
+    #    branches:
+    #        # Triggered when PR into this branch is closed.
+    #        - main
+
+    # Pushes to main (e.g. after a PR) are the only way that this workflow should be triggered.
     push:
         branches:
             - main


### PR DESCRIPTION
As proposed, the changes work on my fork, producing the correct behavior.  Having said that, there is a branch protection rule in place on the InVEST repo that I am unable to access on my fork, so it is possible that this is what's preventing branch creation.  I'd like to propose that we merge the PR as-is (pending your review, of course!) and then if the action fails I'll loosen the branch restrictions slightly.

The two main changes here are 1) limiting the workflow to only run on pushes to main and 2) the `gh api` calls now reflect the suggested parameters from the github api docs.  It's possible that the omission of some of these parameters were contributing to the error the api was reporting earlier.

RE: #2342 
