### PR TITLE
Clean up usage logging code

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -113,6 +113,8 @@ Workbench
   `InVEST Data Collection Notice <https://naturalcapitalalliance.stanford.edu/
   software/invest/invest-downloads-data#invest-data-collection-notice>`_.
   (`#2553 <https://github.com/natcap/invest/issues/2553>`_)
+* Removed outdated usage-logging code to reflect current data collection
+  practices. (`#2600 <https://github.com/natcap/invest/issues/2600>`_)
 
 Annual Water Yield
 ==================

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -274,7 +274,6 @@ def log_model_start():
         pyname=models.model_id_to_pyname[modelID],
         model_args=json.loads(payload['model_args']),
         invest_interface=payload['invest_interface'],
-        session_id=payload['session_id'],
         type=payload['type'],
         source=payload.get('source', None))  # source only used for plugins
     return 'OK'

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -274,7 +274,7 @@ def log_model_start():
         pyname=models.model_id_to_pyname[modelID],
         model_args=json.loads(payload['model_args']),
         invest_interface=payload['invest_interface'],
-        type=payload['type'],
+        type=payload['type'],  # 'core' or 'plugin'
         source=payload.get('source', None))  # source only used for plugins
     return 'OK'
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -274,8 +274,8 @@ def log_model_start():
         pyname=models.model_id_to_pyname[modelID],
         model_args=json.loads(payload['model_args']),
         invest_interface=payload['invest_interface'],
-        type=payload['type'],  # 'core' or 'plugin'
-        source=payload.get('source', None))  # source only used for plugins
+        model_type=payload['model_type'],  # 'core' or 'plugin'
+        plugin_source=payload.get('plugin_source', None))  # source only used for plugins
     return 'OK'
 
 

--- a/src/natcap/invest/ui_server.py
+++ b/src/natcap/invest/ui_server.py
@@ -280,15 +280,6 @@ def log_model_start():
     return 'OK'
 
 
-@app.route(f'/{PREFIX}/log_model_exit', methods=['POST'])
-def log_model_exit():
-    payload = request.get_json()
-    usage._log_exit_status(
-        payload['session_id'],
-        payload['status'])
-    return 'OK'
-
-
 @app.route(f'/{PREFIX}/languages', methods=['GET'])
 def get_supported_languages():
     """Return a mapping of supported languages to their display names."""

--- a/src/natcap/invest/usage.py
+++ b/src/natcap/invest/usage.py
@@ -119,33 +119,6 @@ def _calculate_args_bounding_box(args, model_spec):
     return bb_intersection, bb_union
 
 
-def _log_exit_status(session_id, status):
-    """Log the completion of a model with the given status.
-
-    Args:
-        session_id (string): a unique string that can be used to identify
-            the current session between the model initial start and exit.
-        status (string): a string describing the exit status of the model,
-            'success' would indicate the successful completion while an
-            exception string could indicate a failure.
-
-    Returns:
-        None
-    """
-    logger = logging.getLogger('natcap.invest.usage._log_exit_status')
-
-    try:
-        log_finish_url = requests.get(_ENDPOINTS_INDEX_URL).json()['FINISH']
-        requests.post(log_finish_url, data={
-            'session_id': session_id,
-            'status': status,
-        })
-    except Exception as exception:
-        # An exception was thrown, we don't care.
-        logger.warning(
-            f'an exception encountered in _log_exit_status: {str(exception)}')
-
-
 def _log_model(pyname, model_args, invest_interface, type, source, session_id=None):
     """Log information about a model run to a remote server.
 

--- a/src/natcap/invest/usage.py
+++ b/src/natcap/invest/usage.py
@@ -1,12 +1,8 @@
-"""Module to that provides functions for usage logging."""
-import contextlib
+"""Module that provides functions for usage logging."""
 import locale
 import logging
 import platform
 import sys
-import threading
-import traceback
-import uuid
 import importlib
 
 from osgeo import osr
@@ -23,44 +19,6 @@ LOGGER = logging.getLogger(__name__)
 _ENDPOINTS_INDEX_URL = (
     'http://data.naturalcapitalproject.org/server_registry/'
     'invest_usage_logger_v2/index.html')
-
-# This is defined here because it's very useful to know the thread name ahead
-# of time so we can exclude any log messages it generates from the logging.
-# Python doesn't care about having multiple threads have the same name.
-_USAGE_LOGGING_THREAD_NAME = 'usage-logging-thread'
-
-
-@contextlib.contextmanager
-def log_run(model_pyname, args):
-    """Context manager to log an InVEST model run and exit status.
-
-    Args:
-        model_pyname (string): The string module name that identifies the model.
-        args (dict): The full args dictionary.
-
-    Returns:
-        ``None``
-    """
-    invest_interface = 'Qt'  # this cm is only used by the Qt interface
-    session_id = str(uuid.uuid4())
-    log_thread = threading.Thread(
-        target=_log_model,
-        args=(model_pyname, args, invest_interface, session_id),
-        name=_USAGE_LOGGING_THREAD_NAME)
-    log_thread.start()
-
-    try:
-        yield
-    except Exception:
-        exit_status_message = traceback.format_exc()
-        raise
-    else:
-        exit_status_message = ':)'
-    finally:
-        log_exit_thread = threading.Thread(
-            target=_log_exit_status, args=(session_id, exit_status_message),
-            name=_USAGE_LOGGING_THREAD_NAME)
-        log_exit_thread.start()
 
 
 def _calculate_args_bounding_box(args, model_spec):

--- a/src/natcap/invest/usage.py
+++ b/src/natcap/invest/usage.py
@@ -119,7 +119,7 @@ def _calculate_args_bounding_box(args, model_spec):
     return bb_intersection, bb_union
 
 
-def _log_model(pyname, model_args, invest_interface, type, source, session_id=None):
+def _log_model(pyname, model_args, invest_interface, type, source):
     """Log information about a model run to a remote server.
 
     Args:
