### PR TITLE
Upgrade actions/cache to v5 and mamba-org/setup-micromamba to v3.

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -57,7 +57,7 @@ runs:
         cat environment.yml
 
     - name: Setup conda environment
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         micromamba-version: '1.5.12-0'
         environment-file: environment.yml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,7 +89,7 @@ jobs:
       # Test data is way, way faster by contrast (on the order of a few
       # seconds to archive).
       - name: Restore git-LFS test data cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: data/invest-test-data
           key: git-lfs-testdata-${{ hashfiles('Makefile') }}
@@ -276,7 +276,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: nodemodules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: workbench/node_modules
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}
@@ -360,7 +360,7 @@ jobs:
 
       - name: Restore node_modules cache
         id: nodemodules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: workbench/node_modules
           key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('workbench/yarn.lock') }}


### PR DESCRIPTION
## Description
Fixes #2612.

Do not merge until after 3.20.0 release.

## Checklist
~~- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)~~
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
