### PR TITLE
Bugfix: plugin run logging

### DIFF
--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -30,14 +30,11 @@ import re
 import shutil
 import tarfile
 import tempfile
-import warnings
 
-from osgeo import gdal
-
-from . import spec
-from . import utils
-from . import models
-
+from natcap.invest import models
+from natcap.invest import spec
+from natcap.invest import utils
+from natcap.invest.utils import base_model_id
 
 LOGGER = logging.getLogger(__name__)
 DATASTACK_EXTENSION = '.invest.tar.gz'
@@ -142,7 +139,7 @@ def build_datastack_archive(args, model_id, datastack_path):
     """
     module = importlib.import_module(
         # For plugins, use the model id before the '@'
-        name=models.model_id_to_pyname[model_id.split('@')[0]])
+        name=models.model_id_to_pyname[base_model_id(model_id)])
 
     args = args.copy()
     temp_workspace = tempfile.mkdtemp(prefix='datastack_')
@@ -163,7 +160,7 @@ def build_datastack_archive(args, model_id, datastack_path):
     LOGGER.debug(f'Keys: {sorted(args.keys())}')
 
     spatial_types = {spec.SingleBandRasterInput, spec.VectorInput,
-        spec.RasterOrVectorInput}
+                     spec.RasterOrVectorInput}
     file_based_types = spatial_types.union({
         spec.CSVInput, spec.FileInput, spec.DirectoryInput})
     rewritten_args = {}
@@ -311,7 +308,7 @@ def build_datastack_archive(args, model_id, datastack_path):
             target_arg_value = target_filepath
             files_found[source_path] = target_arg_value
 
-        elif type(input_spec)is spec.DirectoryInput:
+        elif type(input_spec) is spec.DirectoryInput:
             # copy the whole folder
             target_directory = os.path.join(data_dir, f'{key}_directory')
             os.makedirs(target_directory)
@@ -367,7 +364,7 @@ def build_datastack_archive(args, model_id, datastack_path):
             subdir = os.path.dirname(parameter_set['args'][k])
             target_location = os.path.join(temp_workspace, subdir)
             spec.write_metadata_file(v, this_arg_spec, keywords,
-                                           out_workspace=target_location)
+                                     out_workspace=target_location)
 
     # Remove the handler before archiving the working dir (and the logfile)
     archive_filehandler.close()

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -3,7 +3,6 @@ import importlib
 import json
 import logging
 
-from osgeo import gdal
 from flask import Flask
 from flask import request
 from flask_cors import CORS
@@ -16,6 +15,7 @@ from natcap.invest import models
 from natcap.invest import spec
 from natcap.invest import usage
 from natcap.invest import validation
+from natcap.invest.utils import base_model_id
 
 LOGGER = logging.getLogger(__name__)
 
@@ -269,8 +269,9 @@ def build_datastack_archive():
 @app.route(f'/{PREFIX}/log_model_start', methods=['POST'])
 def log_model_start():
     payload = request.get_json()
+    modelID = base_model_id(payload['model_id'])
     usage._log_model(
-        pyname=models.model_id_to_pyname[payload['model_id']],
+        pyname=models.model_id_to_pyname[modelID],
         model_args=json.loads(payload['model_args']),
         invest_interface=payload['invest_interface'],
         session_id=payload['session_id'],

--- a/src/natcap/invest/utils.py
+++ b/src/natcap/invest/utils.py
@@ -2,8 +2,6 @@
 import ast
 import codecs
 import contextlib
-import functools
-import json
 import logging
 import os
 import platform
@@ -321,7 +319,7 @@ def read_csv_to_dataframe(path, **kwargs):
                 'encoding': 'utf-8-sig',
                 **kwargs
             })
-    except UnicodeDecodeError as error:
+    except UnicodeDecodeError:
         raise ValueError(
             f'The file {path} must be encoded as UTF-8 or ASCII')
 
@@ -711,7 +709,7 @@ class _GDALPath:
     scheme : str
         URI scheme such as "https" or "zip+s3".
     """
-    
+
     def __init__(self, path, archive, scheme):
         self.path = path
         self.archive = archive
@@ -1006,3 +1004,17 @@ def resample_population_raster(
         target_path=target_population_raster_path)
 
     shutil.rmtree(tmp_working_dir, ignore_errors=True)
