### PR TITLE
UMH: updated sample data metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DATA_DIR := data
 GIT_SAMPLE_DATA_REPO        := https://bitbucket.org/natcap/invest-sample-data.git
 GIT_SAMPLE_DATA_REPO_PATH   := $(DATA_DIR)/invest-sample-data
-GIT_SAMPLE_DATA_REPO_REV    := 828eb570dab6a84751fcbe0eff430ec66e4a1621
+GIT_SAMPLE_DATA_REPO_REV    := 098183806c0c715e6422d4d0570db91321c0f4e8
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data

--- a/src/natcap/invest/reports/raster_utils.py
+++ b/src/natcap/invest/reports/raster_utils.py
@@ -2,8 +2,9 @@ import base64
 import collections
 import logging
 import math
-import textwrap
 import os
+import re
+import textwrap
 from io import BytesIO
 from enum import Enum
 
@@ -24,8 +25,7 @@ from pydantic.dataclasses import dataclass
 from typing import Literal
 
 from natcap.invest import gettext
-from natcap.invest.spec import ModelSpec, Input, Output, \
-    CSVInput, SingleBandRasterInput
+from natcap.invest.spec import Input, Output, CSVInput, SingleBandRasterInput
 
 LOGGER = logging.getLogger(__name__)
 
@@ -112,6 +112,10 @@ NODATA_COL_NAME = gettext('Nodata value')
 UNITS_COL_NAME = gettext('Units')
 UNKNOWN_VAL_TEXT = gettext('unknown')
 UNITS_TEXT = gettext('Units')
+
+# Raster Attribute Tables sometimes contain these columns
+# Right now we filter them out and create our own color palette.
+RAT_COLOR_COLS = ['red', 'green', 'blue', 'alpha', 'opacity']
 
 
 class RasterDatatype(str, Enum):
@@ -747,7 +751,8 @@ def plot_categorical_raster_with_table(raster_path_list: list[str]):
             # Some RATs include color tables. This is not useful to display in
             # this context because it will be confusing.
             # Best we can do is guess what the column names could be.
-            col_filter = df.filter(['Red', 'Green', 'Blue', 'Alpha', 'Opacity'])
+            col_filter = df.filter(
+                regex=re.compile('|'.join(RAT_COLOR_COLS), flags=re.I))
             df = df.drop(col_filter, axis=1)
             rat_df_list.append(df)
         if len(rat_value_names) == 1:

--- a/tests/reports/test_raster_utils.py
+++ b/tests/reports/test_raster_utils.py
@@ -705,6 +705,21 @@ class PlotCategoricalRastersTest(unittest.TestCase):
         # Our RAT has 3 columns, a 4th was added for the color swatch
         self.assertEqual(df.shape, (num_vals, 4))
 
+    def test_plot_single_raster_with_rat_color_table(self):
+        """Test that the RAT color table will be filtered out."""
+        target_filepath = os.path.join(self.workspace_dir, 'lulc.tif')
+        num_vals = 12
+        make_nominal_raster_with_distinct_counts(
+            target_filepath, num_vals)
+        add_raster_attribute_table(
+            target_filepath,
+            extra_cols=['RED', 'green', 'Blue', 'ALPHA', 'opacity'])
+        img_src, table = raster_utils.plot_categorical_raster_with_table(
+            [target_filepath])
+        df = self.html_string_to_dataframe(table)
+        # All the RGBA (and opacity) columns should be filtered out
+        self.assertEqual(df.shape, (num_vals, 3))
+
     def test_plot_single_raster_without_rat(self):
         """Test single raster without RAT."""
         target_filepath = os.path.join(self.workspace_dir, 'lulc.tif')


### PR DESCRIPTION
I rebuilt the raster attribute table pixel counts for the LULC rasters using `gdal raster info --hist`. That updated the XML docs. I transferred those values to the DBFs because the DBFs contain other useful columns. Then I updated the YML docs using `geometamaker describe`.

Those changes are in,
https://bitbucket.org/natcap/invest-sample-data/commits/b2315822dba2577c05bda733aab58a33b74e7a7e
https://bitbucket.org/natcap/invest-sample-data/commits/645f2cddb46482f5d3561f67ffb7613a1687171f

A side-effect was the case of some RAT columns changed, so I updated the `raster_utils` function to be case-insensitive when it filters out the color table columns.

Fixes #2604 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
- [x] Tested the UMH sampledata report