@@ -152,7 +152,6 @@ def _log_model(pyname, model_args, invest_interface, type, source, session_id=No
             'system_default_language': locale.getdefaultlocale()[0],
             'bounding_box_intersection': str(bounding_box_intersection),
             'bounding_box_union': str(bounding_box_union),
-            'session_id': session_id,
             'type': type,
             'source': source
         })

--- a/src/natcap/invest/usage.py
+++ b/src/natcap/invest/usage.py
@@ -1,10 +1,7 @@
 """Module to that provides functions for usage logging."""
 import contextlib
-import hashlib
-import json
 import locale
 import logging
-import os
 import platform
 import sys
 import threading
@@ -209,19 +206,6 @@ def _log_model(pyname, model_args, invest_interface, type, source, session_id=No
     """
     logger = logging.getLogger('natcap.invest.usage._log_model')
 
-    def _node_hash():
-        """Return a hash for the current computational node."""
-        data = {
-            'os': platform.platform(),
-            'hostname': platform.node(),
-            'userdir': os.path.expanduser('~')
-        }
-        md5 = hashlib.md5()
-        # a json dump will handle non-ascii encodings
-        # but then data must be encoded before hashing in Python 3.
-        md5.update(json.dumps(data).encode('utf-8'))
-        return md5.hexdigest()
-
     model_spec = importlib.import_module(pyname).MODEL_SPEC
 
     try:
@@ -232,7 +216,6 @@ def _log_model(pyname, model_args, invest_interface, type, source, session_id=No
             'model_name': pyname,
             'invest_release': natcap.invest.__version__,
             'invest_interface': invest_interface,
-            'node_hash': _node_hash(),
             'system_full_platform_string': platform.platform(),
             'system_preferred_encoding': locale.getdefaultlocale()[1],
             'system_default_language': locale.getdefaultlocale()[0],

--- a/src/natcap/invest/usage.py
+++ b/src/natcap/invest/usage.py
@@ -119,7 +119,8 @@ def _calculate_args_bounding_box(args, model_spec):
     return bb_intersection, bb_union
 
 
-def _log_model(pyname, model_args, invest_interface, type, source):
+def _log_model(
+        pyname, model_args, invest_interface, model_type, plugin_source):
     """Log information about a model run to a remote server.
 
     Args:
@@ -127,9 +128,9 @@ def _log_model(pyname, model_args, invest_interface, type, source):
         model_args (dict): the traditional InVEST argument dictionary.
         invest_interface (string): a string identifying the calling UI,
             e.g. `Qt` or 'Workbench'.
-        type (string): 'core' or 'plugin'
-        source (string): For plugins, a string identifying the source of the
-            plugin (e.g. 'git+https://github.com/foo/bar' or 'local'). For
+        model_type (string): 'core' or 'plugin'
+        plugin_source (string): For plugins, a string identifying the source of
+            the plugin (e.g. 'git+https://github.com/foo/bar' or 'local'). For
             core models, this is None.
 
     Returns:
@@ -152,8 +153,8 @@ def _log_model(pyname, model_args, invest_interface, type, source):
             'system_default_language': locale.getdefaultlocale()[0],
             'bounding_box_intersection': str(bounding_box_intersection),
             'bounding_box_union': str(bounding_box_union),
-            'type': type,
-            'source': source
+            'type': model_type,
+            'source': plugin_source
         })
     except Exception as exception:
         # An exception was thrown, we don't care.

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -221,7 +221,7 @@ class EndpointFunctionTests(unittest.TestCase):
                 'workspace_dir': 'foo'
             }),
             'invest_interface': 'Workbench',
