### PR TITLE
Update vega altair versions for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ geometamaker>=0.3.1
 pydantic
 certifi
 docutils
-altair
+altair>=6.0.0
 fiona
 geopandas
 jinja2

--- a/src/natcap/invest/reports/templates/models/coastal_vulnerability.html
+++ b/src/natcap/invest/reports/templates/models/coastal_vulnerability.html
@@ -72,9 +72,7 @@
 {% from 'vegalite-plot.html' import embed_vega %}
 {% block scripts %}
   {{ super() }}
-  <script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.20.1"></script>
-  <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
+  {% include "vega-dependencies.html" %}
   {% include 'vega-embed-js.html' %}
   {% set chart_spec_id_list = [
     (exposure_map_json, 'exposure_map'),

--- a/src/natcap/invest/reports/templates/vega-dependencies.html
+++ b/src/natcap/invest/reports/templates/vega-dependencies.html
@@ -1,3 +1,3 @@
-<script src="https://cdn.jsdelivr.net/npm/vega@5"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-lite@5.20.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite@6.4.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>


### PR DESCRIPTION
Fixes #2579 

Also, for some reason the https://cdn.jsdelivr.net/npm/vega@5 script from the CDN was tagged with a `text/plain` content-type instead of `text/javascript` in the response header and the Workbench failed to load that resource in one case. Oddly, it did not fail for all reports I tried. Anyway, the version 6 file is fetched with the correct content-type.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