+
+
+def base_model_id(model_id: str) -> str:
+    """Strip version info from an annotated model ID.
+
+    Useful for translating from a key in the Workbench's
+    ``settingsStore.plugins`` to a key in
+    ``natcap.invest.models.model_id_to_pyname``.
+
+    Returns the substring of ``model_id`` from position 0 up to, but not
+    including, the ``@``. If ``model_id`` contains no ``@``, ``model_id`` is
+    returned unchanged.
+    """
+    return model_id.split('@')[0]

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -147,7 +147,8 @@ class EndpointFunctionTests(unittest.TestCase):
                 'workspace_dir': 'foo'
             }),
         }
-        response = test_client.post(f'{ROUTE_PREFIX}/save_to_python', json=payload)
+        response = test_client.post(
+            f'{ROUTE_PREFIX}/save_to_python', json=payload)
         self.assertEqual(response.status_code, 200)
         # test_cli.py asserts the actual contents of the file
         self.assertTrue(os.path.exists(filepath))
@@ -204,11 +205,11 @@ class EndpointFunctionTests(unittest.TestCase):
             self.assertEqual(
                 response.json,
                 {'message': error_message, 'error': True})
-    
+
     @patch('natcap.invest.ui_server.usage.requests.post')
     @patch('natcap.invest.ui_server.usage.requests.get')
-    def test_log_model_start(self, mock_get, mock_post):
-        """UI server: log_model_start endpoint."""
+    def test_log_model_start_core_model(self, mock_get, mock_post):
+        """UI server: log_model_start endpoint with core model."""
         mock_response = Mock()
         mock_url = 'http://foo.org/bar.html'
         mock_response.json.return_value = {'START': mock_url}
@@ -239,6 +240,51 @@ class EndpointFunctionTests(unittest.TestCase):
         self.assertEqual(
             mock_post.call_args.kwargs['data']['session_id'],
             payload['session_id'])
+
+    @patch('natcap.invest.ui_server.usage.requests.post')
+    @patch('natcap.invest.ui_server.usage.requests.get')
+    @patch.dict(models.model_id_to_pyname,
+                {'sample_plugin': 'sample_plugin'}, clear=True)
+    def test_log_model_start_plugin(self, mock_get, mock_post):
+        """UI server: log_model_start endpoint with plugin."""
+        import importlib
+
+        mock_response = Mock()
+        mock_url = 'https://example.com'
+        mock_response.json.return_value = {'START': mock_url}
+        mock_get.return_value = mock_response
+        test_client = ui_server.app.test_client()
+        payload = {
+            # Plugin ID tracked by Workbench includes version info.
+            'model_id': 'sample_plugin@0_0_42',
+            'model_args': json.dumps({
+                'workspace_dir': 'sample_workspace'
+            }),
+            'invest_interface': 'Workbench',
+            'session_id': '12345',
+            'type': 'plugin'
+        }
+
+        # Mock ``importlib.import_module`` because ``usage._log_model`` will
+        # try to import 'sample_plugin' to access its ``MODEL_SPEC``, but
+        # 'sample_plugin' isn't a real importable module.
+        with patch.object(importlib, 'import_module', Mock(MODEL_SPEC={})):
+            response = test_client.post(
+                f'{ROUTE_PREFIX}/log_model_start', json=payload)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_data(as_text=True), 'OK')
+            mock_get.assert_called_once()
+            mock_post.assert_called_once()
+            self.assertEqual(mock_post.call_args.args[0], mock_url)
+            self.assertEqual(
+                mock_post.call_args.kwargs['data']['model_name'],
+                'sample_plugin')
+            self.assertEqual(
+                mock_post.call_args.kwargs['data']['invest_interface'],
+                payload['invest_interface'])
+            self.assertEqual(
+                mock_post.call_args.kwargs['data']['session_id'],
+                payload['session_id'])
 
     @patch('natcap.invest.ui_server.usage.requests.post')
     @patch('natcap.invest.ui_server.usage.requests.get')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,12 +13,10 @@ import tempfile
 import textwrap
 import threading
 import unittest
-import unittest.mock
 import warnings
 
 import numpy
 import numpy.testing
-import pandas as pd
 import pygeoprocessing
 from osgeo import gdal
 from osgeo import ogr
