### PR TITLE
AWY: allow MULTIPOLYGON geometry type on input.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -97,6 +97,11 @@ Workbench
 * Added a link to the InVEST Plugin Developer's Guide to the Workbench Manage
   Plugins modal. (`#2145 <https://github.com/natcap/invest/issues/2145>`_)
 
+Annual Water Yield
+==================
+* Allow watershed input to have a POLYGON or MULTIPOLYGON geometry type.
+  (`#2513 <https://github.com/natcap/invest/issues/2513>`_)
+
 SDR
 ===
 * Added exception-handling when checking if watershed geoemtries overlap.

--- a/src/natcap/invest/annual_water_yield/annual_water_yield.py
+++ b/src/natcap/invest/annual_water_yield/annual_water_yield.py
@@ -221,7 +221,7 @@ MODEL_SPEC = spec.ModelSpec(
                 " to a point of interest where hydropower production will be"
                 " analyzed."
             ),
-            geometry_types={"POLYGON"},
+            geometry_types={"POLYGON", "MULTIPOLYGON"},
             fields=[
                 spec.IntegerInput(
                     id="ws_id",


### PR DESCRIPTION
The subwatershed input already allows `MULTIPOLYGON`, the watershed input should too. They are used exactly the same way by the model.

Fixes #2513 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
