### PR TITLE
Update autopr branch deletion to use github API

### DIFF
--- a/.github/workflows/autopr-cleanup.yml
+++ b/.github/workflows/autopr-cleanup.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     delete-autopr-branch:
-        #if: github.repository == 'natcap/invest'
+        if: github.repository == 'natcap/invest'
         name: "AutoPR delete merged autopr branch"
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/autopr-create.yml
+++ b/.github/workflows/autopr-create.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     create-pr-into-release:
-        #if: github.repository == 'natcap/invest'
+        if: github.repository == 'natcap/invest'
         name: "AutoPR main into release branches"
         runs-on: ubuntu-latest
         permissions:


### PR DESCRIPTION
This updates the branch deletion logic to use the github api (authenticated via github actions' PAT) to delete the autopr branch.  Seems to work as expected on my fork, so fingers crossed it'll work here upstream.

Fixes #2361
