### PR TITLE
Remove usage of deprecated numpy "a" dtype

### DIFF
--- a/src/natcap/invest/recreation/recmodel_server.py
+++ b/src/natcap/invest/recreation/recmodel_server.py
@@ -690,6 +690,40 @@ class RecModel(object):
         return out_aoi_ud_path, monthly_table_path
 
 
+def _string_to_structured_array(chunk_string, pattern):
+    """Parse chunk of a CSV file to a structured array.
+
+    Args:
+
+        chunk_string (str): chunk of a CSV file
+        pattern (str): the regex pattern of the CSV, which can vary by
+            dataset (flickr vs twitter)
+
+    Returns:
+        structured numpy.array
+
+    """
+    structured_array = numpy.fromregex(
+        StringIO(chunk_string), pattern,
+        [('user', 'S40'), ('date', 'datetime64[D]'), ('lat', 'f4'),
+         ('lng', 'f4')])
+
+    def md5hash(user_string):
+        """md5hash userid."""
+        return hashlib.md5(user_string).digest()[-4:]
+
+    md5hash_v = numpy.vectorize(md5hash, otypes=['S4'])
+    hashes = md5hash_v(structured_array['user'])
+
+    user_day_lng_lat = numpy.empty(
+        hashes.size, dtype='datetime64[D],S4,f4,f4')
+    user_day_lng_lat['f0'] = structured_array['date']
+    user_day_lng_lat['f1'] = hashes
+    user_day_lng_lat['f2'] = structured_array['lng']
+    user_day_lng_lat['f3'] = structured_array['lat']
+    return user_day_lng_lat
+
+
 def _parse_big_input_csv(
         block_offset_size_queue, numpy_array_queue, csv_filepath, dataset_name):
     """Parse CSV file lines to (datetime64[d], userhash, lat, lng) tuples.
@@ -716,27 +750,11 @@ def _parse_big_input_csv(
         chunk_string = csv_file.read(chunk_size)
         csv_file.close()
 
-        result = numpy.fromregex(
-            StringIO(chunk_string), CSV_PATTERNS[dataset_name],
-            [('user', 'S40'), ('date', 'datetime64[D]'), ('lat', 'f4'),
-             ('lng', 'f4')])
-
-        def md5hash(user_string):
-            """md5hash userid."""
-            return hashlib.md5(user_string).digest()[-4:]
-
-        md5hash_v = numpy.vectorize(md5hash, otypes=['S4'])
-        hashes = md5hash_v(result['user'])
-
-        user_day_lng_lat = numpy.empty(
-            hashes.size, dtype='datetime64[D],S4,f4,f4')
-        user_day_lng_lat['f0'] = result['date']
-        user_day_lng_lat['f1'] = hashes
-        user_day_lng_lat['f2'] = result['lng']
-        user_day_lng_lat['f3'] = result['lat']
-        # multiprocessing.Queue pickles the array. Pickling isn't perfect and
-        # it modifies the `datetime64` dtype metadata, causing a warning later.
-        # To avoid this we dump the array to a string before adding to queue.
+        user_day_lng_lat = _string_to_structured_array(
+            chunk_string, CSV_PATTERNS[dataset_name])
+        # # multiprocessing.Queue pickles the array. Pickling isn't perfect and
+        # # it modifies the `datetime64` dtype metadata, causing a warning later.
+        # # To avoid this we dump the array to a string before adding to queue.
         numpy_array_queue.put(_numpy_dumps(user_day_lng_lat))
     numpy_array_queue.put('STOP')
 
@@ -765,25 +783,9 @@ def _parse_small_input_csv_list(
         chunk_string = csv_file.read()
         csv_file.close()
 
-        def md5hash(user_string):
-            """md5hash userid."""
-            return hashlib.md5(user_string).digest()[-4:]
-
         if chunk_string:
-            result = numpy.fromregex(
-                StringIO(chunk_string), CSV_PATTERNS[dataset_name],
-                [('user', 'S40'), ('date', 'datetime64[D]'), ('lat', 'f4'),
-                 ('lng', 'f4')])
-
-            md5hash_v = numpy.vectorize(md5hash, otypes=['S4'])
-            hashes = md5hash_v(result['user'])
-
-            user_day_lng_lat = numpy.empty(
-                hashes.size, dtype='datetime64[D],a4,f4,f4')
-            user_day_lng_lat['f0'] = result['date']
-            user_day_lng_lat['f1'] = hashes
-            user_day_lng_lat['f2'] = result['lng']
-            user_day_lng_lat['f3'] = result['lat']
+            user_day_lng_lat = _string_to_structured_array(
+                chunk_string, CSV_PATTERNS[dataset_name])
             # multiprocessing.Queue pickles the array. Pickling isn't perfect
             # and it modifies the `datetime64` dtype metadata, causing a
             # UserWarning later, on save. To avoid this we dump the array


### PR DESCRIPTION
I'm not sure how this lasted so long since I think we raise DeprecationWarnings to errors in our test suite. We had already updated this in other places in the code, but there was one left and now numpy raises a `TypeError` on it. I consolidated some redundant code in the process.

Fixes #2649

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