@@ -437,8 +435,6 @@ class ReadCSVToDataframeTests(unittest.TestCase):
         self.assertEqual(df['header2'][1], 'FOO')
         self.assertEqual(df['header3'][1], 'bar')
         self.assertEqual(df['header1'][0], 1)
-
-
 
 
 class CreateCoordinateTransformationTests(unittest.TestCase):
@@ -934,7 +930,8 @@ class ReclassifyRasterOpTests(unittest.TestCase):
         origin = (1180000, 690000)
         raster_path = os.path.join(self.workspace_dir, 'tmp_raster.tif')
 
-        array = numpy.array([[1,1,1], [2,2,2], [3,3,3]], dtype=numpy.int32)
+        array = numpy.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]],
+                            dtype=numpy.int32)
 
         pygeoprocessing.numpy_array_to_raster(
             array, -1, (1, -1), origin, projection_wkt, raster_path)
@@ -1003,6 +1000,7 @@ class ExpandPathTests(unittest.TestCase):
             self.assertEqual(
                 None, utils.expand_path(value, self.workspace_dir))
 
+
 class _GDALPathTests(unittest.TestCase):
 
     def test_local_path(self):
@@ -1029,11 +1027,13 @@ class _GDALPathTests(unittest.TestCase):
 
     def test_https_zip_path(self):
         from natcap.invest import utils
-        gdal_path = utils._GDALPath.from_uri('zip+https://example.com/foo.zip/foo/bar.tif')
+        gdal_path = utils._GDALPath.from_uri(
+            'zip+https://example.com/foo.zip/foo/bar.tif')
         self.assertTrue(gdal_path.is_remote)
         self.assertEqual(gdal_path.scheme, 'zip+https')
-        self.assertEqual(gdal_path.to_normalized_path(),
-                         '/vsizip/vsicurl/https://example.com/foo.zip/foo/bar.tif')
+        self.assertEqual(
+            gdal_path.to_normalized_path(),
+            '/vsizip/vsicurl/https://example.com/foo.zip/foo/bar.tif')
 
 
 class FormatArgsTest(unittest.TestCase):
@@ -1126,3 +1126,19 @@ class ResamplePopulationRasterTest(unittest.TestCase):
                 numpy.testing.assert_allclose(
                     population_array.sum(), resampled_population_array.sum(),
                     rtol=1e-3)
+
+
+class BaseModelIdTests(unittest.TestCase):
+    """Tests for natcap.invest.utils.base_model_id."""
+
+    def test_annotated_model_id(self):
+        """Annotated model ID should be stripped of annotations."""
+        from natcap.invest.utils import base_model_id
+        self.assertEqual(base_model_id('sample_plugin@0_0_42'),
+                         'sample_plugin')
+
+    def test_unannotated_model_id(self):
+        """Unannotated model ID should be returned unchanged."""
+        from natcap.invest.utils import base_model_id
+        self.assertEqual(base_model_id('sample_core_model'),
+                         'sample_core_model')

--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -26,8 +26,8 @@ export default function investUsageLogger() {
 
     const plugins = settingsStore.get('plugins');
     if (plugins && Object.keys(plugins).includes(modelID)) {
-      const source = plugins[modelID].source;
       body.type = 'plugin';
+      const source = plugins[modelID].source;
       // don't log the path to a local plugin, just log that it's local
       body.source = source.startsWith('git+') ? source : 'local';
     } else {

--- a/workbench/src/main/setupAddRemovePlugin.js
+++ b/workbench/src/main/setupAddRemovePlugin.js
@@ -201,7 +201,7 @@ function storePluginMetadataSync(
 
   // Write plugin metadata to the workbench's config.json
   logger.info('writing plugin info to settings store');
-  // Uniquely identify plugin by a hash of its ID and version
+  // Uniquely identify plugin by its ID and version
   // Replace dots with underscores in the version, because dots are a
   // special character in keys for electron-store's set and get methods
   const pluginID = `${modelID}@${version}`;


### PR DESCRIPTION
## Description
Fixes #2515.

Specifically: version info is stripped from a plugin ID before attempting to log a model run.

I also added/updated tests and did some minor cleanup (removing unused imports, removing unused variables, adding/removing whitespace) in the files I was working in.

Note that further changes to how we keep track of plugins (e.g., see #2525) may be coming in the not-too-distant future. The goal of this PR is only to get plugin usage logging working again.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
