### PR TITLE
Reports: styling & other usability improvements to Vega-Lite visualizations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -78,6 +78,9 @@ General
 * To ensure consistent raster plot sizing in reports, padding is now added to
   the top of raster plots if an adjacent raster plot has a units subheading.
   (`#2471 <https://github.com/natcap/invest/issues/2471>`_)
+* Made some styling and usability improvements to the Vega-Lite visualizations
+  (e.g., vector plots, histograms) that appear in some InVEST reports.
+  (`#2532 <https://github.com/natcap/invest/issues/2532>`_)
 
 3.19.0 (2026-04-16)
 -------------------

--- a/src/natcap/invest/reports/templates/models/urban_mental_health.html
+++ b/src/natcap/invest/reports/templates/models/urban_mental_health.html
@@ -32,25 +32,25 @@
   )}}
 
   {% set cases_map_block = content_grid([
-    ('<div class="vega-fit-horizontal"><div id="cases_map"></div></div>', 100),
+    ('<div id="cases_map"></div>', 100),
     (caption(cases_map_caption, aggregate_map_source_list), 100)
   ]) %}
-  
+
   {% set cases_cost_items = [
     (cases_map_block, 100 if not cost_map_json else 50)
   ] %}
-  
+
   {% if cost_map_json %}
     {% set cost_map_block = content_grid([
-      ('<div class="vega-fit-horizontal"><div id="cost_map"></div></div>', 100),
+      ('<div id="cost_map"></div>', 100),
       (caption(cost_map_caption, aggregate_map_source_list), 100)
     ]) %}
-  
+
     {% set cases_cost_items = cases_cost_items + [
       (cost_map_block, 50)
     ] %}
   {% endif %}
-  
+
   {{ accordion_section(
     'Preventable Cases by AOI Feature',
     content_grid(cases_cost_items)
@@ -108,18 +108,18 @@
   {% set input_items = [
     (caption(raster_group_caption, pre_caption=True), 100)
   ] %}
-  
+
   {% if args_dict['lulc_base'] %}
     {% set input_items = input_items + [
       (caption(lulc_pre_caption, pre_caption=True), 100)
     ] %}
   {% endif %}
-  
+
   {% set input_items = input_items + [
     (raster_plot_img(inputs_img_src, 'Raster Inputs'), 100),
     (caption(inputs_caption, definition_list=True), 100)
   ] %}
-  
+
   {{ accordion_section(
     'Input Maps',
     content_grid(input_items)

--- a/src/natcap/invest/reports/templates/styles.html
+++ b/src/natcap/invest/reports/templates/styles.html
@@ -177,6 +177,10 @@
   align to top keeps the actual maps aligned*/
   .vega-embed {
     vertical-align: top;
+    svg {
+      max-width: 100%;
+      height: auto;
+    }
   }
   .vega-embed .vega-bind-radio label {
     padding-right: 0.5rem;
@@ -191,10 +195,6 @@
     border: 0.1rem solid var(--invest-green);
     border-collapse: collapse;
     font-size: 0.8rem;
-  }
-  .vega-fit-horizontal {
-    display: flex;
-    justify-content: center;
   }
   .caption {
     background-color: ghostwhite;

--- a/src/natcap/invest/reports/templates/styles.html
+++ b/src/natcap/invest/reports/templates/styles.html
@@ -181,6 +181,9 @@
       max-width: 100%;
       height: auto;
     }
+    &.has-actions summary {
+      opacity: 0.65;
+    }
   }
   .vega-embed .vega-bind-radio label {
     padding-right: 0.5rem;

--- a/src/natcap/invest/reports/templates/vega-embed-js.html
+++ b/src/natcap/invest/reports/templates/vega-embed-js.html
@@ -13,7 +13,7 @@
       throw error;
     }
     let el = document.getElementById(elId);
-    vegaEmbed('#'+elId, chart_spec, {
+    vegaEmbed(`#${elId}`, chart_spec, {
       // https://vega.github.io/vega-embed/#options
       mode: 'vega-lite',
       renderer: 'svg',
@@ -23,7 +23,8 @@
         // not necessarily useful to invest users.
         compiled: false,
         source: false,
-      }
+      },
+      downloadFileName: `InVEST-${elId}`,
     })
     .then(function (_result) {
       if (el.classList.contains('loading')) {

--- a/src/natcap/invest/reports/templates/vega-embed-js.html
+++ b/src/natcap/invest/reports/templates/vega-embed-js.html
@@ -16,6 +16,7 @@
     vegaEmbed('#'+elId, chart_spec, {
       // https://vega.github.io/vega-embed/#options
       mode: 'vega-lite',
+      renderer: 'svg',
       scaleFactor: { png: 2 }, // scale on export
       actions: {
         // These don't work in the electron browser context and are


### PR DESCRIPTION
## Description
Fixes #2532. Specifically, Vega-Lite visualizations (e.g., vector plots) are now styled to prevent them from overflowing their containers or overlapping one another. With this change, the `.vega-fit-horizontal` styles no longer appear to be needed, so I removed them.

I also snuck in a few other small improvements, namely:
- All vegaEmbed elements now use the SVG renderer instead of the default canvas renderer.
- The default filename for "Save as PNG" or "Save as SVG" downloads via the Vega actions menu is now `InVEST-{elementId}`, where the `elementId` is the `id` of the HTML element that contains the visualization. This ID is defined by the report author and is typically a short name that identifies the purpose of the visualization, e.g., `cases_map`, `habitat_map`, or `exposure_histogram`.
- The Vega actions menu button now has slightly higher contrast to make it easier for people to discover it.

## Examples
### Vector plots scale down at smaller viewport widths
<img width="732" height="519" alt="vector_plots_responsive-2026_05_01" src="https://github.com/user-attachments/assets/b19b4792-b132-4df5-b8df-215d77bd6bdb" />

### New default filename when saving an SVG or PNG
<img width="633" height="217" alt="vega_download_filename-2026_05_01" src="https://github.com/user-attachments/assets/9bebcaa8-31d9-45c0-a331-f5280873e6ae" />

### Vega actions menu button, before
<img width="610" height="320" alt="vega_actions_button-before-2026_05_01" src="https://github.com/user-attachments/assets/3d1708dd-9650-4580-8484-779ba99b88ae" />

### Vega actions menu button, after
<img width="615" height="316" alt="vega_actions_button-after-2026_05_01" src="https://github.com/user-attachments/assets/3abb07eb-d359-42e2-9022-2d9bba943fd8" />

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
