### PR TITLE
Workbench: Include docs link in plugin modal

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -87,6 +87,8 @@ Workbench
   doesn't recognize (such as the ID of a plugin that isn't installed, or an
   otherwise malformed model ID) now presents an error message instead of
   failing silently. (`#2489 <https://github.com/natcap/invest/issues/2489>`_)
+* Added a link to the InVEST Plugin Developer's Guide to the Workbench Manage
+  Plugins modal. (`#2145 <https://github.com/natcap/invest/issues/2145>`_)
 
 3.19.0 (2026-04-16)
 -------------------

--- a/workbench/src/renderer/components/MetadataModal/index.jsx
+++ b/workbench/src/renderer/components/MetadataModal/index.jsx
@@ -18,6 +18,7 @@ import { openLinkInBrowser } from '../../utils';
 
 function AboutMetadataDiv() {
   const { t } = useTranslation();
+  const gmmURL = "https://github.com/natcap/geometamaker";
 
   return (
     <div>
@@ -43,7 +44,9 @@ function AboutMetadataDiv() {
       <p>
         {t('InVEST uses GeoMetaMaker to generate metadata. Learn more about ')}
         <a
-          href="https://github.com/natcap/geometamaker"
+          href={gmmURL}
+          title={gmmURL}
+          aria-label={t('GeoMetaMaker GitHub repository (opens in web browser)')}
           onClick={openLinkInBrowser}
         >GeoMetaMaker on Github</a>.
       </p>

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -252,6 +252,7 @@ export default function PluginModal(props) {
     );
   }
 
+  const pluginsURL = "https://invest.readthedocs.io/en/latest/plugins.html";
   let modalBody = (
     <Modal.Body>
       <Form aria-labelledby="add-plugin-form-title">
@@ -398,7 +399,9 @@ export default function PluginModal(props) {
         <p>
           {t('For more information about plugins, read our ')}
           <a
-            href="https://invest.readthedocs.io/en/latest/plugins.html"
+            href={pluginsURL}
+            title={pluginsURL}
+            aria-label={t("Plugins Developer's Guide (opens in web browser)")}
             onClick={openLinkInBrowser}
           >{t("Developer's Guide")}</a>.
         </p>

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -9,6 +9,7 @@ import Spinner from 'react-bootstrap/Spinner';
 import { useTranslation } from 'react-i18next';
 import { MdCheckCircleOutline, MdClose } from 'react-icons/md';
 
+import { openLinkInBrowser } from '../../utils';
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
 const { ipcRenderer } = window.Workbench.electron;
@@ -392,6 +393,16 @@ export default function PluginModal(props) {
           }
         </div>
       </Form>
+      <hr />
+      <div>
+        <p>
+          {t('For more information about plugins, read our ')}
+          <a
+            href="https://invest.readthedocs.io/en/latest/plugins.html"
+            onClick={openLinkInBrowser}
+          >{t("Developer's Guide")}</a>.
+        </p>
+      </div>
     </Modal.Body>
   );
   if (installErr) {


### PR DESCRIPTION
## Description
Fixes #2145

Link the plugin developer docs from the Workbench "manage plugins" modal, to make it easier for folks to find more information. 

I debated whether to put this link at the top or bottom of the modal. I landed on the bottom, but really don't have a strong opinion and would be fine with switching it. Screenshots for comparison:
<img width="550" height="871" alt="Screenshot 2026-05-06 at 2 44 12 PM" src="https://github.com/user-attachments/assets/e332a677-040e-478a-8eb5-59494dc5ed74" />
<img width="551" height="872" alt="Screenshot 2026-05-06 at 2 43 12 PM" src="https://github.com/user-attachments/assets/ed542387-19fa-4349-9bfe-71ff34abba84" /> 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
