### PR TITLE
Use `open` instead of (deprecated) `codecs.open`

### DIFF
--- a/scripts/update-citation-cff.py
+++ b/scripts/update-citation-cff.py
@@ -1,5 +1,4 @@
 import argparse
-import codecs
 import os
 
 RELEASES_BUCKET = 'http://releases.naturalcapitalproject.org'
@@ -20,7 +19,7 @@ def update_citation_file(citation_filepath, version, date):
     Returns:
         ``None``.
     """
-    with codecs.open(citation_filepath, encoding='utf-8') as citation_file:
+    with open(citation_filepath, encoding='utf-8') as citation_file:
         citation_data = citation_file.readlines()
 
     # This approach allows us to only change the lines we need to change and
@@ -40,7 +39,7 @@ def update_citation_file(citation_filepath, version, date):
 
         lines.append(line)
 
-    with codecs.open(citation_filepath, 'w', encoding='utf-8') as citation_file:
+    with open(citation_filepath, 'w', encoding='utf-8') as citation_file:
         citation_file.writelines(lines)
 
 

--- a/src/natcap/invest/cli.py
+++ b/src/natcap/invest/cli.py
@@ -1,7 +1,6 @@
 # coding=UTF-8
 """Single entry point for all InVEST applications."""
 import argparse
-import codecs
 import datetime
 import gettext
 import importlib
@@ -148,7 +147,7 @@ def export_to_python(target_filepath, model_id, args_dict=None):
         cast_args = dict((str(key), value) for (key, value)
                          in args_dict.items())
 
-    with codecs.open(target_filepath, 'w', encoding='utf-8') as py_file:
+    with open(target_filepath, 'w', encoding='utf-8') as py_file:
         args = pprint.pformat(cast_args, indent=4)  # 4 spaces
         # Tweak formatting from pprint:
         # * Bump parameter inline with starting { to next line

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -18,7 +18,6 @@ run.
 """
 
 import ast
-import codecs
 import collections
 import importlib
 import json
@@ -490,7 +489,7 @@ def build_parameter_set(args, model_id, paramset_path, relative=False):
         'model_id': model_id,
         'args': _recurse(args)
     }
-    with codecs.open(paramset_path, 'w', encoding='UTF-8') as paramset_file:
+    with open(paramset_path, 'w', encoding='UTF-8') as paramset_file:
         paramset_file.write(
             json.dumps(parameter_data,
                        indent=4,
@@ -515,7 +514,7 @@ def extract_parameter_set(paramset_path):
             model_id (string): the ID of the model that these parameters are for
     """
     paramset_parent_dir = os.path.dirname(os.path.abspath(paramset_path))
-    with codecs.open(paramset_path, 'r', encoding='UTF-8') as paramset_file:
+    with open(paramset_path, 'r', encoding='UTF-8') as paramset_file:
         params_raw = paramset_file.read()
 
     read_params = json.loads(params_raw)
@@ -587,7 +586,7 @@ def extract_parameters_from_logfile(logfile_path):
     Raises:
         ValueError - when no arguments could be parsed from the logfile.
     """
-    with codecs.open(logfile_path, 'r', encoding='utf-8') as logfile:
+    with open(logfile_path, 'r', encoding='utf-8') as logfile:
         detected_args = []
         args_started = False
         for line in logfile:


### PR DESCRIPTION
## Description
Fixes #2520 by replacing calls to `codecs.open` (deprecated in Python 3.14) with calls to `open`, and remove `codecs` import where no longer needed.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