-            'type': 'core'
+            'model_type': 'core'
         }
         response = test_client.post(
             f'{ROUTE_PREFIX}/log_model_start', json=payload)
@@ -257,7 +257,7 @@ class EndpointFunctionTests(unittest.TestCase):
                 'workspace_dir': 'sample_workspace'
             }),
             'invest_interface': 'Workbench',
-            'type': 'plugin'
+            'model_type': 'plugin'
         }
 
         # Mock ``importlib.import_module`` because ``usage._log_model`` will

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -221,7 +221,6 @@ class EndpointFunctionTests(unittest.TestCase):
                 'workspace_dir': 'foo'
             }),
             'invest_interface': 'Workbench',
-            'session_id': '12345',
             'type': 'core'
         }
         response = test_client.post(
@@ -237,9 +236,6 @@ class EndpointFunctionTests(unittest.TestCase):
         self.assertEqual(
             mock_post.call_args.kwargs['data']['invest_interface'],
             payload['invest_interface'])
-        self.assertEqual(
-            mock_post.call_args.kwargs['data']['session_id'],
-            payload['session_id'])
 
     @patch('natcap.invest.ui_server.usage.requests.post')
     @patch('natcap.invest.ui_server.usage.requests.get')
@@ -261,7 +257,6 @@ class EndpointFunctionTests(unittest.TestCase):
                 'workspace_dir': 'sample_workspace'
             }),
             'invest_interface': 'Workbench',
-            'session_id': '12345',
             'type': 'plugin'
         }
 
@@ -282,9 +277,6 @@ class EndpointFunctionTests(unittest.TestCase):
             self.assertEqual(
                 mock_post.call_args.kwargs['data']['invest_interface'],
                 payload['invest_interface'])
-            self.assertEqual(
-                mock_post.call_args.kwargs['data']['session_id'],
-                payload['session_id'])
 
     @patch('natcap.invest.ui_server.geometamaker.config.platformdirs.user_config_dir')
     def test_get_geometamaker_profile(self, mock_user_config_dir):

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -286,28 +286,6 @@ class EndpointFunctionTests(unittest.TestCase):
                 mock_post.call_args.kwargs['data']['session_id'],
                 payload['session_id'])
 
-    @patch('natcap.invest.ui_server.usage.requests.post')
-    @patch('natcap.invest.ui_server.usage.requests.get')
-    def test_log_model_exit(self, mock_get, mock_post):
-        """UI server: log_model_start endpoint."""
-        mock_response = Mock()
-        mock_url = 'http://foo.org/bar.html'
-        mock_response.json.return_value = {'FINISH': mock_url}
-        mock_get.return_value = mock_response
-        test_client = ui_server.app.test_client()
-        payload = {
-            'session_id': '12345',
-            'status': ''
-        }
-        response = test_client.post(
-            f'{ROUTE_PREFIX}/log_model_exit', json=payload)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_data(as_text=True), 'OK')
-        mock_get.assert_called_once()
-        mock_post.assert_called_once()
-        self.assertEqual(mock_post.call_args.args[0], mock_url)
-        self.assertEqual(mock_post.call_args.kwargs['data'], payload)
-
     @patch('natcap.invest.ui_server.geometamaker.config.platformdirs.user_config_dir')
     def test_get_geometamaker_profile(self, mock_user_config_dir):
         """UI server: get_geometamaker_profile endpoint."""

