### PR TITLE
Adding license and NOTICE.txt to docker builds.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -131,6 +131,8 @@ General
   (`#2229 <https://github.com/natcap/invest/issues/2229>`_)
 * Temporarily removed Python 3.10 from CI and PyPI wheel builds.
   (`#2424 <https://github.com/natcap/invest/issues/2424>`_)
+* Docker container builds now include the InVEST license and NOTICES.txt.
+  (`#2422 <https://github.com/natcap/invest/issues/2422>`_)
 
 Workbench
 =========

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@ ADD src /invest/src
 ADD pyproject.toml /invest/pyproject.toml
 ADD setup.py /invest/setup.py
 ADD requirements.txt /invest/requirements.txt
+ADD LICENSE.txt /invest/LICENSE.txt
+ADD NOTICE.txt /invest/NOTICE.txt
 ADD .git /invest/.git
 RUN cd /invest && python3 -m build
 


### PR DESCRIPTION
Just a small PR to resolve a warning that our LICENSE (and NOTICE.txt by implication) were not being included in our container builds.

Fixes #2422

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
