### PR TITLE
GHA maintenance: fix `deploy_reports`; replace `gsutil`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -439,7 +439,7 @@ jobs:
         id: invest-autotest
         if : |
           (github.event_name == 'push' &&
-          (startsWith(github.ref, 'refs/heads/bugfix') || github.ref == 'refs/heads/main')) ||
+          (startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main')) ||
           (github.event_name == 'pull_request' && startsWith(github.head_ref, 'autorelease'))
         run: |
           mkdir autotest_dir

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -195,15 +195,15 @@ jobs:
   #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
   #         path: conda-env.txt
 
-  #     - name: Authenticate GCP
-  #       if: github.event_name != 'pull_request'
-  #       uses: google-github-actions/auth@v3
-  #       with:
-  #         credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+      - name: Authenticate GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-  #     - name: Set up GCP
-  #       if: github.event_name != 'pull_request'
-  #       uses: google-github-actions/setup-gcloud@v3
+      - name: Set up GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v3
 
   #     # gsutil (part of make deploy) never seems to support the latest python version.
   #     - name: Set up python for gsutil
@@ -470,6 +470,8 @@ jobs:
       - name: Deploy autotest reports
         id: invest-autotest-deploy
         if: steps.invest-autotest.outcome == 'success' && matrix.os == 'windows-latest'
+        env:
+          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: |
           make deploy_autotest_reports AUTOTEST_DIR=autotest_dir
           make print-REPORTS_BASE_URL >> $GITHUB_OUTPUT
@@ -491,16 +493,16 @@ jobs:
       #     name: ${{ runner.os }}_puppeteer_log.zip'
       #     path: ${{ matrix.puppeteer-log }}
 
-      - name: Tar the workspace to preserve permissions
-        if: always()
-        run: tar -cvf ${{ matrix.workspace-path}} ${{ github.workspace }}
+      # - name: Tar the workspace to preserve permissions
+      #   if: always()
+      #   run: tar -cvf ${{ matrix.workspace-path}} ${{ github.workspace }}
 
       - name: Upload workspace on failure
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: InVEST-failed-${{ runner.os }}-workspace
-          path: ${{ matrix.workspace-path}}
+          path: ${{ github.workspace }}
 
   # build-sampledata:
   #   name: Build sampledata archives

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -322,7 +322,7 @@ jobs:
             binary-extension: dmg
           - os: windows-latest
             puppeteer-log: ~/AppData/Roaming/invest-workbench/logs/
-            workspace-path: ${{ github.workspace }}
+            workspace-path: InVEST-failed-windows-workspace.tar
             binary-extension: exe
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,294 +27,294 @@ env:
 
 
 jobs:
-  check-syntax-errors:
-    name: Check for syntax errors
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
+  # check-syntax-errors:
+  #   name: Check for syntax errors
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
 
-      - name: Set up python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+  #     - name: Set up python
+  #       uses: actions/setup-python@v6
+  #       with:
+  #         python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-      # this is fast enough that it's not worth caching
-      - name: Set up environment
-        run: pip install flake8
+  #     # this is fast enough that it's not worth caching
+  #     - name: Set up environment
+  #       run: pip install flake8
 
-      - name: Lint with flake8
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          python -m flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          python -m flake8 src --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  #     - name: Lint with flake8
+  #       run: |
+  #         # stop the build if there are Python syntax errors or undefined names
+  #         python -m flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
+  #         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+  #         python -m flake8 src --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-  check-rst-syntax:
-    name: Check RST syntax
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
+  # check-rst-syntax:
+  #   name: Check RST syntax
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        name: Set up python
-        with:
-          python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+  #     - uses: actions/setup-python@v6
+  #       name: Set up python
+  #       with:
+  #         python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-      - name: Set up environment
-        run: pip install doc8
+  #     - name: Set up environment
+  #       run: pip install doc8
 
-      - name: Lint with doc8
-        run: |
-          # Skip line-too-long errors (D001)
-          python -m doc8 --ignore D001 HISTORY.rst README_PYTHON.rst
+  #     - name: Lint with doc8
+  #       run: |
+  #         # Skip line-too-long errors (D001)
+  #         python -m doc8 --ignore D001 HISTORY.rst README_PYTHON.rst
 
-  run-model-tests:
-    name: Run model tests
-    runs-on: ${{ matrix.os }}
-    needs: check-syntax-errors
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: [windows-latest, macos-15-intel, ubuntu-latest]
-        include:
-          - os: ubuntu-latest
-            python-version: "3.10"
-            platform-specific-dependencies: libxcrypt
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Fetch complete history for accurate versioning
+  # run-model-tests:
+  #   name: Run model tests
+  #   runs-on: ${{ matrix.os }}
+  #   needs: check-syntax-errors
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+  #       os: [windows-latest, macos-15-intel, ubuntu-latest]
+  #       include:
+  #         - os: ubuntu-latest
+  #           python-version: "3.10"
+  #           platform-specific-dependencies: libxcrypt
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      # NOTE: It takes twice as long to save the sample data cache
-      # as it does to do a fresh clone (almost 5 minutes vs. 2.5 minutes)
-      # Test data is way, way faster by contrast (on the order of a few
-      # seconds to archive).
-      - name: Restore git-LFS test data cache
-        uses: actions/cache@v4
-        with:
-          path: data/invest-test-data
-          key: git-lfs-testdata-${{ hashfiles('Makefile') }}
+  #     # NOTE: It takes twice as long to save the sample data cache
+  #     # as it does to do a fresh clone (almost 5 minutes vs. 2.5 minutes)
+  #     # Test data is way, way faster by contrast (on the order of a few
+  #     # seconds to archive).
+  #     - name: Restore git-LFS test data cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: data/invest-test-data
+  #         key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
-      - uses: ./.github/actions/create_build_requirements_file
+  #     - uses: ./.github/actions/create_build_requirements_file
 
-      - name: Set up build environment
-        uses: ./.github/actions/setup_env
-        with:
-          requirements-files: requirements-build.txt
-          requirements: |
-            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-            python=${{ matrix.python-version }}
-          env-name: build_env
+  #     - name: Set up build environment
+  #       uses: ./.github/actions/setup_env
+  #       with:
+  #         requirements-files: requirements-build.txt
+  #         requirements: |
+  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+  #           python=${{ matrix.python-version }}
+  #         env-name: build_env
 
-      - name: Set up test environment
-        uses: ./.github/actions/setup_env
-        with:
-          env-name: test_env
-          requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
-          requirements: |
-            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-            ${{ matrix.platform-specific-dependencies }}
-            python=${{ matrix.python-version }}
-            twine
-            gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}
-            wheel
+  #     - name: Set up test environment
+  #       uses: ./.github/actions/setup_env
+  #       with:
+  #         env-name: test_env
+  #         requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
+  #         requirements: |
+  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+  #           ${{ matrix.platform-specific-dependencies }}
+  #           python=${{ matrix.python-version }}
+  #           twine
+  #           gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}
+  #           wheel
 
-      - name: Download previous conda environment.yml
-        continue-on-error: true
-        # Using 'dawidd6' since 'download-artifact' GH action doesn't
-        # support downloading artifacts from prior workflow runs
-        uses: dawidd6/action-download-artifact@v11
-        with:
-          workflow: build-and-test.yml
-          # Get frozen conda env artifact from last successful workflow
-          workflow_conclusion: success
-          name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
-          path: ./conda-env-artifact
+  #     - name: Download previous conda environment.yml
+  #       continue-on-error: true
+  #       # Using 'dawidd6' since 'download-artifact' GH action doesn't
+  #       # support downloading artifacts from prior workflow runs
+  #       uses: dawidd6/action-download-artifact@v11
+  #       with:
+  #         workflow: build-and-test.yml
+  #         # Get frozen conda env artifact from last successful workflow
+  #         workflow_conclusion: success
+  #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
+  #         path: ./conda-env-artifact
 
