### PR TITLE
remove references to frictionless data in pyinstaller script

### DIFF
--- a/exe/invest.spec
+++ b/exe/invest.spec
@@ -14,15 +14,8 @@ conda_env = os.environ['CONDA_PREFIX']
 
 if is_win:
     proj_datas = (os.path.join(conda_env, 'Library/share/proj'), 'proj')
-    frictionless_datas = (
-        os.path.join(conda_env, 'Lib/site-packages/frictionless/assets'),
-        'frictionless/assets')
 else:
     proj_datas = (os.path.join(conda_env, 'share/proj'), 'proj')
-    frictionless_datas = (
-        glob.glob(os.path.join(
-            conda_env, 'lib/python3*/site-packages/frictionless/assets'))[0],
-        'frictionless/assets')
 
 kwargs = {
     'hookspath': [os.path.join(current_dir, 'exe', 'hooks')],
@@ -42,7 +35,7 @@ kwargs = {
         'scipy._lib.array_api_compat.numpy.fft',
         'scipy._cyutility'
     ],
-    'datas': [proj_datas, frictionless_datas],
+    'datas': [proj_datas],
     'cipher': block_cipher,
 }
 


### PR DESCRIPTION
`Frictionless` is no longer in the dependency chain as of `geometamaker` 0.3.2

Fixes #2538

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
