### PR TITLE
replace gsutil rsync with cp for single files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,10 +364,10 @@ deploy:
 	@echo "  * $(DOWNLOAD_DIR_URL)"
 
 deploy_wheel:
-	$(GSUTIL) -m rsync $(DIST_DIR)/*.whl $(DIST_URL_BASE)
+	$(GSUTIL) -m cp $(DIST_DIR)/*.whl $(DIST_URL_BASE)
 
 deploy_sdist:
-	$(GSUTIL) -m rsync $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
+	$(GSUTIL) -m cp $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
 
 deploy_data:
 	$(GSUTIL) -m rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data


### PR DESCRIPTION
## Description
Fixes #2548 

Apparently `gsutil rsync` only works on directories.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