--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -21,12 +21,12 @@ export default function investUsageLogger() {
 
     const plugins = settingsStore.get('plugins');
     if (plugins && Object.keys(plugins).includes(modelID)) {
-      body.type = 'plugin';
-      const source = plugins[modelID].source;
+      body.model_type = 'plugin';
+      const plugin_source = plugins[modelID].source;
       // don't log the path to a local plugin, just log that it's local
-      body.source = source.startsWith('git+') ? source : 'local';
+      body.plugin_source = plugin_source.startsWith('git+') ? plugin_source : 'local';
     } else {
-      body.type = 'core';
+      body.model_type = 'core';
     }
     fetch(`${HOSTNAME}:${port}/${PREFIX}/log_model_start`, {
       method: 'post',

--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -1,5 +1,3 @@
-import crypto from 'crypto';
-
 import fetch from 'node-fetch';
 
 import { logger } from './logger';
@@ -11,7 +9,6 @@ const HOSTNAME = 'http://127.0.0.1';
 const PREFIX = 'api';
 
 export default function investUsageLogger() {
-  const sessionId = crypto.randomUUID();
 
   function start(modelID, args, port) {
     logger.debug('logging model start');
@@ -20,7 +17,6 @@ export default function investUsageLogger() {
       model_id: modelID,
       model_args: JSON.stringify(args),
       invest_interface: `Workbench ${WORKBENCH_VERSION}`,
-      session_id: sessionId,
     };
 
     const plugins = settingsStore.get('plugins');

--- a/workbench/src/main/investUsageLogger.js
+++ b/workbench/src/main/investUsageLogger.js
@@ -43,24 +43,7 @@ export default function investUsageLogger() {
       .catch((error) => logger.error(error));
   }
 
-  function exit(status, port) {
-    logger.debug('logging model exit');
-    fetch(`${HOSTNAME}:${port}/${PREFIX}/log_model_exit`, {
-      method: 'post',
-      body: JSON.stringify({
-        session_id: sessionId,
-        status: status,
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-      .then(async (response) => {
-        if (!response.ok) { logger.error(await response.text()); }
-      })
-      .catch((error) => logger.error(error));
-  }
-
   return {
     start: start,
-    exit: exit,
   };
 }

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -191,9 +191,6 @@ export function setupInvestRunHandlers() {
           if (e) { logger.error(e); }
         });
       });
-      if (!ELECTRON_DEV_MODE && !process.env.PUPPETEER) {
-        usageLogger.exit(investStdErr, port);
-      }
     });
   });
 }

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -255,16 +255,10 @@ describe('investUsageLogger', () => {
     expect(fetch.mock.calls[0][0]).toBe(expectedURL);
     const startPayload = JSON.parse(fetch.mock.calls[0][1].body);
 
-    usageLogger.exit(investStdErr, PORT);
-    expect(fetch.mock.calls).toHaveLength(2);
-    const exitPayload = JSON.parse(fetch.mock.calls[1][1].body);
-
     expect(startPayload.type).toBe('core');
-    expect(startPayload.session_id).toBe(exitPayload.session_id);
     expect(startPayload.model_id).toBe(modelID);
     expect(JSON.parse(startPayload.model_args)).toMatchObject(args);
     expect(startPayload.invest_interface).toContain('Workbench');
-    expect(exitPayload.status).toBe(investStdErr);
   });
 
   test('logs plugin usage correctly', () => {

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -255,7 +255,7 @@ describe('investUsageLogger', () => {
     expect(fetch.mock.calls[0][0]).toBe(expectedURL);
     const startPayload = JSON.parse(fetch.mock.calls[0][1].body);
 
-    expect(startPayload.type).toBe('core');
+    expect(startPayload.model_type).toBe('core');
     expect(startPayload.model_id).toBe(modelID);
     expect(JSON.parse(startPayload.model_args)).toMatchObject(args);
     expect(startPayload.invest_interface).toContain('Workbench');
@@ -281,14 +281,14 @@ describe('investUsageLogger', () => {
 
     usageLogger.start('pluginA', args, PORT);
     let startPayload = JSON.parse(fetch.mock.calls[0][1].body);
-    expect(startPayload.type).toBe('plugin');
+    expect(startPayload.model_type).toBe('plugin');
     expect(startPayload.model_id).toBe('pluginA');
-    expect(startPayload.source).toBe('git+https://plugin');
+    expect(startPayload.plugin_source).toBe('git+https://plugin');
 
     usageLogger.start('pluginB', args, PORT);
     startPayload = JSON.parse(fetch.mock.calls[1][1].body);
-    expect(startPayload.type).toBe('plugin');
+    expect(startPayload.model_type).toBe('plugin');
     expect(startPayload.model_id).toBe('pluginB');
-    expect(startPayload.source).toBe('local');
+    expect(startPayload.plugin_source).toBe('local');
   });
 });


### PR DESCRIPTION
## Description
Closes #2600.

Specifically, this PR removes the following:
- `node_hash` and `session_id` (we are no longer logging these attributes; the API endpoint ignores them),
- model exit logging (we no longer track model exit details; the API endpoint ignores the request body), and
- the `log_run` context manager (was used only by the Qt app, which is no longer actively maintained).

I tested this locally (by temporarily enabling logging in dev mode) and confirmed there were no errors and my model run arrived in the DB as expected.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
