### PR TITLE
Fix memory leak in ManagedRaster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if platform.system() == 'Windows':
     include_dirs.append(os.path.join(
         os.environ["NATCAP_INVEST_GDAL_LIB_PATH"].rstrip(), "include"))
 else:
-    compiler_args = [subprocess.run(
+    compiler_args = ['-g', '-O0', subprocess.run(
         ['gdal-config', '--cflags'], capture_output=True, text=True
     ).stdout.strip()]
     compiler_and_linker_args = ['-std=c++20']

--- a/src/natcap/invest/managed_raster/ManagedRaster.h
+++ b/src/natcap/invest/managed_raster/ManagedRaster.h
@@ -515,6 +515,10 @@ public:
     m_ptr = new NeighborTuple(i, xj, yj, static_cast<float>(flow));
     i++;
   }
+
+  ~NeighborIterator() {
+    delete m_ptr;
+  }
 };
 
 // Iterates over neighbor pixels that are downslope of a given pixel,

--- a/src/natcap/invest/managed_raster/ManagedRaster.h
+++ b/src/natcap/invest/managed_raster/ManagedRaster.h
@@ -517,7 +517,9 @@ public:
   }
 
   ~NeighborIterator() {
-    delete m_ptr;
+    if (this->m_ptr != &endVal) {
+      delete this->m_ptr;
+    }
   }
 };
 

--- a/src/natcap/invest/managed_raster/ManagedRaster.h
+++ b/src/natcap/invest/managed_raster/ManagedRaster.h
@@ -379,6 +379,7 @@ class ManagedRaster {
       GDALClose( (GDALDatasetH) dataset );
       delete lru_cache;
       free(actualBlockWidths);
+      free(geotransform);
     }
 };
 


### PR DESCRIPTION
## Description
Fixes #

Adds a destructor to the `NeighborIterator` class, which `delete`s any remaining instance of `NeighborTuple`. 

`NeighborIterator` points to one `NeighborTuple` at a time (with its `m_ptr` attribute). Each time we call the `next()` method, the previous `NeighborTuple` is deleted and a new one is created. But if we break out of the iterator without reaching the end, the final `NeighborTuple` assigned to `m_ptr` never got deleted, causing the memory leak.

Running on the sample data, `valgrind` output before this change included:
```
==485979== 12,937,488 bytes in 808,593 blocks are definitely lost in loss record 11,521 of 11,521
==485979==    at 0x4C39913: operator new(unsigned long) (vg_replace_malloc.c:483)
==485979==    by 0x4A9BB572: next<> (ManagedRaster.h:689)
==485979==    by 0x4A9BB572: UpslopeNeighborIterator (ManagedRaster.h:655)
==485979==    by 0x4A9BB572: begin (ManagedRaster.h:842)
==485979==    by 0x4A9BB572: void run_sediment_deposition<MFD>(char*, char*, char*, char*, char*) (sediment_deposition.h:191)
==485979==    by 0x4A9B02CF: __pyx_pf_6natcap_6invest_3sdr_8sdr_core_calculate_sediment_deposition (sdr_core.cpp:3089)
==485979==    by 0x4A9B02CF: __pyx_pw_6natcap_6invest_3sdr_8sdr_core_1calculate_sediment_deposition(_object*, _object* const*, long, _object*) (sdr_core.cpp:2677)
==485979==    by 0x394595: UnknownInlinedFun (call.c:285)
==485979==    by 0x394595: _PyObject_Call (call.c:348)
...
==485979== LEAK SUMMARY:
==485979==    definitely lost: 19,310,808 bytes in 1,206,651 blocks
==485979==    indirectly lost: 5,024 bytes in 124 blocks
==485979==      possibly lost: 241,427 bytes in 296 blocks
==485979==    still reachable: 6,116,700 bytes in 14,739 blocks
==485979==                       of which reachable via heuristic:
==485979==                         stdstring          : 454 bytes in 6 blocks
==485979==         suppressed: 553,107 bytes in 1,194 blocks
```



## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
