### PR TITLE
SDR: handle topology exception in `_geometries_overlap`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -92,6 +92,14 @@ Workbench
 * Added a link to the InVEST Plugin Developer's Guide to the Workbench Manage
   Plugins modal. (`#2145 <https://github.com/natcap/invest/issues/2145>`_)
 
+SDR
+===
+* Added exception-handling when checking if watershed geoemtries overlap.
+  Invalid geometries will no longer raise an exception during this check
+  because they can still be rasterized and used in zonal_statistics.
+  (`#2386 <https://github.com/natcap/invest/issues/2386>`_)
+
+
 3.19.0 (2026-04-16)
 -------------------
 

--- a/src/natcap/invest/sdr/sdr.py
+++ b/src/natcap/invest/sdr/sdr.py
@@ -15,6 +15,7 @@ import pygeoprocessing
 import pygeoprocessing.routing
 from osgeo import gdal
 from osgeo import ogr
+from shapely.errors import GEOSException
 
 from natcap.invest import gettext
 from natcap.invest import spec
@@ -1574,8 +1575,12 @@ def _generate_report(
     # It's worth it to check if the geometries don't significantly overlap.
     # On large rasters, this can save a TON of time rasterizing even a
     # relatively simple vector.
-    geometries_might_overlap = urban_nature_access._geometries_overlap(
-        watershed_results_sdr_path)
+    try:
+        geometries_might_overlap = urban_nature_access._geometries_overlap(
+            watershed_results_sdr_path)
+    except GEOSException as error:
+        geometries_might_overlap = True
+        LOGGER.warning(error)
     fields_and_rasters = [
         ('usle_tot', usle_path), ('sed_export', sed_export_path),
         ('sed_dep', sed_deposition_path), ('avoid_exp', avoided_export_path),

--- a/src/natcap/invest/urban_nature_access/urban_nature_access.py
+++ b/src/natcap/invest/urban_nature_access/urban_nature_access.py
@@ -897,9 +897,9 @@ def execute(args):
         split_population_fields = list(
             filter(lambda x: re.match(POP_FIELD_REGEX, x),
                    validation.load_fields_from_vector(
-                       args['admin_boundaries_vector_path'])))
+                       file_registry['reprojected_admin_boundaries'])))
 
-        if _geometries_overlap(args['admin_boundaries_vector_path']):
+        if _geometries_overlap(file_registry['reprojected_admin_boundaries']):
             LOGGER.warning(
                 "Some administrative boundaries overlap, which will affect "
                 "the accuracy of supply rasters per population group. ")


### PR DESCRIPTION
The `urban_nature_access._geometries_overlap` is a utility that can raise an exception on invalid geometries. The way it is used by SDR, we don't need to exit the program if there are invalid geometries.

I considered adding the exception-handling within the function itself, but depending on how the function is used, it may not always make sense to handle the exception in the same way.

In `urban_nature_access` I updated a couple places where the raw AOI input file was read for checking geometries, and for getting a list of fields, instead of reading from the reprojected version, which is the version actually used in subsequent geoprocessing.

Fixes #2386

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
