### PR TITLE
Don't try to upload sdist from build_binaries job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -432,7 +432,7 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-        run: make deploy_wheel deploy_sdist deploy_userguide deploy_workbench
+        run: make deploy_wheel deploy_userguide deploy_workbench
 
       # This relies on the file existing on GCP, so it must be run after `make
       # deploy` is called.


### PR DESCRIPTION
## Description
Fixes #2557
Removing `deploy_sdist` because apparently only the wheel is built in this job.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
