### PR TITLE
Bugfix for unhandled exception during plugin installation

### DIFF
--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -265,8 +265,11 @@ export function setupAddPlugin(i18n) {
             logger.error('Error downloading plugin source code:');
             throw error;
           } finally {
+            logger.info('cleaning up temporary plugin source directory');
             // We only needed the pyproject.toml content, the rest can go.
-            fs.rmSync(tmpPluginDir, { recursive: true, force: true });
+            fs.rm(tmpPluginDir,
+              { recursive: true, force: true, maxRetries: 5 },
+              (err) => logger.error(err));
           }
         } else { // install from local path
           logger.info(`adding plugin from ${localPath}`);


### PR DESCRIPTION
My best guess is that a `git` process may have been locking some files in the temp dir that node is trying to remove. Allowing some retries did the trick.

I don't know when this bug appeared, it appears to be a race condition that was always there. But I don't run into it in `3.17.2` so perhaps it's related to nodejs upgrades we did recently.

Fixes #2405 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