-      - name: Compare conda environments
-        if: matrix.os != 'ubuntu-latest'
-        run: |
-          micromamba list > conda-env.txt
-          # make sure that the exit code is always 0
-          # otherwise, an error appears in the action annotations
-          diff ./conda-env.txt ./conda-env-artifact/conda-env.txt || true
+  #     - name: Compare conda environments
+  #       if: matrix.os != 'ubuntu-latest'
+  #       run: |
+  #         micromamba list > conda-env.txt
+  #         # make sure that the exit code is always 0
+  #         # otherwise, an error appears in the action annotations
+  #         diff ./conda-env.txt ./conda-env-artifact/conda-env.txt || true
 
-      # `build` by default builds an sdist, and then a wheel from that sdist,
-      # so the following tests cover both distributions
-      - name: Build sdist and wheel
-        run: |
-          micromamba activate build_env
-          NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --no-isolation
-          ls -la dist
+  #     # `build` by default builds an sdist, and then a wheel from that sdist,
+  #     # so the following tests cover both distributions
+  #     - name: Build sdist and wheel
+  #       run: |
+  #         micromamba activate build_env
+  #         NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --no-isolation
+  #         ls -la dist
 
-      # Modify the wheel metadata to require the same minor version of gdal that we built against.
-      # The C++ extensions will be compiled and linked against the libgdal version
-      # that's in the build environment, and so that same libgdal version has to be
-      # available in the target environment. Each libgdal version corresponds to a
-      # minor version of GDAL itself. Adding this requirement to the package metadata
-      # should prevent it from being installed in an env without the necessary libgdal.
-      # Users who need a different GDAL version can use the conda-forge package or
-      # build their own wheel from source.
-      - name: Modify wheel to add gdal constraint
-        run: |
-          wheel unpack dist/*.whl --dest tmp
-          sed -i.bak 's/Requires-Dist: gdal.*/Requires-Dist: gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}/I' tmp/*/*.dist-info/METADATA
-          rm tmp/*/*.dist-info/*.bak
-          wheel pack tmp/* --dest-dir dist
+  #     # Modify the wheel metadata to require the same minor version of gdal that we built against.
+  #     # The C++ extensions will be compiled and linked against the libgdal version
+  #     # that's in the build environment, and so that same libgdal version has to be
+  #     # available in the target environment. Each libgdal version corresponds to a
+  #     # minor version of GDAL itself. Adding this requirement to the package metadata
+  #     # should prevent it from being installed in an env without the necessary libgdal.
+  #     # Users who need a different GDAL version can use the conda-forge package or
+  #     # build their own wheel from source.
+  #     - name: Modify wheel to add gdal constraint
+  #       run: |
+  #         wheel unpack dist/*.whl --dest tmp
+  #         sed -i.bak 's/Requires-Dist: gdal.*/Requires-Dist: gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}/I' tmp/*/*.dist-info/METADATA
+  #         rm tmp/*/*.dist-info/*.bak
+  #         wheel pack tmp/* --dest-dir dist
 
-      - name: Install wheel and run model tests
-        run: |
-          micromamba activate test_env
-          # uninstall InVEST if it was already in the restored cache
-          python -m pip uninstall -y natcap.invest
-          pip install $(find dist -name "natcap[._-]invest*.whl")
-          make test
+  #     - name: Install wheel and run model tests
+  #       run: |
+  #         micromamba activate test_env
+  #         # uninstall InVEST if it was already in the restored cache
+  #         python -m pip uninstall -y natcap.invest
+  #         pip install $(find dist -name "natcap[._-]invest*.whl")
+  #         make test
 
-      - name: Check long description with twine
-        run: twine check $(find dist -name "natcap[._-]invest*")
+  #     - name: Check long description with twine
+  #       run: twine check $(find dist -name "natcap[._-]invest*")
 
