### PR TITLE
Datastack: copy CSV inputs into argument-named subdirectories and preserve original filenames

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,6 +83,9 @@ General
 * Fixed an issue with Windows binary builds where users would see runtime
   warnings saying ``GDAL_DATA`` is not defined.
   (`#2555 <https://github.com/natcap/invest/issues/2555>`_)
+* When saving a datastack, CSVs are now copied into argument-named
+  subfolders, which preserves original filenames and ensures metadata
+  compatibility. (`#2442 <https://github.com/natcap/invest/issues/2442>`_)
 
 Workbench
 =========

--- a/src/natcap/invest/datastack.py
+++ b/src/natcap/invest/datastack.py
@@ -230,15 +230,18 @@ def build_datastack_archive(args, model_id, datastack_path):
 
             LOGGER.debug(f'Detected spatial columns: {spatial_columns}')
 
+            csv_dir = os.path.join(data_dir, f'{key}_csv')
+            os.makedirs(csv_dir)
+
             target_csv_path = os.path.join(
-                data_dir, f'{key}_csv.csv')
+                csv_dir, os.path.basename(source_path))
             if not spatial_columns:
                 LOGGER.debug(
                     f'No spatial columns, copying to {target_csv_path}')
                 shutil.copyfile(source_path, target_csv_path)
             else:
                 contained_files_dir = os.path.join(
-                    data_dir, f'{key}_csv_data')
+                    csv_dir, f'{key}_csv_data')
 
                 dataframe = input_spec.get_validated_dataframe(source_path)
                 csv_source_dir = os.path.abspath(os.path.dirname(source_path))
@@ -284,7 +287,7 @@ def build_datastack_archive(args, model_id, datastack_path):
                             target_filepath = utils.copy_spatial_files(
                                 source_filepath, target_dir)
                             target_filepath = os.path.relpath(
-                                target_filepath, data_dir)
+                                target_filepath, csv_dir)
 
                         LOGGER.debug(
                             'Spatial file in CSV copied from '

--- a/src/natcap/invest/hra/hra.py
+++ b/src/natcap/invest/hra/hra.py
@@ -2392,7 +2392,8 @@ def _override_datastack_archive_criteria_table_path(
     args_key = 'criteria_table_path'
     criteria_table_array = utils.read_csv_to_dataframe(
         criteria_table_path, header=None).to_numpy()
-    contained_data_dir = os.path.join(data_dir, f'{args_key}_data')
+    contained_data_dir = os.path.join(data_dir, f'{args_key}_csv',
+                                      f'{args_key}_csv_data')
 
     known_rating_cols = set()
     for row in range(1, len(criteria_table_array)):  # skip named habitats
@@ -2443,7 +2444,8 @@ def _override_datastack_archive_criteria_table_path(
                 criteria_table_array[row, col] = new_path
                 known_files[value] = new_path
 
-    target_output_path = os.path.join(data_dir, f'{args_key}.csv')
+    target_output_path = os.path.join(data_dir, f'{args_key}_csv',
+                                      os.path.basename(criteria_table_path))
     numpy.savetxt(target_output_path, criteria_table_array, delimiter=',',
                   fmt="%s", encoding="UTF-8")
     return target_output_path

--- a/src/natcap/invest/hra/hra.py
+++ b/src/natcap/invest/hra/hra.py
@@ -2446,6 +2446,7 @@ def _override_datastack_archive_criteria_table_path(
 
     target_output_path = os.path.join(data_dir, f'{args_key}_csv',
                                       os.path.basename(criteria_table_path))
+    os.makedirs(os.path.dirname(target_output_path), exist_ok=True)
     numpy.savetxt(target_output_path, criteria_table_array, delimiter=',',
                   fmt="%s", encoding="UTF-8")
     return target_output_path

--- a/tests/test_datastack.py
+++ b/tests/test_datastack.py
@@ -451,6 +451,13 @@ class DatastackArchiveTests(unittest.TestCase):
         numpy.testing.assert_allclose(model_array, reg_array)
         utils._assert_vectors_equal(
             archive_params['vector'], params['vector'])
+        # assert CSV in datastack is saved to correct subfolder location
+        expected_csv_path = os.path.join(
+            out_directory, 'data', 'simple_table_csv',
+            os.path.basename(params['simple_table']))
+        self.assertEqual(archive_params['simple_table'], expected_csv_path)
+        self.assertTrue(os.path.exists(expected_csv_path))
+        self.assertTrue(os.path.exists(expected_csv_path + '.yml'))
         pandas.testing.assert_frame_equal(
             pandas.read_csv(archive_params['simple_table']),
             pandas.read_csv(params['simple_table']))
@@ -473,6 +480,13 @@ class DatastackArchiveTests(unittest.TestCase):
             archive_params['spatial_table']
         ).to_dict(orient='index')
         spatial_csv_dir = os.path.dirname(archive_params['spatial_table'])
+        # assert paths inside CSV are relative to CSV folder
+        contained_files_dir = os.path.join(
+            spatial_csv_dir, 'spatial_table_csv_data')
+        spatial_file_from_csv = spatial_csv_dict[3]['path']
+        self.assertTrue(os.path.exists(spatial_file_from_csv))
+        self.assertIn(contained_files_dir, spatial_file_from_csv)
+
         numpy.testing.assert_allclose(
             pygeoprocessing.raster_to_numpy_array(
                 os.path.join(spatial_csv_dir, spatial_csv_dict[3]['path'])),

--- a/tests/test_hra.py
+++ b/tests/test_hra.py
@@ -954,14 +954,17 @@ class HRAUnitTests(unittest.TestCase):
                 SRS_WKT, mgmt_path)
 
         data_dir = os.path.join(self.workspace_dir, 'datastack_data')
+        csv_dir = os.path.join(data_dir, 'criteria_table_path_csv')
         known_files = {}
 
         new_csv_path = hra._override_datastack_archive_criteria_table_path(
             criteria_table_path, data_dir, known_files)
         self.assertEqual(
-            new_csv_path, os.path.join(data_dir, 'criteria_table_path.csv'))
+            new_csv_path,
+            os.path.join(csv_dir, os.path.basename(criteria_table_path))
+        )
         output_criteria_data_dir = os.path.join(
-            data_dir, 'criteria_table_path_data')
+            csv_dir, 'criteria_table_path_csv_data')
         self.maxDiff = None
 
         self.assertEqual(


### PR DESCRIPTION
## Description
When saving a datastack, CSV inputs are now treated like other (multipart) spatial files and are copied into their own argument-named subfolders within the output datastack directory. Original CSV filenames are now preserved, which means that sidecar geometamaker metadata matches (as it is named by the original filename).

Fixes #2442

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
