### PR TITLE
Add registry link to plugins modal

### DIFF
--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -265,9 +265,7 @@ export default function PluginModal(props) {
             aria-label={t("Community Plugin Registry (opens in web browser)")}
             onClick={openLinkInBrowser}
           >{t("Community Plugin Registry")}</a>.
-        </p>
-        <p>
-          {t('For more information about creating a plugin, read our ')}
+          {t(' For more information about creating a plugin, read our ')}
           <a
             href={pluginDocsURL}
             title={pluginDocsURL}

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -252,9 +252,31 @@ export default function PluginModal(props) {
     );
   }
 
-  const pluginsURL = "https://invest.readthedocs.io/en/latest/plugins.html";
+  const pluginDocsURL = "https://invest.readthedocs.io/en/latest/plugins.html";
+  const pluginRegistryURL = "https://natcap.github.io/invest-plugin-registry/";
   let modalBody = (
     <Modal.Body>
+      <div>
+        <p>
+          {t('Explore available plugins on our ')}
+          <a
+            href={pluginRegistryURL}
+            title={pluginRegistryURL}
+            aria-label={t("Community Plugin Registry (opens in web browser)")}
+            onClick={openLinkInBrowser}
+          >{t("Community Plugin Registry")}</a>.
+        </p>
+        <p>
+          {t('For more information about creating a plugin, read our ')}
+          <a
+            href={pluginDocsURL}
+            title={pluginDocsURL}
+            aria-label={t("Plugins Developer's Guide (opens in web browser)")}
+            onClick={openLinkInBrowser}
+          >{t("Developer's Guide")}</a>.
+        </p>
+      </div>
+      <hr />
       <Form aria-labelledby="add-plugin-form-title">
         <Form.Group>
           <h5 id="add-plugin-form-title" className="mb-3">{t('Add a plugin')}</h5>
@@ -394,18 +416,6 @@ export default function PluginModal(props) {
           }
         </div>
       </Form>
-      <hr />
-      <div>
-        <p>
-          {t('For more information about plugins, read our ')}
-          <a
-            href={pluginsURL}
-            title={pluginsURL}
-            aria-label={t("Plugins Developer's Guide (opens in web browser)")}
-            onClick={openLinkInBrowser}
-          >{t("Developer's Guide")}</a>.
-        </p>
-      </div>
     </Modal.Body>
   );
   if (installErr) {


### PR DESCRIPTION
## Description
Fixes #2584 

This PR adds a link to the Plugin Registry to the Manage Plugins modal. I think it makes more sense for this link to be at the top of the modal than the bottom, so I moved the Developer Docs link to the top as well. 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
