### PR TITLE
Add LULC RAT support to Urban Cooling report.

### DIFF
--- a/src/natcap/invest/reports/templates/models/urban_cooling.html
+++ b/src/natcap/invest/reports/templates/models/urban_cooling.html
@@ -115,12 +115,21 @@
   {% endif %}
 
   {{ accordion_section(
-    input_raster_heading,
+    lulc_raster_heading,
     content_grid([
       (caption(raster_group_caption, pre_caption=True), 100),
-      (caption(lulc_pre_caption, pre_caption=True), 100),
-      (raster_plot_img(inputs_img_src, input_raster_heading), 100),
-      (caption(inputs_caption, definition_list=True), 100)
+      (raster_plot_img(lulc_img_src, lulc_raster_heading), 60),
+      (wide_table(lulc_legend_html | safe), 40),
+      (caption(lulc_caption, definition_list=True), 100),
+    ])
+  )}}
+
+  {{ accordion_section(
+    et0_raster_heading,
+    content_grid([
+      (caption(raster_group_caption, pre_caption=True), 100),
+      (raster_plot_img(et0_img_src, et0_raster_heading), 100),
+      (caption(et0_caption, definition_list=True), 100)
     ])
   )}}
 

--- a/src/natcap/invest/urban_cooling_model/reporter.py
+++ b/src/natcap/invest/urban_cooling_model/reporter.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 import altair
@@ -281,21 +282,26 @@ def report(file_registry: dict[str, str], args_dict: dict,
     """
 
     # Input rasters: LULC, reference evapotranspiration
-    input_raster_heading = gettext(
-        'Input Rasters: LULC and Reference Evapotranspiration')
-    input_raster_plot_configs = [
-        RasterPlotConfig(args_dict['lulc_raster_path'],
-                         RasterDatatype.nominal,
-                         model_spec.get_input('lulc_raster_path')),
+    lulc_raster_heading = gettext('Land Use/Land Cover Input')
+    (lulc_img_src,
+     lulc_legend_html) = raster_utils.plot_categorical_raster_with_table(
+        [args_dict['lulc_raster_path']])
+    lulc_filename = os.path.basename(args_dict['lulc_raster_path'])
+    lulc_desc = model_spec.get_input('lulc_raster_path').about
+    lulc_caption = f'{lulc_filename}:{lulc_desc}'
+
+    et0_raster_heading = gettext(
+        'Reference Evapotranspiration Input')
+    et0_raster_plot_configs = [
         RasterPlotConfig(args_dict['ref_eto_raster_path'],
                          RasterDatatype.continuous,
                          model_spec.get_input('ref_eto_raster_path'),
                          colormap='Greens'),
     ]
-    inputs_img_src = raster_utils.plot_and_base64_encode_rasters(
-        input_raster_plot_configs)
-    input_raster_caption = raster_utils.caption_raster_list(
-        input_raster_plot_configs)
+    et0_img_src = raster_utils.plot_and_base64_encode_rasters(
+        et0_raster_plot_configs)
+    et0_raster_caption = raster_utils.caption_raster_list(
+        et0_raster_plot_configs)
 
     # Primary raster outputs: air temperature, heat mitigation index
     output_raster_heading = gettext(
@@ -411,10 +417,13 @@ def report(file_registry: dict[str, str], args_dict: dict,
             bldg_map_json=bldg_map_json,
             bldg_map_caption=bldg_map_caption,
             bldg_map_source_list=bldg_map_source_list,
-            input_raster_heading=input_raster_heading,
-            inputs_img_src=inputs_img_src,
-            inputs_caption=input_raster_caption,
-            lulc_pre_caption=report_constants.LULC_PRE_CAPTION,
+            lulc_raster_heading=lulc_raster_heading,
+            lulc_img_src=lulc_img_src,
+            lulc_legend_html=lulc_legend_html,
+            lulc_caption=lulc_caption,
+            et0_raster_heading=et0_raster_heading,
+            et0_img_src=et0_img_src,
+            et0_caption=et0_raster_caption,
             output_raster_heading=output_raster_heading,
             outputs_img_src=outputs_img_src,
             outputs_caption=output_raster_caption,

--- a/tests/reports/test_urban_cooling_template.py
+++ b/tests/reports/test_urban_cooling_template.py
@@ -22,7 +22,6 @@ def _get_render_args(model_spec):
     input_stats_table = '<table class="test__input-stats-table"></table>'
     stats_table_note = 'This is a test!'
     inputs_caption = ['input.tif:Input map.']
-    lulc_pre_caption = 'This is a test of the LULC broadcasting system!'
     outputs_caption = ['results.tif:Results map.']
     raster_group_caption = 'This is another test!'
     uhi_table = '<table class="test__uhi-table"></table>'
@@ -30,6 +29,7 @@ def _get_render_args(model_spec):
     bldg_totals_table = '<table class="test__bldg-table-totals"></table>'
     vector_caption = [
         'field_1:Things. (Units: unitless)', 'field_2:Stuff. (Units: kg)']
+    lulc_legend_html = '<table class="test__lulc-legend-table"></table>'
 
     return {
         'report_script': model_spec.reporter,
@@ -52,10 +52,13 @@ def _get_render_args(model_spec):
         'bldg_map_json': mock_json,
         'bldg_map_caption': vector_caption,
         'bldg_map_source_list': ['bldg.shp'],
-        'input_raster_heading': 'LULC and Reference Evapotranspiration',
-        'inputs_img_src': img_src,
-        'inputs_caption': inputs_caption,
-        'lulc_pre_caption': lulc_pre_caption,
+        'lulc_raster_heading': 'Land Use/Land Cover Input',
+        'lulc_img_src': img_src,
+        'lulc_legend_html': lulc_legend_html,
+        'lulc_caption': inputs_caption,
+        'et0_raster_heading': 'Reference Evapotranspiration Input',
+        'et0_img_src': img_src,
+        'et0_caption': inputs_caption,
         'output_raster_heading': 'Air Temperature',
         'outputs_img_src': img_src,
         'outputs_caption': outputs_caption,
@@ -83,7 +86,7 @@ class UrbanCoolingTemplateTests(unittest.TestCase):
         soup = BeautifulSoup(html, BSOUP_HTML_PARSER)
 
         sections = soup.find_all(class_='accordion-section')
-        self.assertEqual(len(sections), 9)
+        self.assertEqual(len(sections), 10)
 
         self.assertEqual(
             soup.h1.string, f'InVEST Results: {MODEL_SPEC.model_title}')
@@ -97,8 +100,8 @@ class UrbanCoolingTemplateTests(unittest.TestCase):
         soup = BeautifulSoup(html, BSOUP_HTML_PARSER)
 
         sections = soup.find_all(class_='accordion-section')
-        # 9 default sections plus 2 for building stats.
-        self.assertEqual(len(sections), 11)
+        # 10 default sections plus 2 for building stats.
+        self.assertEqual(len(sections), 12)
 
         self.assertEqual(
             soup.h1.string, f'InVEST Results: {MODEL_SPEC.model_title}')


### PR DESCRIPTION
## Description
Adds LULC RAT support to the Urban Cooling report.

[Updated sample report](https://storage.googleapis.com/data.naturalcapitalproject.org/invest-reports/urban_cooling_model_report_multi_feature_aoi_factors_with_valuation.html)

This sample report provides a good example of the fallback legend table, since the sample data in this case does not have a RAT.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
