### PR TITLE
Fix cross-compilation of `natcap.invest` for other architectures on conda-forge

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -66,6 +66,13 @@
 Unreleased Changes
 ------------------
 
+General
+=======
+* Fixed an issue with cross-compiling ``natcap.invest`` for non-native
+  architectures, particularly on conda-forge.  This should also speed up
+  the operation of ``setup.py``.
+  (`#2630 <https://github.com/natcap/invest/issues/2630>`_)
+
 Workbench
 =========
 * Added a file browse button to the input field for selecting a

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,28 @@
+import importlib.util
 import os
 import platform
 import subprocess
 
 import numpy
-import pygeoprocessing
 from Cython.Build import cythonize
 from setuptools import setup
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.extension import Extension
 
-include_dirs = [numpy.get_include(),
-                os.path.join(pygeoprocessing.__path__[0], 'extensions')]
+include_dirs = [numpy.get_include()]
+
+pygeoprocessing_spec = importlib.util.find_spec("pygeoprocessing")
+if pygeoprocessing_spec is not None and pygeoprocessing_spec.submodule_search_locations:
+    # Don't import all of pygeoprocessing, just get the include dir from
+    # package metadata.
+    # This should avoid issues with conda-forge when cross-compiling to
+    # non-native architectures like linux-ppcle64.
+    include_dirs.append(os.path.join(
+        pygeoprocessing_spec.submodule_search_locations[0], 'extensions'))
+else:
+    raise ModuleNotFoundError(
+        "Pygeoprocessing is required to compile natcap.invest")
+
 if platform.system() == 'Windows':
     compiler_args = ['/std:c++20']
     compiler_and_linker_args = []


### PR DESCRIPTION
This PR updates `setup.py` to read the pygeoprocessing package location from metadata instead of from the imported module object, which avoids a cross-compilation issue in conda-forge.

It turns out that the problem described in #2630 was due to cross-compilation: the aarch64 (mac and linux) and ppc64le (linux) builds are actually built on x64 hardware at this time.

When we go to build a cross-compiled package, `setup.py` is being executed by a different interpreter, `cross-python` inside the `build` environment on conda-forge, which is an x64 environment.  Everything installed into the build environment (including pygeoprocessing and its dependencies like rtree/libspatialindex) is x64.  The binaries that _result_ from the execution of `setup.py` by `cross-python` is the target architecture (e.g. aarch64).  However, this means that if we import `pygeoprocessing` inside of `setup.py`, it's trying to load an x64 binary from an "aarch64" (spoofed) python, which is why it couldn't find a compatible `libspatialindex_c` binary and the cross-compiled builds were failing.

Fortunately, we only need the location of the `pygeoprocessing` package, which we can get from the package metadata!  And that's what this change does.

Plus, not importing the entirety of pygeoprocessing and its dependencies should make `setup.py` executions a whole lot faster.

Fixes:#2630

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