-      # Only upload sdist from one of the matrix cases because they should all be the same
-      - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-        with:
-          name: Source distribution
-          path: dist/*.tar.gz
+  #     # Only upload sdist from one of the matrix cases because they should all be the same
+  #     - name: Upload sdist artifact
+  #       uses: actions/upload-artifact@v4
+  #       if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+  #       with:
+  #         name: Source distribution
+  #         path: dist/*.tar.gz
 
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Wheel for ${{ matrix.os }} ${{ matrix.python-version }}
-          path: dist/*.whl
+  #     - name: Upload wheel artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: Wheel for ${{ matrix.os }} ${{ matrix.python-version }}
+  #         path: dist/*.whl
 
-      - name: Upload conda env artifact
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
-          path: conda-env.txt
+  #     - name: Upload conda env artifact
+  #       uses: actions/upload-artifact@v4
+  #       continue-on-error: true
+  #       with:
+  #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
+  #         path: conda-env.txt
 
-      - name: Authenticate GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+  #     - name: Authenticate GCP
+  #       if: github.event_name != 'pull_request'
+  #       uses: google-github-actions/auth@v3
+  #       with:
+  #         credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-      - name: Set up GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v3
+  #     - name: Set up GCP
+  #       if: github.event_name != 'pull_request'
+  #       uses: google-github-actions/setup-gcloud@v3
 
-      # gsutil (part of make deploy) never seems to support the latest python version.
-      - name: Set up python for gsutil
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-        id: python-gsutil-task
+  #     # gsutil (part of make deploy) never seems to support the latest python version.
+  #     - name: Set up python for gsutil
+  #       uses: actions/setup-python@v6
+  #       with:
+  #         python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+  #       id: python-gsutil-task
 
-      - name: Deploy wheel to GCS
-        if: github.event_name != 'pull_request'
-        env:
-          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-        run: make deploy_wheel
+  #     - name: Deploy wheel to GCS
+  #       if: github.event_name != 'pull_request'
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+  #       run: make deploy_wheel
 
-      # Only upload sdist from one of the matrix cases because they should all be the same
-      - name: Deploy sdist to GCS
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-        env:
-          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-        run: make deploy_sdist
+  #     # Only upload sdist from one of the matrix cases because they should all be the same
+  #     - name: Deploy sdist to GCS
+  #       if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+  #       run: make deploy_sdist
 
-  validate-resources:
-    name: Validate Sampledata & User Guide
-    runs-on: windows-latest
-    needs: check-syntax-errors
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Fetch complete history for accurate versioning
+  # validate-resources:
+  #   name: Validate Sampledata & User Guide
+  #   runs-on: windows-latest
+  #   needs: check-syntax-errors
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      - uses: ./.github/actions/create_build_requirements_file
+  #     - uses: ./.github/actions/create_build_requirements_file
 
-      - uses: ./.github/actions/setup_env
-        with:
-          requirements-files: requirements.txt requirements-build.txt
-          requirements: |
-            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-            python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
-            pytest
+  #     - uses: ./.github/actions/setup_env
+  #       with:
+  #         requirements-files: requirements.txt requirements-build.txt
+  #         requirements: |
+  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+  #           python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+  #           pytest
 
-      - name: Make install
-        run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
+  #     - name: Make install
+  #       run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
 
-      - name: Validate sample data
-        run: make validate_sampledata
+  #     - name: Validate sample data
+  #       run: make validate_sampledata
 
-      - name: Validate user guide links
-        run: make validate_userguide_filenames
+  #     - name: Validate user guide links
+  #       run: make validate_userguide_filenames
 
-  run-workbench-tests:
-    name: Run Workbench Tests
-    runs-on: ${{ matrix.os }}
-    needs: check-syntax-errors
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        os: [windows-latest, macos-15-intel]
+  # run-workbench-tests:
+  #   name: Run Workbench Tests
+  #   runs-on: ${{ matrix.os }}
+  #   needs: check-syntax-errors
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 4
+  #     matrix:
+  #       os: [windows-latest, macos-15-intel]
 
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Fetch complete history for accurate versioning
+  #   steps:
+  #     - name: Check out repo
+  #       uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      - uses: ./.github/actions/create_build_requirements_file
+  #     - uses: ./.github/actions/create_build_requirements_file
 
-      - name: Set up python environment
-        uses: ./.github/actions/setup_env
-        with:
-          requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt requirements-build.txt
-          requirements: |
-            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-            python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+  #     - name: Set up python environment
+  #       uses: ./.github/actions/setup_env
+  #       with:
+  #         requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt requirements-build.txt
+  #         requirements: |
+  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+  #           python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-      - name: Make install
-        run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
+  #     - name: Make install
+  #       run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
 
-      - name: Set up node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
+  #     - name: Set up node
+  #       uses: actions/setup-node@v6
+  #       with:
+  #         node-version: 22
 
-      - name: Restore node_modules cache
-        id: nodemodules-cache
-        uses: actions/cache@v4
-        with:
-          path: workbench/node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
+  #     - name: Restore node_modules cache
+  #       id: nodemodules-cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: workbench/node_modules
+  #         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
 
-      - name: Install workbench dependencies
-        if: steps.nodemodules-cache.outputs.cache-hit != 'true'
-        working-directory: workbench
-        run: |
-          yarn config set network-timeout 600000 -g
-          yarn install
+  #     - name: Install workbench dependencies
+  #       if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+  #       working-directory: workbench
+  #       run: |
+  #         yarn config set network-timeout 600000 -g
+  #         yarn install
 
-      - name: Run workbench tests
-        working-directory: workbench
-        env:
-          CI: true
-        run: yarn test
+  #     - name: Run workbench tests
+  #       working-directory: workbench
+  #       env:
+  #         CI: true
+  #       run: yarn test
 
   build-binaries:
     name: Build binaries
-    needs: check-syntax-errors
+    # needs: check-syntax-errors
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15-intel, windows-latest]
+        os: [windows-latest]
         include:
           - os: macos-15-intel
             puppeteer-log: ~/Library/Logs/invest-workbench/
@@ -366,102 +366,102 @@ jobs:
       - name: Build binaries
         run: make CONDA="$MAMBA_EXE" binaries
 
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
+      # - name: Install Node.js
+      #   uses: actions/setup-node@v6
+      #   with:
+      #     node-version: 22
 
-      - name: Restore node_modules cache
-        id: nodemodules-cache
-        uses: actions/cache@v4
-        with:
-          path: workbench/node_modules
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
+      # - name: Restore node_modules cache
+      #   id: nodemodules-cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: workbench/node_modules
+      #     key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
 
-      - name: Install Workbench Dependencies
-        if: steps.nodemodules-cache.outputs.cache-hit != 'true'
-        working-directory: workbench
-        run: |
-          yarn config set network-timeout 600000 -g
-          yarn install
+      # - name: Install Workbench Dependencies
+      #   if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+      #   working-directory: workbench
+      #   run: |
+      #     yarn config set network-timeout 600000 -g
+      #     yarn install
 
-      - name: Download micromamba for distribution (MacOS)
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-          mv bin/micromamba dist/
-          ./dist/micromamba --help  # make sure the executable works
+      # - name: Download micromamba for distribution (MacOS)
+      #   if: matrix.os == 'macos-15-intel'
+      #   run: |
+      #     curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+      #     mv bin/micromamba dist/
+      #     ./dist/micromamba --help  # make sure the executable works
 
-      - name: Download micromamba for distribution (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-          tar xf micromamba.tar.bz2
-          MOVE -Force Library\bin\micromamba.exe dist\micromamba.exe
-          .\dist\micromamba.exe --help  # make sure the executable works
+      # - name: Download micromamba for distribution (Windows)
+      #   if: matrix.os == 'windows-latest'
+      #   shell: pwsh
+      #   run: |
+      #     Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+      #     tar xf micromamba.tar.bz2
+      #     MOVE -Force Library\bin\micromamba.exe dist\micromamba.exe
+      #     .\dist\micromamba.exe --help  # make sure the executable works
 
-      - name: Authenticate GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+      # - name: Authenticate GCP
+      #   if: github.event_name != 'pull_request'
+      #   uses: google-github-actions/auth@v3
+      #   with:
+      #     credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-      - name: Set up GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v3
+      # - name: Set up GCP
+      #   if: github.event_name != 'pull_request'
+      #   uses: google-github-actions/setup-gcloud@v3
 
-      - name: Build Workbench
-        working-directory: workbench
-        env:
-          GH_TOKEN: env.GITHUB_TOKEN
-          DEBUG: electron-builder
-          CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
-        run: |
-          yarn run build
-          yarn run dist
+      # - name: Build Workbench
+      #   working-directory: workbench
+      #   env:
+      #     GH_TOKEN: env.GITHUB_TOKEN
+      #     DEBUG: electron-builder
+      #     CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
+      #   run: |
+      #     yarn run build
+      #     yarn run dist
 
-      # gsutil (part of make deploy) never seems to support the latest python version.
-      - name: Set up python for gsutil
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-        id: python-gsutil-task
+      # # gsutil (part of make deploy) never seems to support the latest python version.
+      # - name: Set up python for gsutil
+      #   uses: actions/setup-python@v6
+      #   with:
+      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+      #   id: python-gsutil-task
 
-      - name: Deploy binaries and user guide to GCS
-        if: github.event_name != 'pull_request'
-        env:
-          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-        run: make deploy_wheel deploy_userguide deploy_workbench
+      # - name: Deploy binaries and user guide to GCS
+      #   if: github.event_name != 'pull_request'
+      #   env:
+      #     CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+      #   run: make deploy_wheel deploy_userguide deploy_workbench
 
-      # This relies on the file existing on GCP, so it must be run after `make
-      # deploy` is called.
-      - name: Queue binaries for signing
-        if: github.event_name != 'pull_request'
-        env:
-          ACCESS_TOKEN: ${{ secrets.CODESIGN_QUEUE_ACCESS_TOKEN }}
-        run: |
-          make codesign
+      # # This relies on the file existing on GCP, so it must be run after `make
+      # # deploy` is called.
+      # - name: Queue binaries for signing
+      #   if: github.event_name != 'pull_request'
+      #   env:
+      #     ACCESS_TOKEN: ${{ secrets.CODESIGN_QUEUE_ACCESS_TOKEN }}
+      #   run: |
+      #     make codesign
 
-      - name: Upload workbench binary artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Workbench-${{ runner.os }}-binary
-          path: workbench/dist/*.${{ matrix.binary-extension }}
+      # - name: Upload workbench binary artifact
+      #   if: always()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: Workbench-${{ runner.os }}-binary
+      #     path: workbench/dist/*.${{ matrix.binary-extension }}
 
-      - name: Upload user's guide artifact (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: InVEST-user-guide
-          path: dist/InVEST_*_userguide.zip
+      # - name: Upload user's guide artifact (Windows)
+      #   if: matrix.os == 'windows-latest'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: InVEST-user-guide
+      #     path: dist/InVEST_*_userguide.zip
 
       - name: Run invest-autotest with binaries
         id: invest-autotest
         if : |
           (github.event_name == 'push' &&
-          (startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main')) ||
+          (startsWith(github.ref, 'refs/heads/bugfix') || github.ref == 'refs/heads/main')) ||
           (github.event_name == 'pull_request' && startsWith(github.head_ref, 'autorelease'))
         run: |
           mkdir autotest_dir
@@ -480,66 +480,66 @@ jobs:
           DEST=gs://releases.naturalcapitalproject.org/invest-reports/latest
           gsutil -m rsync -r ${{ steps.invest-autotest-deploy.outputs.REPORTS_BASE_URL }} $DEST
 
-      - name: Test electron app with puppeteer
-        working-directory: workbench
-        run: npx cross-env CI=true yarn run test-electron-app
+      # - name: Test electron app with puppeteer
+      #   working-directory: workbench
+      #   run: npx cross-env CI=true yarn run test-electron-app
 
-      - name: Upload workbench logging from puppeteer
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: ${{ runner.os }}_puppeteer_log.zip'
-          path: ${{ matrix.puppeteer-log }}
+      # - name: Upload workbench logging from puppeteer
+      #   uses: actions/upload-artifact@v4
+      #   if: always()
+      #   with:
+      #     name: ${{ runner.os }}_puppeteer_log.zip'
+      #     path: ${{ matrix.puppeteer-log }}
 
       - name: Tar the workspace to preserve permissions
-        if: failure()
+        if: always()
         run: tar -cvf ${{ matrix.workspace-path}} ${{ github.workspace }}
 
       - name: Upload workspace on failure
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: InVEST-failed-${{ runner.os }}-workspace
           path: ${{ matrix.workspace-path}}
 
-  build-sampledata:
-    name: Build sampledata archives
-    needs: check-syntax-errors
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # Fetch complete history for accurate versioning
+  # build-sampledata:
+  #   name: Build sampledata archives
+  #   needs: check-syntax-errors
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-        id: python-gsutil-task
+  #     - uses: actions/setup-python@v6
+  #       with:
+  #         python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+  #       id: python-gsutil-task
 
-      - name: Install dependencies
-        # dependencies of setup.py, needed to get the version string
-        run: pip install babel cython numpy setuptools setuptools_scm wheel
+  #     - name: Install dependencies
+  #       # dependencies of setup.py, needed to get the version string
+  #       run: pip install babel cython numpy setuptools setuptools_scm wheel
 
-      - run: make sampledata sampledata_single
+  #     - run: make sampledata sampledata_single
 
-      - name: Upload sample data artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: InVEST-sample-data
-          path: dist/*.zip
+  #     - name: Upload sample data artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: InVEST-sample-data
+  #         path: dist/*.zip
 
-      - name: Authenticate GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+  #     - name: Authenticate GCP
+  #       if: github.event_name != 'pull_request'
+  #       uses: google-github-actions/auth@v3
+  #       with:
+  #         credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-      - name: Set up GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v3
+  #     - name: Set up GCP
+  #       if: github.event_name != 'pull_request'
+  #       uses: google-github-actions/setup-gcloud@v3
 
-      - name: Deploy sample data to GCS
-        if: github.event_name != 'pull_request'
-        env:
-          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-        run: make deploy_data
+  #     - name: Deploy sample data to GCS
+  #       if: github.event_name != 'pull_request'
+  #       env:
+  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+  #       run: make deploy_data

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,8 +21,6 @@ env:
   # setuptools_scm: needed for versioning to work
   CONDA_DEFAULT_DEPENDENCIES: python-build setuptools_scm gdal==3.10.3
   LATEST_SUPPORTED_PYTHON_VERSION: "3.14"
-  # gsutil never seems to support the latest python
-  # GSUTIL_PYTHON_VERSION: "3.13"
   GDAL_VERSION_FOR_WHEEL_BUILD: "3.10.*"
 
 
@@ -205,24 +203,13 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v3
 
-      # gsutil (part of make deploy) never seems to support the latest python version.
-      # - name: Set up python for gsutil
-      #   uses: actions/setup-python@v6
-      #   with:
-      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-      #   id: python-gsutil-task
-
       - name: Deploy wheel to GCS
         if: github.event_name != 'pull_request'
-        # env:
-        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy_wheel
 
       # Only upload sdist from one of the matrix cases because they should all be the same
       - name: Deploy sdist to GCS
         if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-        # env:
-        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy_sdist
 
   validate-resources:
@@ -309,7 +296,7 @@ jobs:
 
   build-binaries:
     name: Build binaries
-    # needs: check-syntax-errors
+    needs: check-syntax-errors
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -421,17 +408,8 @@ jobs:
           yarn run build
           yarn run dist
 
-      # gsutil (part of make deploy) never seems to support the latest python version.
-      # - name: Set up python for gsutil
-      #   uses: actions/setup-python@v6
-      #   with:
-      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-      #   id: python-gsutil-task
-
       - name: Deploy binaries and user guide to GCS
         if: github.event_name != 'pull_request'
-        # env:
-        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy_wheel deploy_userguide deploy_workbench
 
       # This relies on the file existing on GCP, so it must be run after `make
@@ -470,8 +448,6 @@ jobs:
       - name: Deploy autotest reports
         id: invest-autotest-deploy
         if: steps.invest-autotest.outcome == 'success' && matrix.os == 'windows-latest'
-        env:
-          CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: |
           make deploy_autotest_reports AUTOTEST_DIR=autotest_dir
           make print-REPORTS_BASE_URL >> $GITHUB_OUTPUT
@@ -509,11 +485,6 @@ jobs:
         with:
           fetch-depth: 0 # Fetch complete history for accurate versioning
 
-      # - uses: actions/setup-python@v6
-      #   with:
-      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-      #   id: python-gsutil-task
-
       - name: Install dependencies
         # dependencies of setup.py, needed to get the version string
         run: pip install babel cython numpy setuptools setuptools_scm wheel
@@ -538,6 +509,4 @@ jobs:
 
       - name: Deploy sample data to GCS
         if: github.event_name != 'pull_request'
-        # env:
-        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: make deploy_data

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -301,7 +301,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-15-intel]
+        os: [macos-15-intel, windows-latest]
         include:
           - os: macos-15-intel
             puppeteer-log: ~/Library/Logs/invest-workbench/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -195,15 +195,15 @@ jobs:
   #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
   #         path: conda-env.txt
 
-      - name: Authenticate GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+      # - name: Authenticate GCP
+      #   if: github.event_name != 'pull_request'
+      #   uses: google-github-actions/auth@v3
+      #   with:
+      #     credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-      - name: Set up GCP
-        if: github.event_name != 'pull_request'
-        uses: google-github-actions/setup-gcloud@v3
+      # - name: Set up GCP
+      #   if: github.event_name != 'pull_request'
+      #   uses: google-github-actions/setup-gcloud@v3
 
   #     # gsutil (part of make deploy) never seems to support the latest python version.
   #     - name: Set up python for gsutil
@@ -427,6 +427,16 @@ jobs:
         with:
           python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
         id: python-gsutil-task
+
+      - name: Authenticate GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+
+      - name: Set up GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v3
 
       # - name: Deploy binaries and user guide to GCS
       #   if: github.event_name != 'pull_request'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -483,7 +483,6 @@ jobs:
         env:
           CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: |
-          find autotest_dir -name "*report*.html"
           make deploy_autotest_reports AUTOTEST_DIR=autotest_dir
           make print-REPORTS_BASE_URL >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -483,6 +483,7 @@ jobs:
         env:
           CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
         run: |
+          find autotest_dir -name "*report*.html"
           make deploy_autotest_reports AUTOTEST_DIR=autotest_dir
           make print-REPORTS_BASE_URL >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,290 +22,290 @@ env:
   CONDA_DEFAULT_DEPENDENCIES: python-build setuptools_scm gdal==3.10.3
   LATEST_SUPPORTED_PYTHON_VERSION: "3.14"
   # gsutil never seems to support the latest python
-  GSUTIL_PYTHON_VERSION: "3.13"
+  # GSUTIL_PYTHON_VERSION: "3.13"
   GDAL_VERSION_FOR_WHEEL_BUILD: "3.10.*"
 
 
 jobs:
-  # check-syntax-errors:
-  #   name: Check for syntax errors
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
+  check-syntax-errors:
+    name: Check for syntax errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-  #     - name: Set up python
-  #       uses: actions/setup-python@v6
-  #       with:
-  #         python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+      - name: Set up python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-  #     # this is fast enough that it's not worth caching
-  #     - name: Set up environment
-  #       run: pip install flake8
+      # this is fast enough that it's not worth caching
+      - name: Set up environment
+        run: pip install flake8
 
-  #     - name: Lint with flake8
-  #       run: |
-  #         # stop the build if there are Python syntax errors or undefined names
-  #         python -m flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
-  #         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-  #         python -m flake8 src --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          python -m flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          python -m flake8 src --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-  # check-rst-syntax:
-  #   name: Check RST syntax
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
+  check-rst-syntax:
+    name: Check RST syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
-  #     - uses: actions/setup-python@v6
-  #       name: Set up python
-  #       with:
-  #         python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+      - uses: actions/setup-python@v6
+        name: Set up python
+        with:
+          python-version: ${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-  #     - name: Set up environment
-  #       run: pip install doc8
+      - name: Set up environment
+        run: pip install doc8
 
-  #     - name: Lint with doc8
-  #       run: |
-  #         # Skip line-too-long errors (D001)
-  #         python -m doc8 --ignore D001 HISTORY.rst README_PYTHON.rst
+      - name: Lint with doc8
+        run: |
+          # Skip line-too-long errors (D001)
+          python -m doc8 --ignore D001 HISTORY.rst README_PYTHON.rst
 
-  # run-model-tests:
-  #   name: Run model tests
-  #   runs-on: ${{ matrix.os }}
-  #   needs: check-syntax-errors
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-  #       os: [windows-latest, macos-15-intel, ubuntu-latest]
-  #       include:
-  #         - os: ubuntu-latest
-  #           python-version: "3.10"
-  #           platform-specific-dependencies: libxcrypt
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #       with:
-  #         fetch-depth: 0 # Fetch complete history for accurate versioning
+  run-model-tests:
+    name: Run model tests
+    runs-on: ${{ matrix.os }}
+    needs: check-syntax-errors
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        os: [windows-latest, macos-15-intel, ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+            platform-specific-dependencies: libxcrypt
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch complete history for accurate versioning
 
-  #     # NOTE: It takes twice as long to save the sample data cache
-  #     # as it does to do a fresh clone (almost 5 minutes vs. 2.5 minutes)
-  #     # Test data is way, way faster by contrast (on the order of a few
-  #     # seconds to archive).
-  #     - name: Restore git-LFS test data cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: data/invest-test-data
-  #         key: git-lfs-testdata-${{ hashfiles('Makefile') }}
+      # NOTE: It takes twice as long to save the sample data cache
+      # as it does to do a fresh clone (almost 5 minutes vs. 2.5 minutes)
+      # Test data is way, way faster by contrast (on the order of a few
+      # seconds to archive).
+      - name: Restore git-LFS test data cache
+        uses: actions/cache@v4
+        with:
+          path: data/invest-test-data
+          key: git-lfs-testdata-${{ hashfiles('Makefile') }}
 
-  #     - uses: ./.github/actions/create_build_requirements_file
+      - uses: ./.github/actions/create_build_requirements_file
 
-  #     - name: Set up build environment
-  #       uses: ./.github/actions/setup_env
-  #       with:
-  #         requirements-files: requirements-build.txt
-  #         requirements: |
-  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-  #           python=${{ matrix.python-version }}
-  #         env-name: build_env
+      - name: Set up build environment
+        uses: ./.github/actions/setup_env
+        with:
+          requirements-files: requirements-build.txt
+          requirements: |
+            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+            python=${{ matrix.python-version }}
+          env-name: build_env
 
-  #     - name: Set up test environment
-  #       uses: ./.github/actions/setup_env
-  #       with:
-  #         env-name: test_env
-  #         requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
-  #         requirements: |
-  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-  #           ${{ matrix.platform-specific-dependencies }}
-  #           python=${{ matrix.python-version }}
-  #           twine
-  #           gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}
-  #           wheel
+      - name: Set up test environment
+        uses: ./.github/actions/setup_env
+        with:
+          env-name: test_env
+          requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt
+          requirements: |
+            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+            ${{ matrix.platform-specific-dependencies }}
+            python=${{ matrix.python-version }}
+            twine
+            gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}
+            wheel
 
-  #     - name: Download previous conda environment.yml
-  #       continue-on-error: true
-  #       # Using 'dawidd6' since 'download-artifact' GH action doesn't
-  #       # support downloading artifacts from prior workflow runs
-  #       uses: dawidd6/action-download-artifact@v11
-  #       with:
-  #         workflow: build-and-test.yml
-  #         # Get frozen conda env artifact from last successful workflow
-  #         workflow_conclusion: success
-  #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
-  #         path: ./conda-env-artifact
+      - name: Download previous conda environment.yml
+        continue-on-error: true
+        # Using 'dawidd6' since 'download-artifact' GH action doesn't
+        # support downloading artifacts from prior workflow runs
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: build-and-test.yml
+          # Get frozen conda env artifact from last successful workflow
+          workflow_conclusion: success
+          name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
+          path: ./conda-env-artifact
 
-  #     - name: Compare conda environments
-  #       if: matrix.os != 'ubuntu-latest'
-  #       run: |
-  #         micromamba list > conda-env.txt
-  #         # make sure that the exit code is always 0
-  #         # otherwise, an error appears in the action annotations
-  #         diff ./conda-env.txt ./conda-env-artifact/conda-env.txt || true
+      - name: Compare conda environments
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+          micromamba list > conda-env.txt
+          # make sure that the exit code is always 0
+          # otherwise, an error appears in the action annotations
+          diff ./conda-env.txt ./conda-env-artifact/conda-env.txt || true
 
-  #     # `build` by default builds an sdist, and then a wheel from that sdist,
-  #     # so the following tests cover both distributions
-  #     - name: Build sdist and wheel
-  #       run: |
-  #         micromamba activate build_env
-  #         NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --no-isolation
-  #         ls -la dist
+      # `build` by default builds an sdist, and then a wheel from that sdist,
+      # so the following tests cover both distributions
+      - name: Build sdist and wheel
+        run: |
+          micromamba activate build_env
+          NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" python -m build --no-isolation
+          ls -la dist
 
-  #     # Modify the wheel metadata to require the same minor version of gdal that we built against.
-  #     # The C++ extensions will be compiled and linked against the libgdal version
-  #     # that's in the build environment, and so that same libgdal version has to be
-  #     # available in the target environment. Each libgdal version corresponds to a
-  #     # minor version of GDAL itself. Adding this requirement to the package metadata
-  #     # should prevent it from being installed in an env without the necessary libgdal.
-  #     # Users who need a different GDAL version can use the conda-forge package or
-  #     # build their own wheel from source.
-  #     - name: Modify wheel to add gdal constraint
-  #       run: |
-  #         wheel unpack dist/*.whl --dest tmp
-  #         sed -i.bak 's/Requires-Dist: gdal.*/Requires-Dist: gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}/I' tmp/*/*.dist-info/METADATA
-  #         rm tmp/*/*.dist-info/*.bak
-  #         wheel pack tmp/* --dest-dir dist
+      # Modify the wheel metadata to require the same minor version of gdal that we built against.
+      # The C++ extensions will be compiled and linked against the libgdal version
+      # that's in the build environment, and so that same libgdal version has to be
+      # available in the target environment. Each libgdal version corresponds to a
+      # minor version of GDAL itself. Adding this requirement to the package metadata
+      # should prevent it from being installed in an env without the necessary libgdal.
+      # Users who need a different GDAL version can use the conda-forge package or
+      # build their own wheel from source.
+      - name: Modify wheel to add gdal constraint
+        run: |
+          wheel unpack dist/*.whl --dest tmp
+          sed -i.bak 's/Requires-Dist: gdal.*/Requires-Dist: gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}/I' tmp/*/*.dist-info/METADATA
+          rm tmp/*/*.dist-info/*.bak
+          wheel pack tmp/* --dest-dir dist
 
-  #     - name: Install wheel and run model tests
-  #       run: |
-  #         micromamba activate test_env
-  #         # uninstall InVEST if it was already in the restored cache
-  #         python -m pip uninstall -y natcap.invest
-  #         pip install $(find dist -name "natcap[._-]invest*.whl")
-  #         make test
+      - name: Install wheel and run model tests
+        run: |
+          micromamba activate test_env
+          # uninstall InVEST if it was already in the restored cache
+          python -m pip uninstall -y natcap.invest
+          pip install $(find dist -name "natcap[._-]invest*.whl")
+          make test
 
-  #     - name: Check long description with twine
-  #       run: twine check $(find dist -name "natcap[._-]invest*")
+      - name: Check long description with twine
+        run: twine check $(find dist -name "natcap[._-]invest*")
 
-  #     # Only upload sdist from one of the matrix cases because they should all be the same
-  #     - name: Upload sdist artifact
-  #       uses: actions/upload-artifact@v4
-  #       if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-  #       with:
-  #         name: Source distribution
-  #         path: dist/*.tar.gz
+      # Only upload sdist from one of the matrix cases because they should all be the same
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        with:
+          name: Source distribution
+          path: dist/*.tar.gz
 
-  #     - name: Upload wheel artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: Wheel for ${{ matrix.os }} ${{ matrix.python-version }}
-  #         path: dist/*.whl
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Wheel for ${{ matrix.os }} ${{ matrix.python-version }}
+          path: dist/*.whl
 
-  #     - name: Upload conda env artifact
-  #       uses: actions/upload-artifact@v4
-  #       continue-on-error: true
-  #       with:
-  #         name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
-  #         path: conda-env.txt
+      - name: Upload conda env artifact
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: Conda Env for ${{ matrix.os }} ${{ matrix.python-version }}
+          path: conda-env.txt
 
-      # - name: Authenticate GCP
-      #   if: github.event_name != 'pull_request'
-      #   uses: google-github-actions/auth@v3
+      - name: Authenticate GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+
+      - name: Set up GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v3
+
+      # gsutil (part of make deploy) never seems to support the latest python version.
+      # - name: Set up python for gsutil
+      #   uses: actions/setup-python@v6
       #   with:
-      #     credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+      #   id: python-gsutil-task
 
-      # - name: Set up GCP
-      #   if: github.event_name != 'pull_request'
-      #   uses: google-github-actions/setup-gcloud@v3
+      - name: Deploy wheel to GCS
+        if: github.event_name != 'pull_request'
+        # env:
+        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+        run: make deploy_wheel
 
-  #     # gsutil (part of make deploy) never seems to support the latest python version.
-  #     - name: Set up python for gsutil
-  #       uses: actions/setup-python@v6
-  #       with:
-  #         python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-  #       id: python-gsutil-task
+      # Only upload sdist from one of the matrix cases because they should all be the same
+      - name: Deploy sdist to GCS
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        # env:
+        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+        run: make deploy_sdist
 
-  #     - name: Deploy wheel to GCS
-  #       if: github.event_name != 'pull_request'
-  #       env:
-  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-  #       run: make deploy_wheel
+  validate-resources:
+    name: Validate Sampledata & User Guide
+    runs-on: windows-latest
+    needs: check-syntax-errors
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch complete history for accurate versioning
 
-  #     # Only upload sdist from one of the matrix cases because they should all be the same
-  #     - name: Deploy sdist to GCS
-  #       if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
-  #       env:
-  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-  #       run: make deploy_sdist
+      - uses: ./.github/actions/create_build_requirements_file
 
-  # validate-resources:
-  #   name: Validate Sampledata & User Guide
-  #   runs-on: windows-latest
-  #   needs: check-syntax-errors
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #       with:
-  #         fetch-depth: 0 # Fetch complete history for accurate versioning
+      - uses: ./.github/actions/setup_env
+        with:
+          requirements-files: requirements.txt requirements-build.txt
+          requirements: |
+            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+            python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+            pytest
 
-  #     - uses: ./.github/actions/create_build_requirements_file
+      - name: Make install
+        run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
 
-  #     - uses: ./.github/actions/setup_env
-  #       with:
-  #         requirements-files: requirements.txt requirements-build.txt
-  #         requirements: |
-  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-  #           python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
-  #           pytest
+      - name: Validate sample data
+        run: make validate_sampledata
 
-  #     - name: Make install
-  #       run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
+      - name: Validate user guide links
+        run: make validate_userguide_filenames
 
-  #     - name: Validate sample data
-  #       run: make validate_sampledata
+  run-workbench-tests:
+    name: Run Workbench Tests
+    runs-on: ${{ matrix.os }}
+    needs: check-syntax-errors
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        os: [windows-latest, macos-15-intel]
 
-  #     - name: Validate user guide links
-  #       run: make validate_userguide_filenames
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch complete history for accurate versioning
 
-  # run-workbench-tests:
-  #   name: Run Workbench Tests
-  #   runs-on: ${{ matrix.os }}
-  #   needs: check-syntax-errors
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 4
-  #     matrix:
-  #       os: [windows-latest, macos-15-intel]
+      - uses: ./.github/actions/create_build_requirements_file
 
-  #   steps:
-  #     - name: Check out repo
-  #       uses: actions/checkout@v6
-  #       with:
-  #         fetch-depth: 0 # Fetch complete history for accurate versioning
+      - name: Set up python environment
+        uses: ./.github/actions/setup_env
+        with:
+          requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt requirements-build.txt
+          requirements: |
+            ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
+            python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
 
-  #     - uses: ./.github/actions/create_build_requirements_file
+      - name: Make install
+        run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
 
-  #     - name: Set up python environment
-  #       uses: ./.github/actions/setup_env
-  #       with:
-  #         requirements-files: requirements.txt requirements-dev.txt constraints_tests.txt requirements-build.txt
-  #         requirements: |
-  #           ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
-  #           python=${{ env.LATEST_SUPPORTED_PYTHON_VERSION }}
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
 
-  #     - name: Make install
-  #       run: NATCAP_INVEST_GDAL_LIB_PATH="$CONDA_PREFIX/Library" make install
+      - name: Restore node_modules cache
+        id: nodemodules-cache
+        uses: actions/cache@v4
+        with:
+          path: workbench/node_modules
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
 
-  #     - name: Set up node
-  #       uses: actions/setup-node@v6
-  #       with:
-  #         node-version: 22
+      - name: Install workbench dependencies
+        if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+        working-directory: workbench
+        run: |
+          yarn config set network-timeout 600000 -g
+          yarn install
 
-  #     - name: Restore node_modules cache
-  #       id: nodemodules-cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: workbench/node_modules
-  #         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
-
-  #     - name: Install workbench dependencies
-  #       if: steps.nodemodules-cache.outputs.cache-hit != 'true'
-  #       working-directory: workbench
-  #       run: |
-  #         yarn config set network-timeout 600000 -g
-  #         yarn install
-
-  #     - name: Run workbench tests
-  #       working-directory: workbench
-  #       env:
-  #         CI: true
-  #       run: yarn test
+      - name: Run workbench tests
+        working-directory: workbench
+        env:
+          CI: true
+        run: yarn test
 
   build-binaries:
     name: Build binaries
@@ -314,7 +314,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, macos-15-intel]
         include:
           - os: macos-15-intel
             puppeteer-log: ~/Library/Logs/invest-workbench/
@@ -360,73 +360,46 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv  # Choco-provided command to reload environment variables
 
-      # - name: Build userguide
-      #   run: make userguide
+      - name: Build userguide
+        run: make userguide
 
       - name: Build binaries
         run: make CONDA="$MAMBA_EXE" binaries
 
-      # - name: Install Node.js
-      #   uses: actions/setup-node@v6
-      #   with:
-      #     node-version: 22
-
-      # - name: Restore node_modules cache
-      #   id: nodemodules-cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: workbench/node_modules
-      #     key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
-
-      # - name: Install Workbench Dependencies
-      #   if: steps.nodemodules-cache.outputs.cache-hit != 'true'
-      #   working-directory: workbench
-      #   run: |
-      #     yarn config set network-timeout 600000 -g
-      #     yarn install
-
-      # - name: Download micromamba for distribution (MacOS)
-      #   if: matrix.os == 'macos-15-intel'
-      #   run: |
-      #     curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-      #     mv bin/micromamba dist/
-      #     ./dist/micromamba --help  # make sure the executable works
-
-      # - name: Download micromamba for distribution (Windows)
-      #   if: matrix.os == 'windows-latest'
-      #   shell: pwsh
-      #   run: |
-      #     Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-      #     tar xf micromamba.tar.bz2
-      #     MOVE -Force Library\bin\micromamba.exe dist\micromamba.exe
-      #     .\dist\micromamba.exe --help  # make sure the executable works
-
-      # - name: Authenticate GCP
-      #   if: github.event_name != 'pull_request'
-      #   uses: google-github-actions/auth@v3
-      #   with:
-      #     credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
-
-      # - name: Set up GCP
-      #   if: github.event_name != 'pull_request'
-      #   uses: google-github-actions/setup-gcloud@v3
-
-      # - name: Build Workbench
-      #   working-directory: workbench
-      #   env:
-      #     GH_TOKEN: env.GITHUB_TOKEN
-      #     DEBUG: electron-builder
-      #     CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
-      #   run: |
-      #     yarn run build
-      #     yarn run dist
-
-      # gsutil (part of make deploy) never seems to support the latest python version.
-      - name: Set up python for gsutil
-        uses: actions/setup-python@v6
+      - name: Install Node.js
+        uses: actions/setup-node@v6
         with:
-          python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-        id: python-gsutil-task
+          node-version: 22
+
+      - name: Restore node_modules cache
+        id: nodemodules-cache
+        uses: actions/cache@v4
+        with:
+          path: workbench/node_modules
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
+
+      - name: Install Workbench Dependencies
+        if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+        working-directory: workbench
+        run: |
+          yarn config set network-timeout 600000 -g
+          yarn install
+
+      - name: Download micromamba for distribution (MacOS)
+        if: matrix.os == 'macos-15-intel'
+        run: |
+          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+          mv bin/micromamba dist/
+          ./dist/micromamba --help  # make sure the executable works
+
+      - name: Download micromamba for distribution (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Invoke-Webrequest -URI https://micro.mamba.pm/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+          tar xf micromamba.tar.bz2
+          MOVE -Force Library\bin\micromamba.exe dist\micromamba.exe
+          .\dist\micromamba.exe --help  # make sure the executable works
 
       - name: Authenticate GCP
         if: github.event_name != 'pull_request'
@@ -438,34 +411,51 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: google-github-actions/setup-gcloud@v3
 
-      # - name: Deploy binaries and user guide to GCS
-      #   if: github.event_name != 'pull_request'
-      #   env:
-      #     CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-      #   run: make deploy_wheel deploy_userguide deploy_workbench
+      - name: Build Workbench
+        working-directory: workbench
+        env:
+          GH_TOKEN: env.GITHUB_TOKEN
+          DEBUG: electron-builder
+          CSC_IDENTITY_AUTO_DISCOVERY: false  # disable electron-builder code signing
+        run: |
+          yarn run build
+          yarn run dist
 
-      # # This relies on the file existing on GCP, so it must be run after `make
-      # # deploy` is called.
-      # - name: Queue binaries for signing
-      #   if: github.event_name != 'pull_request'
-      #   env:
-      #     ACCESS_TOKEN: ${{ secrets.CODESIGN_QUEUE_ACCESS_TOKEN }}
-      #   run: |
-      #     make codesign
-
-      # - name: Upload workbench binary artifact
-      #   if: always()
-      #   uses: actions/upload-artifact@v4
+      # gsutil (part of make deploy) never seems to support the latest python version.
+      # - name: Set up python for gsutil
+      #   uses: actions/setup-python@v6
       #   with:
-      #     name: Workbench-${{ runner.os }}-binary
-      #     path: workbench/dist/*.${{ matrix.binary-extension }}
+      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+      #   id: python-gsutil-task
 
-      # - name: Upload user's guide artifact (Windows)
-      #   if: matrix.os == 'windows-latest'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: InVEST-user-guide
-      #     path: dist/InVEST_*_userguide.zip
+      - name: Deploy binaries and user guide to GCS
+        if: github.event_name != 'pull_request'
+        # env:
+        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+        run: make deploy_wheel deploy_userguide deploy_workbench
+
+      # This relies on the file existing on GCP, so it must be run after `make
+      # deploy` is called.
+      - name: Queue binaries for signing
+        if: github.event_name != 'pull_request'
+        env:
+          ACCESS_TOKEN: ${{ secrets.CODESIGN_QUEUE_ACCESS_TOKEN }}
+        run: |
+          make codesign
+
+      - name: Upload workbench binary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Workbench-${{ runner.os }}-binary
+          path: workbench/dist/*.${{ matrix.binary-extension }}
+
+      - name: Upload user's guide artifact (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: InVEST-user-guide
+          path: dist/InVEST_*_userguide.zip
 
       - name: Run invest-autotest with binaries
         id: invest-autotest
@@ -490,68 +480,64 @@ jobs:
         if: steps.invest-autotest-deploy.outcome == 'success' && github.ref == 'refs/heads/main'
         run: |
           DEST=gs://releases.naturalcapitalproject.org/invest-reports/latest
-          gsutil -m rsync -r ${{ steps.invest-autotest-deploy.outputs.REPORTS_BASE_URL }} $DEST
+          gcloud storage rsync -r ${{ steps.invest-autotest-deploy.outputs.REPORTS_BASE_URL }} $DEST
 
-      # - name: Test electron app with puppeteer
-      #   working-directory: workbench
-      #   run: npx cross-env CI=true yarn run test-electron-app
+      - name: Test electron app with puppeteer
+        working-directory: workbench
+        run: npx cross-env CI=true yarn run test-electron-app
 
-      # - name: Upload workbench logging from puppeteer
-      #   uses: actions/upload-artifact@v4
-      #   if: always()
-      #   with:
-      #     name: ${{ runner.os }}_puppeteer_log.zip'
-      #     path: ${{ matrix.puppeteer-log }}
-
-      # - name: Tar the workspace to preserve permissions
-      #   if: always()
-      #   run: tar -cvf ${{ matrix.workspace-path}} ${{ github.workspace }}
+      - name: Upload workbench logging from puppeteer
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ runner.os }}_puppeteer_log.zip'
+          path: ${{ matrix.puppeteer-log }}
 
       - name: Upload workspace on failure
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: InVEST-failed-${{ runner.os }}-workspace
           path: ${{ github.workspace }}
 
-  # build-sampledata:
-  #   name: Build sampledata archives
-  #   needs: check-syntax-errors
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #       with:
-  #         fetch-depth: 0 # Fetch complete history for accurate versioning
+  build-sampledata:
+    name: Build sampledata archives
+    needs: check-syntax-errors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch complete history for accurate versioning
 
-  #     - uses: actions/setup-python@v6
-  #       with:
-  #         python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-  #       id: python-gsutil-task
+      # - uses: actions/setup-python@v6
+      #   with:
+      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+      #   id: python-gsutil-task
 
-  #     - name: Install dependencies
-  #       # dependencies of setup.py, needed to get the version string
-  #       run: pip install babel cython numpy setuptools setuptools_scm wheel
+      - name: Install dependencies
+        # dependencies of setup.py, needed to get the version string
+        run: pip install babel cython numpy setuptools setuptools_scm wheel
 
-  #     - run: make sampledata sampledata_single
+      - run: make sampledata
 
-  #     - name: Upload sample data artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: InVEST-sample-data
-  #         path: dist/*.zip
+      - name: Upload sample data artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: InVEST-sample-data
+          path: dist/*.zip
 
-  #     - name: Authenticate GCP
-  #       if: github.event_name != 'pull_request'
-  #       uses: google-github-actions/auth@v3
-  #       with:
-  #         credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
+      - name: Authenticate GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACC_KEY }}
 
-  #     - name: Set up GCP
-  #       if: github.event_name != 'pull_request'
-  #       uses: google-github-actions/setup-gcloud@v3
+      - name: Set up GCP
+        if: github.event_name != 'pull_request'
+        uses: google-github-actions/setup-gcloud@v3
 
-  #     - name: Deploy sample data to GCS
-  #       if: github.event_name != 'pull_request'
-  #       env:
-  #         CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
-  #       run: make deploy_data
+      - name: Deploy sample data to GCS
+        if: github.event_name != 'pull_request'
+        # env:
+        #   CLOUDSDK_PYTHON: ${{ steps.python-gsutil-task.outputs.python-path }}
+        run: make deploy_data

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -360,8 +360,8 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv  # Choco-provided command to reload environment variables
 
-      - name: Build userguide
-        run: make userguide
+      # - name: Build userguide
+      #   run: make userguide
 
       - name: Build binaries
         run: make CONDA="$MAMBA_EXE" binaries
@@ -421,12 +421,12 @@ jobs:
       #     yarn run build
       #     yarn run dist
 
-      # # gsutil (part of make deploy) never seems to support the latest python version.
-      # - name: Set up python for gsutil
-      #   uses: actions/setup-python@v6
-      #   with:
-      #     python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
-      #   id: python-gsutil-task
+      # gsutil (part of make deploy) never seems to support the latest python version.
+      - name: Set up python for gsutil
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.GSUTIL_PYTHON_VERSION }}
+        id: python-gsutil-task
 
       # - name: Deploy binaries and user guide to GCS
       #   if: github.event_name != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ PIP = $(PYTHON) -m pip
 VERSION := $(shell $(PYTHON) -m setuptools_scm)
 PYTHON_ARCH := $(shell $(PYTHON) -c "import sys; print('x86' if sys.maxsize <= 2**32 else 'x64')")
 
-GSUTIL := gsutil
+GSUTIL := gcloud storage
 SIGNTOOL := SignTool
 RST2HTML5 := rst2html5
 
@@ -356,27 +356,27 @@ codesign:
 	python codesigning/enqueue-current-installer.py
 
 deploy:
-	-$(GSUTIL) -m rsync $(DIST_DIR) $(DIST_URL_BASE)
-	-$(GSUTIL) -m rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
-	-$(GSUTIL) -m rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
-	-$(GSUTIL) -m rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
+	-$(GSUTIL) rsync $(DIST_DIR) $(DIST_URL_BASE)
+	-$(GSUTIL) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
+	-$(GSUTIL) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
+	-$(GSUTIL) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
 	@echo "Application binaries (if they were created) can be downloaded from:"
 	@echo "  * $(DOWNLOAD_DIR_URL)"
 
 deploy_wheel:
-	$(GSUTIL) -m cp $(DIST_DIR)/*.whl $(DIST_URL_BASE)
+	$(GSUTIL) cp $(DIST_DIR)/*.whl $(DIST_URL_BASE)
 
 deploy_sdist:
-	$(GSUTIL) -m cp $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
+	$(GSUTIL) cp $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
 
 deploy_data:
-	$(GSUTIL) -m rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
+	$(GSUTIL) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
 
 deploy_userguide:
-	$(GSUTIL) -m rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
+	$(GSUTIL) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
 
 deploy_workbench:
-	$(GSUTIL) -m rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
+	$(GSUTIL) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
 
 changelog:
 	$(RST2HTML5) $(CHANGELOG_SRC) $(CHANGELOG_DEST)

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ invest_autotest: $(GIT_SAMPLE_DATA_REPO_PATH) $(INVEST_BINARIES_DIR)
 	$(INVEST_AUTOTESTER)
 
 deploy_autotest_reports:
-	find $(AUTOTEST_DIR) -name "*report*.html" | gcloud storage cp -I $(REPORTS_BASE_URL)
+	find $(AUTOTEST_DIR) -name "*report*.html" | $(GCLOUD_STORAGE) cp -I $(REPORTS_BASE_URL)
 
 clean:
 	-$(RMDIR) $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ PIP = $(PYTHON) -m pip
 VERSION := $(shell $(PYTHON) -m setuptools_scm)
 PYTHON_ARCH := $(shell $(PYTHON) -c "import sys; print('x86' if sys.maxsize <= 2**32 else 'x64')")
 
-GSUTIL := gcloud storage
+GCLOUD_STORAGE := gcloud storage
 SIGNTOOL := SignTool
 RST2HTML5 := rst2html5
 
@@ -356,27 +356,27 @@ codesign:
 	python codesigning/enqueue-current-installer.py
 
 deploy:
-	-$(GSUTIL) rsync $(DIST_DIR) $(DIST_URL_BASE)
-	-$(GSUTIL) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
-	-$(GSUTIL) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
-	-$(GSUTIL) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
+	-$(GCLOUD_STORAGE) rsync $(DIST_DIR) $(DIST_URL_BASE)
+	-$(GCLOUD_STORAGE) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
+	-$(GCLOUD_STORAGE) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
+	-$(GCLOUD_STORAGE) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
 	@echo "Application binaries (if they were created) can be downloaded from:"
 	@echo "  * $(DOWNLOAD_DIR_URL)"
 
 deploy_wheel:
-	$(GSUTIL) cp $(DIST_DIR)/*.whl $(DIST_URL_BASE)
+	$(GCLOUD_STORAGE) cp $(DIST_DIR)/*.whl $(DIST_URL_BASE)
 
 deploy_sdist:
-	$(GSUTIL) cp $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
+	$(GCLOUD_STORAGE) cp $(DIST_DIR)/*.tar.gz $(DIST_URL_BASE)
 
 deploy_data:
-	$(GSUTIL) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
+	$(GCLOUD_STORAGE) rsync -r $(DIST_DIR)/data $(DIST_URL_BASE)/data
 
 deploy_userguide:
-	$(GSUTIL) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
+	$(GCLOUD_STORAGE) rsync -r $(DIST_DIR)/userguide $(DIST_URL_BASE)/userguide
 
 deploy_workbench:
-	$(GSUTIL) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
+	$(GCLOUD_STORAGE) rsync -r $(WORKBENCH_DIST_DIR) $(DIST_URL_BASE)/workbench
 
 changelog:
 	$(RST2HTML5) $(CHANGELOG_SRC) $(CHANGELOG_DEST)

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ INVEST_AUTOTESTER := $(PYTHON) scripts/invest-autotest.py --cwd $(GIT_SAMPLE_DAT
 
 
 .PHONY: fetch install binaries apidocs userguide changelog sampledata \
-sampledata_single test clean help check python_packages purge deploy \
+test clean help check python_packages purge deploy \
 deploy_wheel deploy_sdist deploy_data deploy_userguide deploy_workbench codesign \
 validate_sampledata validate_userguide_filenames invest_autotest deploy_autotest_reports \
 $(GIT_SAMPLE_DATA_REPO_PATH) $(GIT_TEST_DATA_REPO_PATH) $(GIT_UG_REPO_REV)
@@ -153,7 +153,6 @@ help:
 	@echo "  python_packages              to build natcap.invest wheel and source distributions"
 	@echo "  codesign                     to enqueue a built binary for signing using our codesigning service"
 	@echo "  sampledata                   to build sample data zipfiles"
-	@echo "  sampledata_single            to build a single self-contained data zipfile.  Used for advanced NSIS install."
 	@echo "  test                         to run pytest on the tests directory"
 	@echo "  validate_sampledata          to run invest model validation on sampledata datastacks"
 	@echo "  validate_userguide_filenames to validate that userguide filenames exist"
@@ -342,12 +341,6 @@ sampledata: $(ZIPTARGETS)
 	$(PYTHON) scripts/build_sampledata_filesize_registry.py $(CURDIR)/$(DIST_DATA_DIR)
 $(DIST_DATA_DIR)/%.zip: $(DIST_DATA_DIR) $(GIT_SAMPLE_DATA_REPO_PATH)
 	cd $(GIT_SAMPLE_DATA_REPO_PATH); $(BASHLIKE_SHELL_COMMAND) "$(ZIP) -r $(addprefix ../../,$@) $(subst $(DIST_DATA_DIR)/,$(DATADIR),$(subst .zip,,$@))"
-
-SAMPLEDATA_SINGLE_ARCHIVE := dist/InVEST_$(VERSION)_sample_data.zip
-sampledata_single: $(SAMPLEDATA_SINGLE_ARCHIVE)
-
-$(SAMPLEDATA_SINGLE_ARCHIVE): $(GIT_SAMPLE_DATA_REPO_PATH) dist
-	$(BASHLIKE_SHELL_COMMAND) "cd $(GIT_SAMPLE_DATA_REPO_PATH) && $(ZIP) -r ../../$(SAMPLEDATA_SINGLE_ARCHIVE) ./* -x .svn -x .git"
 
 build/vcredist_x86.exe: | build
 	powershell.exe -Command "Start-BitsTransfer -Source https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe -Destination build\vcredist_x86.exe"

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ invest_autotest: $(GIT_SAMPLE_DATA_REPO_PATH) $(INVEST_BINARIES_DIR)
 	$(INVEST_AUTOTESTER)
 
 deploy_autotest_reports:
-	find $(AUTOTEST_DIR) -name "*report*.html" | $(GSUTIL) -m cp -I $(REPORTS_BASE_URL)
+	find $(AUTOTEST_DIR) -name "*report*.html" | gcloud storage cp -I $(REPORTS_BASE_URL)
 
 clean:
 	-$(RMDIR) $(BUILD_DIR)


### PR DESCRIPTION
This PR replaces all uses of `gsutil` in our `Makefile` and Actions workflows with `gcloud storage`. `gsutil` is considered legacy.

That change fixed the problem with deploying reports after running the invest-autotest.

All of these changes are running "on-push" on my fork for testing because many steps will not run in the PR context. And I temporarily set the autotest steps to run there as well:
https://github.com/davemfish/invest/actions/runs/26300658559

Fixes #2508
Fixes #2562 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
