### PR TITLE
Reports: remove model-specific accent colors

### DIFF
--- a/src/natcap/invest/reports/templates/styles.html
+++ b/src/natcap/invest/reports/templates/styles.html
@@ -1,19 +1,7 @@
-{% set accent_color_suffix = model_id if model_id else 'default' %}
 <style>
   :root {
     --invest-green: #148f68;
-    --accent-color-default: #f0f0f0;
-
-    /* Model-specific accent colors should be added here as needed.
-       Helpful random color generator: https://rgbcolorpicker.com/random/pastel */
-    /* Make sure each accent color has sufficient contrast with black (#000).
-       Minimum 4.5:1; higher is better. Check with https://www.whocanuse.com/. */
-    --accent-color-carbon: #bed4f0;
-    --accent-color-coastal_vulnerability: #fff6d8;
-    --accent-color-ndr: #c2da9d;
-    --accent-color-sdr: #e4b5db;
-
-    --accent-color: var(--accent-color-{{ accent_color_suffix }});
+    --accent-color: #e9efec;
     --caption-border: 1px solid #000;
   }
   * {


### PR DESCRIPTION
## Description
Removes model-specific accent colors, opting instead for a light greenish gray for all reports. This color is meant to be distinct from other grays commonly used in reports, but subtle enough to avoid calling too much attention to itself.

This change doesn't rule out the possibility of introducing model-specific accent colors in the future, but starting from a more neutral default should make future color changes less jarring.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)

## Examples
### CV
<img width="1265" height="625" alt="uniform-accent-color-cv_2026-02-18" src="https://github.com/user-attachments/assets/8ca2f959-b003-42ec-bd45-e3478043e0b4" />

### Carbon
<img width="1269" height="629" alt="uniform-accent-color-carbon_2026-02-18" src="https://github.com/user-attachments/assets/b38ac868-e42a-49b9-8590-56db503b8da1" />
