### PR TITLE
Workbench: pass only "enabled" args to a model run

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -74,6 +74,13 @@ General
   errors. (`#831 <https://github.com/natcap/invest/issues/813>`_)
 
 
+Workbench
+=========
+* The Workbench now filters model args to include only those whose
+  corresponding form fields are enabled at the time a model is run.
+  (`#2436 <https://github.com/natcap/invest/issues/2436>`_)
+
+
 3.18.0 (2026-02-25)
 -------------------
 

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -299,9 +299,20 @@ class SetupTab extends React.Component {
     }
   }
 
+  /** Invoke `investExecute` with prepared model args.
+   *
+   * Args are filtered to include only those whose corresponding form
+   * fields are enabled, then converted to an InVEST args dict-like object.
+   */
   wrapInvestExecute() {
+    const modelArgs = {};
+    for (const key in this.state.argsEnabled) {
+      if (this.state.argsEnabled[key] === true) {
+        modelArgs[key] = {...this.state.argsValues[key]};
+      }
+    }
     this.props.investExecute(
-      argsDictFromObject(this.state.argsValues)
+      argsDictFromObject(modelArgs)
     );
   }
 

--- a/workbench/src/renderer/utils.js
+++ b/workbench/src/renderer/utils.js
@@ -7,7 +7,7 @@ const { ipcRenderer } = window.Workbench.electron;
 const { logger } = window.Workbench;
 
 /**
- * Create a JSON string with invest argument keys and values.
+ * Create a JS object containing only invest argument keys and values.
  * @param {object} args - object keyed by invest argument keys and
  *   with each item including a `value` property, among others.
  * @returns {object} - invest argument key: value pairs as expected


### PR DESCRIPTION
## Description
Fixes #2436.

Specifically: the Workbench now filters model args to include only those whose corresponding form fields are enabled at the time a model is run.

## Example: Carbon model with sample datastack
### Log, Before
```
Arguments for InVEST carbon 3.18.1.dev16+ga61b6b649.d20260304:
calc_sequestration        True
carbon_pools_path         /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/carbon_pools_willamette.csv
discount_rate             
do_valuation              False
lulc_alt_path             /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/lulc_future_willamette.tif
lulc_alt_year             2050
lulc_bas_path             /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/lulc_current_willamette.tif
lulc_bas_year             2020
n_workers                 -1
price_per_metric_ton_of_c 
rate_change               
results_suffix            willamette
workspace_dir             /Users/eadavis/invest-workspaces/carbon-disabled-inputs
```

### Log, After
```
calc_sequestration True
carbon_pools_path  /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/carbon_pools_willamette.csv
do_valuation       False
lulc_alt_path      /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/lulc_future_willamette.tif
lulc_bas_path      /Users/eadavis/invest-inputs/invest-sample-data_3.17.2/Carbon/lulc_current_willamette.tif
n_workers          -1
results_suffix     willamette
workspace_dir      /Users/eadavis/invest-workspaces/carbon-disabled-inputs
```

Note the log now omits all args that are enabled only when `do_valuation` is `True` (namely: `lulc_bas_year`, `lulc_alt_year`, `discount_rate`, `price_per_metric_ton_of_c`, and `rate_change`).

### Args Table, Before
<img width="1269" height="649" alt="args-table-with-disabled-inputs_2026-03-26" src="https://github.com/user-attachments/assets/5479deb8-a9de-497e-9c8c-9af0b06411f8" />

Note the values listed for `lulc_bas_year` and `lulc_alt_year`.

### Args Table, After
<img width="1267" height="651" alt="args-table-without-disabled-inputs_2026-03-26" src="https://github.com/user-attachments/assets/6896316f-23a6-4e26-a659-42af61788ab2" />

Note that `None` is now listed for `lulc_bas_year` and `lulc_alt_year`.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
