### PR TITLE
Align raster subplots by adding top padding even if there isn't a units subheading

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -66,6 +66,12 @@
   Unreleased Changes
   ------------------
 
+General
+=======
+* To ensure consistent raster plot sizing in reports, padding is now added to
+  the top of raster plots if an adjacent raster plot has a units subheading.
+  (`#2471 <https://github.com/natcap/invest/issues/2471>`_)
+
 3.19.0 (2026-04-16)
 -------------------
 

--- a/src/natcap/invest/reports/raster_utils.py
+++ b/src/natcap/invest/reports/raster_utils.py
@@ -355,7 +355,7 @@ def _get_title_kwargs(title: str, resampled: bool, line_width: int, facets=False
     }
 
 
-def _get_units_text_kwargs(units: str, subtitle_offset: int):
+def _get_units_text_kwargs(units: str, subtitle_offset: float):
     # Place subtitle text immediately above subtitle_offset padding.
     text_args = {
         'fontsize': SUBTITLE_FONT_SIZE,

--- a/src/natcap/invest/reports/raster_utils.py
+++ b/src/natcap/invest/reports/raster_utils.py
@@ -355,15 +355,8 @@ def _get_title_kwargs(title: str, resampled: bool, line_width: int, facets=False
     }
 
 
-def _get_units_text_kwargs(units: str, raster_height: int):
-    # This -0.1 multiplier is a bit of a 'magic number' but seems to work for now.
-    subtitle_offset = -0.1 * raster_height
-    # Set ylim top < 0 to add some padding above the plot.
-    ylim_args = {
-        'bottom': raster_height,
-        'top': subtitle_offset,
-    }
-    # Place subtitle text immediately above that padding.
+def _get_units_text_kwargs(units: str, subtitle_offset: int):
+    # Place subtitle text immediately above subtitle_offset padding.
     text_args = {
         'fontsize': SUBTITLE_FONT_SIZE,
         'horizontalalignment': 'left',
@@ -372,7 +365,7 @@ def _get_units_text_kwargs(units: str, raster_height: int):
         'x': -0.5,
         'y': subtitle_offset,
     }
-    return (ylim_args, text_args)
+    return text_args
 
 
 def _get_legend_kwargs(num_patches: int, n_plots: int, xy_ratio: float):
@@ -415,6 +408,11 @@ def plot_raster_list(raster_list: list[RasterPlotConfig]):
     xy_ratio = _get_aspect_ratio(bbox)
     fig, axs = _figure_subplots(xy_ratio, n_plots)
 
+    # To ensure that plots in same group are the same size, subtitle_offset
+    # padding is needed if _any_ raster in list has units (see InVEST #2471)
+    any_raster_has_units = any(
+        [_get_raster_units(r.raster_path) for r in raster_list])
+
     for ax, config in zip(axs.flatten(), raster_list):
         raster_path = config.raster_path
         dtype = config.datatype
@@ -443,10 +441,17 @@ def plot_raster_list(raster_list: list[RasterPlotConfig]):
             config.title, resampled, title_line_width))
 
         units = _get_raster_units(raster_path)
+        if any_raster_has_units:
+            # This -0.1 multiplier is a bit of a 'magic number' but seems to work for now.
+            subtitle_offset = -0.1 * len(arr)
+            # Set ylim top < 0 to add some padding above the plot.
+            ylim_args = {
+                'bottom': len(arr),  # raster height
+                'top': subtitle_offset,
+            }
+            ax.set_ylim(**ylim_args)
         if units:
-            (ylim_kwargs,
-             text_kwargs) = _get_units_text_kwargs(units, len(arr))
-            ax.set_ylim(**ylim_kwargs)
+            text_kwargs = _get_units_text_kwargs(units, subtitle_offset)
             ax.text(**text_kwargs)
 
         if dtype == 'nominal':

--- a/tests/reports/test_raster_utils.py
+++ b/tests/reports/test_raster_utils.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import geometamaker
 import matplotlib
 import matplotlib.testing.compare
 from matplotlib.testing import set_font_settings_for_testing
@@ -170,6 +171,39 @@ class RasterPlotLayoutTests(unittest.TestCase):
         actual_png = os.path.join(self.workspace_dir, figname)
         save_figure(fig, actual_png)
         compare_snapshots(reference, actual_png)
+
+    def test_plot_raster_list_units_subtitle_padding(self):
+        """Test subtitle offset for plots of rasters with and without units"""
+        shape = (4, 4)
+        make_simple_raster(self.raster_config.raster_path, shape)
+
+        # check that no subtitle offset because no units
+        fig = raster_utils.plot_raster_list([self.raster_config])
+        raster_axes = [ax for ax in fig.axes if ax.get_label() != '<colorbar>']
+        for ax in raster_axes:
+            ylim = ax.get_ylim()
+            expected_ylim = (3.5, -0.5)
+            self.assertEqual(ylim, expected_ylim)
+
+        # Test plot ylims if one raster has units and other does not
+        raster_path_with_units = os.path.join(self.workspace_dir, 'foo.tif')
+        make_simple_raster(raster_path_with_units, shape)
+        # units determined by checking metadata
+        metadata = geometamaker.describe(raster_path_with_units)
+        metadata.set_band_description(1, units="meters")
+        metadata.write()
+        raster_config_with_units = RasterPlotConfig(
+            raster_path_with_units,
+            RasterDatatype.continuous,
+            spec.Output(id='foo', units="meter"))
+
+        config_list = [self.raster_config, raster_config_with_units]
+        fig = raster_utils.plot_raster_list(config_list)
+        raster_axes = [ax for ax in fig.axes if ax.get_label() != '<colorbar>']
+        for ax in raster_axes:
+            bottom, top = ax.get_ylim()
+            expected_ylim = (shape[0], -0.1 * shape[0])
+            self.assertEqual((bottom, top), expected_ylim)
 
 
 class RasterPlotDatatypeAndTransformTests(unittest.TestCase):


### PR DESCRIPTION
## Description
Adds padding to the top of a raster plot if _any_ raster in the `raster_list` has units (and more specifically, a units subheading). This ensures that rasters in adjacent subplots are the same size even if one raster in the list has a units subheading and another does not. If no raster in a group has `units`, no padding will be added to any of the subplots.

Fixes #2471

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
