### PR TITLE
Fix plugin serve/run error on Mac when `invest` is installed via conda

### DIFF
--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -127,6 +127,8 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   const modelEnvPath = settingsStore.get(`plugins.${modelID}.env`);
   const args = [
     'run', '--prefix', `"${modelEnvPath}"`,
+    // calling invest with python avoids issues with unescaped
+    // spaces in the python path in the conda bin/invest script
     'python -m natcap.invest', '--debug', 'serve', '--port', port];
   logger.debug('spawning command:', micromamba, args);
   // shell mode is necessary in dev mode & relying on a conda env

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -100,6 +100,8 @@ export function setupInvestRunHandlers() {
       cmdArgs = [
         'run',
         `--prefix "${settingsStore.get(`plugins.${modelID}.env`)}"`,
+        // calling invest with python avoids issues with unescaped
+        // spaces in the python path in the conda bin/invest script
         'python -m natcap.invest',
         LOGLEVELMAP[loggingLevel],
         TGLOGLEVELMAP[taskgraphLoggingLevel],


### PR DESCRIPTION
## Description
Fixes #2410 

Changing the `serve` and `run` commands to call `invest` with python seems to prevent the invalid path error that some of us were seeing with plugins on Mac when `natcap.invest` is installed via conda. This is working on my OS, but it would be great to test on others' systems (and on Windows). The demo plugin, which has `natcap.invest` listed as a conda dependency, is a good test case for confirming installation and launch success. 

See [this demo plugin issue](https://github.com/natcap/invest-demo-plugin/issues/3) for a discussion / some guidance on installing dependencies from conda when possible, to avoid pitfalls with building wheels that sometimes occur with pip.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
