### PR TITLE
Workbench: add data collection notice & update "About InVEST" page

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -108,6 +108,11 @@ Workbench
   failing silently. (`#2489 <https://github.com/natcap/invest/issues/2489>`_)
 * Added a link to the InVEST Plugin Developer's Guide to the Workbench Manage
   Plugins modal. (`#2145 <https://github.com/natcap/invest/issues/2145>`_)
+* Added a disclosure about InVEST data collection to the Workbench installer
+  and to the in-Workbench "About InVEST" page. For more details, refer to the
+  (`InVEST Data Collection Notice <https://naturalcapitalalliance.stanford.edu/
+  software/invest/invest-downloads-data#invest-data-collection-notice>`_).
+  (`#2553 <https://github.com/natcap/invest/issues/2553>`_)
 
 Annual Water Yield
 ==================

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -110,8 +110,8 @@ Workbench
   Plugins modal. (`#2145 <https://github.com/natcap/invest/issues/2145>`_)
 * Added a disclosure about InVEST data collection to the Workbench installer
   and to the in-Workbench "About InVEST" page. For more details, refer to the
-  (`InVEST Data Collection Notice <https://naturalcapitalalliance.stanford.edu/
-  software/invest/invest-downloads-data#invest-data-collection-notice>`_).
+  `InVEST Data Collection Notice <https://naturalcapitalalliance.stanford.edu/
+  software/invest/invest-downloads-data#invest-data-collection-notice>`_.
   (`#2553 <https://github.com/natcap/invest/issues/2553>`_)
 
 Annual Water Yield

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,14 +1,6 @@
-InVEST is a registered trademark of Stanford University. Stanford University
-owns and maintains the trademark, and cooperates with the Natural Capital
-Alliance to develop this policy and any trademark licensing. Visit
-naturalcapitalalliance.stanford.edu/invest-trademark-and-logo-use-policy for
-the complete trademark and logo policy.
+InVEST is a registered trademark of Stanford University. Stanford University owns and maintains the trademark, and cooperates with the Natural Capital Alliance to develop this policy and any trademark licensing. Visit naturalcapitalalliance.stanford.edu/invest-trademark-and-logo-use-policy for the complete trademark and logo policy.
 
-The Natural Capital Alliance software team collects certain non-personal data
-each time an InVEST model or InVEST plugin is run via the InVEST Workbench.
-These data help inform future work on InVEST and support our mission to
-maintain InVEST as free and open-source software. For more details, visit
-naturalcapitalalliance.stanford.edu/invest-data-collection-notice.
+The Natural Capital Alliance software team collects certain non-personal data each time an InVEST model or InVEST plugin is run via the InVEST Workbench. These data help inform future work on InVEST and support our mission to maintain InVEST as free and open-source software. For more details, visit naturalcapitalalliance.stanford.edu/invest-data-collection-notice.
 
 Copyright (c) 2026, Natural Capital Alliance
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,8 +1,14 @@
 InVEST is a registered trademark of Stanford University. Stanford University
 owns and maintains the trademark, and cooperates with the Natural Capital
 Alliance to develop this policy and any trademark licensing. Visit
-naturalcapitalalliance.stanford.edu/invest-trademark-and-logo-use-policy for the
-complete trademark and logo policy.
+naturalcapitalalliance.stanford.edu/invest-trademark-and-logo-use-policy for
+the complete trademark and logo policy.
+
+The Natural Capital Alliance software team collects certain non-personal data
+each time an InVEST model or InVEST plugin is run via the InVEST Workbench.
+These data help inform future work on InVEST and support our mission to
+maintain InVEST as free and open-source software. For more details, visit
+naturalcapitalalliance.stanford.edu/invest-data-collection-notice.
 
 Copyright (c) 2026, Natural Capital Alliance
 

--- a/workbench/about.html
+++ b/workbench/about.html
@@ -11,7 +11,7 @@
     />
   </head>
   <body>
-    <div id="content" />
+    <div id="content"></div>
   </body>
   <script src="/src/renderer/menubar/about.jsx" type="module">
   </script>

--- a/workbench/report_a_problem.html
+++ b/workbench/report_a_problem.html
@@ -11,7 +11,7 @@
     />
   </head>
   <body>
-    <div id="content" />
+    <div id="content"></div>
   </body>
   <script src="/src/renderer/menubar/report.jsx" type="module" >
   </script>

--- a/workbench/src/main/menubar.js
+++ b/workbench/src/main/menubar.js
@@ -115,7 +115,7 @@ function createWindow(parentWindow, isDevMode) {
   const win = new BrowserWindow({
     parent: parentWindow,
     width: 700,
-    height: 800,
+    height: 900,
     frame: true,
     webPreferences: {
       minimumFontSize: 12,

--- a/workbench/src/renderer/menubar/about.css
+++ b/workbench/src/renderer/menubar/about.css
@@ -1,30 +1,50 @@
-#header {
-  text-align: center;
+#content {
+  margin: 0 auto;
+  max-width: 33rem;
 }
 
-#invest-version span {
+.header {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.version-and-copyright {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  justify-content: center;
+  word-break: break-word;
+}
+
+.version-string {
   font-weight: bold;
-  font-size: 1.2rem;
+  font-size: 1.25rem;
 }
 
-#invest-version p {
-  margin: 0.1rem;
-  font-size: 0.8rem;
+.section-heading {
+  font-size: 1.5rem;
+  line-height: 1.2;
+  margin: 1rem 0;
 }
 
-#invest-copyright {
-  font-size: 0.8rem;
+.links {
+  margin: 0;
+  li {
+    padding: 0.5rem 0;
+    &:first-child {
+      padding-top: 0;
+    }
+  }
 }
 
-#links p {
-  margin-top: 0.1rem;
-  margin-bottom: 0.1rem;
-}
-
-#licenses h4 {
-  margin-bottom: 0.1rem;
-}
-
-#licenses td {
-  padding-right: 1rem;
+/* Based on Bootstrap's visually-hidden class */
+.visually-hidden {
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
 }

--- a/workbench/src/renderer/menubar/about.jsx
+++ b/workbench/src/renderer/menubar/about.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactDom from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import { Translation } from 'react-i18next';
 
 import i18n from '../i18n/i18n';
+
 import { handleClickExternalURL } from './handlers';
 import { ipcMainChannels } from '../../main/ipcMainChannels';
 import investLogo from '../static/invest-logo.png';
@@ -16,187 +18,91 @@ async function getInvestVersion() {
 
 await i18n.changeLanguage(window.Workbench.LANGUAGE);
 const investVersion = await getInvestVersion();
-ReactDom.render(
+
+const ariaLabelSuffix = '(opens in web browser)';
+const linkDefs = [
+  {
+    name: 'InVEST User Guide',
+    href: 'http://releases.naturalcapitalproject.org/invest-userguide/latest/en/index.html',
+  },
+  {
+    name: 'InVEST Data Collection Notice',
+    href: 'https://naturalcapitalalliance.stanford.edu/software/invest/invest-downloads-data#invest-data-collection-notice',
+  },
+  {
+    name: 'InVEST Attribution Guidelines',
+    href: 'https://naturalcapitalalliance.stanford.edu/software/invest/invest-downloads-data#invest-attribution-guidelines',
+  },
+  {
+    name: 'InVEST Trademark and Logo Use Policy',
+    href: 'https://naturalcapitalalliance.stanford.edu/software/invest/invest-trademark-and-logo-use-policy',
+  },
+  {
+    name: 'InVEST License',
+    href: 'https://github.com/natcap/invest/blob/main/LICENSE.txt',
+  },
+  {
+    name: 'InVEST on GitHub',
+    href: 'https://github.com/natcap/invest',
+  },
+  {
+    name: 'InVEST Developer Documentation',
+    href: `https://invest.readthedocs.io/en/${investVersion}/`,
+  },
+  {
+    name: 'Natural Capital Alliance',
+    href: 'https://naturalcapitalalliance.stanford.edu/',
+  },
+];
+const linkListItems = linkDefs.map(({name, href}) => (
+  <Translation>
+    {(t, { i18n }) => (
+      <li><a href={href} title={href} aria-label={`${t(name)} ${t(ariaLabelSuffix)}`}>{t(name)}</a></li>
+    )}
+  </Translation>
+));
+
+const root = createRoot(document.getElementById('content'));
+root.render(
   <Translation>
     {(t, { i18n }) => (
       <React.Fragment>
-        <div id="header">
+        <h1 class="visually-hidden">About InVEST</h1>
+        <div class="header">
           <img
             src={investLogo}
             width="191"
             height="159"
             alt="InVEST logo"
           />
-          <div id="invest-version">
-            <p>{t('version:')}</p>
-            <span id="version-string" />
+          <div class="version-and-copyright">
+            <span>
+              {t('Version:')} <span class="version-string">{ investVersion }</span>
+            </span>
+            <span>
+              {t('Copyright 2026, Natural Capital Alliance')}
+            </span>
           </div>
-          <p id="invest-copyright">
-            {t('Copyright 2026, The Natural Capital Alliance')}
-          </p>
         </div>
-        <br />
-        <div id="links">
-          <table>
-            <tbody>
-              <tr>
-                <td>{t('Documentation')}</td>
-                <td>
-                  <a
-                    href="http://releases.naturalcapitalproject.org/invest-userguide/latest/"
-                  >
-                    http://releases.naturalcapitalproject.org/invest-userguide/latest/
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>{t('Homepage')}</td>
-                <td>
-                  <a
-                    href="https://naturalcapitalalliance.stanford.edu/"
-                  >
-                    https://naturalcapitalalliance.stanford.edu/
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>{t('Project page')}</td>
-                <td>
-                  <a
-                    href="https://github.com/natcap/invest"
-                  >
-                    https://github.com/natcap/invest
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>{t('License')}</td>
-                <td>
-                  <a
-                    href="https://github.com/natcap/invest/blob/main/LICENSE.txt"
-                  >
-                    Apache 2.0
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>{t('InVEST Trademark and Logo Use Policy')}</td>
-                <td>
-                  <a
-                    href="https://naturalcapitalalliance.stanford.edu/invest-trademark-and-logo-use-policy"
-                  >
-                    Trademark and Logo Policy
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div id="licenses">
-          <h4>{t('Open-Source Licenses:')}</h4>
-          <table>
-            <tbody>
-              <tr>
-                <td>geometamaker</td>
-                <td>Apache 2.0</td>
-                <td>
-                  <a
-                    href="https://github.com/natcap/geometamaker"
-                  >
-                    https://github.com/natcap/geometamaker
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>GDAL</td>
-                <td>{t('MIT and others')}</td>
-                <td>
-                  <a
-                    href="http://gdal.org"
-                  >
-                    http://gdal.org
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>numpy</td>
-                <td>BSD</td>
-                <td>
-                  <a
-                    href="http://numpy.org"
-                  >
-                    http://numpy.org
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>pygeoprocessing</td>
-                <td>BSD</td>
-                <td>
-                  <a
-                    href="https://github.com/natcap/pygeoprocessing"
-                  >
-                    https://github.com/natcap/pygeoprocessing
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>PyInstaller</td>
-                <td>GPL</td>
-                <td>
-                  <a
-                    href="http://pyinstaller.org"
-                  >
-                    http://pyinstaller.org
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>rtree</td>
-                <td>MIT</td>
-                <td>
-                  <a
-                    href="https://github.com/Toblerity/rtree"
-                  >
-                    https://github.com/Toblerity/rtree
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>scipy</td>
-                <td>BSD</td>
-                <td>
-                  <a
-                    href="http://www.scipy.org/"
-                  >
-                    http://www.scipy.org/
-                  </a>
-                </td>
-              </tr>
-              <tr>
-                <td>shapely</td>
-                <td>BSD</td>
-                <td>
-                  <a
-                    href="http://github.com/Toblerity/Shapely"
-                  >
-                    http://github.com/Toblerity/Shapely
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+        <section>
+          <p>{t('InVEST® is free and open-source software used to map and value the goods and services from nature that sustain and fulfill human life.')}</p>
+        </section>
+        <section>
+          <h2 class="section-heading" id="link-list-heading">{t('Resources')}</h2>
+          <ul role="list" className="links" aria-describedby="link-list-heading">
+            {linkListItems}
+          </ul>
+        </section>
+        <section>
+          <h2 class="section-heading">{t('Data Collection')}</h2>
+          <p>{t('The Natural Capital Alliance software team collects certain non-personal data each time an InVEST model or InVEST plugin is run via the InVEST Workbench. These data help inform future work on InVEST and support our mission to maintain InVEST as free and open-source software.')}</p>
+        </section>
       </React.Fragment>
     )}
-  </Translation>,
-  document.getElementById('content')
+  </Translation>
 );
 document.querySelectorAll('a').forEach(
   (element) => {
     element.addEventListener('click', handleClickExternalURL);
   }
 );
-const node = document.getElementById('version-string');
-const text = document.createTextNode(investVersion);
-node.appendChild(text);

--- a/workbench/src/renderer/menubar/about.jsx
+++ b/workbench/src/renderer/menubar/about.jsx
@@ -55,9 +55,16 @@ const linkDefs = [
   },
 ];
 const linkListItems = linkDefs.map(({name, href}) => (
-  <Translation>
+  <Translation key={name}>
     {(t, { i18n }) => (
-      <li><a href={href} title={href} aria-label={`${t(name)} ${t(ariaLabelSuffix)}`}>{t(name)}</a></li>
+      <li>
+        <a
+          href={href}
+          title={href}
+          aria-label={`${t(name)} ${t(ariaLabelSuffix)}`}
+          onClick={handleClickExternalURL}
+        >{t(name)}</a>
+      </li>
     )}
   </Translation>
 ));
@@ -67,17 +74,17 @@ root.render(
   <Translation>
     {(t, { i18n }) => (
       <React.Fragment>
-        <h1 class="visually-hidden">About InVEST</h1>
-        <div class="header">
+        <h1 className="visually-hidden">About InVEST</h1>
+        <div className="header">
           <img
             src={investLogo}
             width="191"
             height="159"
             alt="InVEST logo"
           />
-          <div class="version-and-copyright">
+          <div className="version-and-copyright">
             <span>
-              {t('Version:')} <span class="version-string">{ investVersion }</span>
+              {t('Version:')} <span className="version-string">{ investVersion }</span>
             </span>
             <span>
               {t('Copyright 2026, Natural Capital Alliance')}
@@ -88,21 +95,16 @@ root.render(
           <p>{t('InVEST® is free and open-source software used to map and value the goods and services from nature that sustain and fulfill human life.')}</p>
         </section>
         <section>
-          <h2 class="section-heading" id="link-list-heading">{t('Resources')}</h2>
+          <h2 className="section-heading" id="link-list-heading">{t('Resources')}</h2>
           <ul role="list" className="links" aria-describedby="link-list-heading">
             {linkListItems}
           </ul>
         </section>
         <section>
-          <h2 class="section-heading">{t('Data Collection')}</h2>
+          <h2 className="section-heading">{t('Data Collection')}</h2>
           <p>{t('The Natural Capital Alliance software team collects certain non-personal data each time an InVEST model or InVEST plugin is run via the InVEST Workbench. These data help inform future work on InVEST and support our mission to maintain InVEST as free and open-source software.')}</p>
         </section>
       </React.Fragment>
     )}
   </Translation>
-);
-document.querySelectorAll('a').forEach(
-  (element) => {
-    element.addEventListener('click', handleClickExternalURL);
-  }
 );


### PR DESCRIPTION
## Description
Closes #2553.

Specifically, this includes the following updates to the "About InVEST" page in the Workbench:
- adds data collection summary and link to full notice,
- adds links to attribution guidelines & dev docs,
- removes outdated/incomplete list of 3rd-party licenses (see #2583), and
- revamps page layout.

It also adds the data collection summary and full data collection notice URL to `NOTICE.txt`. This content will now appear in the installer (together with the extant trademark info and software license).

### New "About InVEST" page
<img width="699" height="899" alt="about_invest-2026_06_05" src="https://github.com/user-attachments/assets/c997b2bf-3064-48d4-89fb-5604e6d8b7a5" />

In production builds, the version string will appear on the same line with the "Version:" text (because production version strings aren't very long). For example, here is what it looks like with the version string mocked as 3.20.0:
<img width="699" height="267" alt="about_invest-mocked_version_string-2026_06_05" src="https://github.com/user-attachments/assets/4a7e4239-8a4d-47ba-be29-6c51f1436f7d" />

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
