### PR TITLE
Refactor server startup logic to better handle errors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,6 +83,8 @@ Workbench
   (`#1798 <https://github.com/natcap/invest/issues/1798>`_)
 * React dependency has been updated to its latest stable version (19.2.7).
   (`#2481 <https://github.com/natcap/invest/issues/2481>`_)
+* Improved handling of errors on plugin server startup
+  (`#2637 https://github.com/natcap/invest/issues/2637`)
 
 3.20.0 (2026-06-11)
 -------------------

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -35,6 +35,8 @@ export async function handleServerStartup(pythonServerProcess, url, maxRetries=5
   pythonServerProcess.stderr.on('data', (data) => {
     logger.debug(`${data}`);
   });
+  // The 'error' event happens when the child process fails to spawn.
+  // This should be rare.
   pythonServerProcess.on('error', (err) => {
     logger.error(pythonServerProcess.spawnargs);
     logger.error(err.stack);
@@ -44,14 +46,16 @@ export async function handleServerStartup(pythonServerProcess, url, maxRetries=5
     );
     throw err;
   });
-  pythonServerProcess.on('close', (code, signal) => {
-    logger.debug(`Flask process closed with code ${code} and signal ${signal}`);
-  });
+  // The 'exit' event is what happens on routine errors like a
+  // typo in the micromamba command or a plugin failing to import
   pythonServerProcess.on('exit', (code) => {
     logger.debug(`Flask process exited with code ${code}`);
     if (code != 0) {
       processErrored = true;
     }
+  });
+  pythonServerProcess.on('close', (code, signal) => {
+    logger.debug(`Flask process closed with code ${code} and signal ${signal}`);
   });
   pythonServerProcess.on('disconnect', () => {
     logger.debug('Flask process disconnected');
@@ -118,12 +122,10 @@ export async function createCoreServerProcess(_port = undefined) {
  * @returns { integer } - PID of the process that was launched
  */
 export async function createPluginServerProcess(modelID, _port = undefined) {
-
   let port = _port;
   if (port === undefined) {
     port = await getFreePort();
   }
-
   logger.debug('creating invest plugin server process');
   const micromamba = settingsStore.get('micromamba');
   const modelEnvPath = settingsStore.get(`plugins.${modelID}.env`);

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -20,39 +20,15 @@ async function getFreePort() {
   });
 }
 
-/** Find out if the Flask server is online, waiting until it is.
- *
- * @param {number} i - the number or previous tries
- * @param {number} retries - number of recursive calls this function is allowed.
- * @returns { Promise } resolves text indicating success.
- */
-export async function getFlaskIsReady(port, i = 0, retries = 41) {
-  try {
-    await fetch(`${HOSTNAME}:${port}/api/ready`, {
-      method: 'get',
-    });
-  } catch (error) {
-    if (error.code === 'ECONNREFUSED') {
-      while (i < retries) {
-        i++;
-        // Try every X ms, usually takes a couple seconds to startup.
-        await new Promise((resolve) => setTimeout(resolve, 300));
-        logger.debug(`retry # ${i}`);
-        return getFlaskIsReady(port, i, retries);
-      }
-      logger.error(`Not able to connect to server after ${retries} tries.`);
-    }
-    logger.error(error);
-    throw error;
-  }
-}
-
 /**
- * Set up handlers for server process events.
+ * Wait for a invest server process to start up, handling any errors.
  * @param  {ChildProcess} pythonServerProcess - server process instance.
- * @returns {undefined}
+ * @param {string} url - server status url to retry
+ * @param {number} maxRetries - number of retries allowed
+ * @returns {number} PID of the started process, or undefined if it fails to launch
  */
-export function setupServerProcessHandlers(pythonServerProcess) {
+export async function handleServerStartup(pythonServerProcess, url, maxRetries=500) {
+  let processErrored = false;
   pythonServerProcess.stdout.on('data', (data) => {
     logger.debug(`${data}`);
   });
@@ -73,11 +49,38 @@ export function setupServerProcessHandlers(pythonServerProcess) {
   });
   pythonServerProcess.on('exit', (code) => {
     logger.debug(`Flask process exited with code ${code}`);
+    if (code != 0) {
+      processErrored = true;
+    }
   });
   pythonServerProcess.on('disconnect', () => {
     logger.debug('Flask process disconnected');
   });
   pidToSubprocess[pythonServerProcess.pid] = pythonServerProcess;
+
+  // Wait for the server to start up
+  let retries = 0;
+  while (retries < 500) {
+    if (processErrored) {
+      return undefined;
+    }
+    logger.debug(`retry # ${retries}`);
+    try {
+      await fetch(url, { method: 'get' });
+      logger.info('flask is ready');
+      return pythonServerProcess.pid;
+    } catch (error) {
+      if (error.code === 'ECONNREFUSED') {
+        // wait 300ms before retrying
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        retries++;
+      } else {
+        logger.error(error);
+        throw error;
+      }
+    }
+  }
+  logger.error(`Not able to connect to server after ${retries} tries.`);
 }
 
 /**
@@ -102,10 +105,9 @@ export async function createCoreServerProcess(_port = undefined) {
   settingsStore.set('core.pid', pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-
-  setupServerProcessHandlers(pythonServerProcess);
-  await getFlaskIsReady(port, 0, 500);
-  logger.info('flask is ready');
+  const pid = await handleServerStartup(
+    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+  return pid;
 }
 
 /**
@@ -116,6 +118,7 @@ export async function createCoreServerProcess(_port = undefined) {
  * @returns { integer } - PID of the process that was launched
  */
 export async function createPluginServerProcess(modelID, _port = undefined) {
+
   let port = _port;
   if (port === undefined) {
     port = await getFreePort();
@@ -136,12 +139,9 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   settingsStore.set(`plugins.${modelID}.pid`, pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-
-  setupServerProcessHandlers(pythonServerProcess);
-
-  await getFlaskIsReady(port, 0, 500);
-  logger.info('flask is ready');
-  return pythonServerProcess.pid;
+  const pid = await handleServerStartup(
+    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+  return pid;
 }
 
 /**

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -58,7 +58,6 @@ async function getFlaskIsReady(url, signal, maxRetries = 500) {
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
 export async function handleServerStartup(pythonServerProcess, url) {
-  logger.debug('handle server startup');
   const controller = new AbortController();
   const signal = controller.signal;
 
@@ -95,8 +94,7 @@ export async function handleServerStartup(pythonServerProcess, url) {
   });
 
   try {
-    logger.debug('wait for server to be ready');
-    await getServerReady(url, signal);
+    await getFlaskIsReady(url, signal);
   } catch (error) {
     return undefined;
   }
@@ -116,7 +114,6 @@ export async function createCoreServerProcess(_port = undefined) {
   if (port === undefined) {
     port = await getFreePort();
   }
-  logger.debug('creating invest core server process');
   const pythonServerProcess = spawn(
     settingsStore.get('investExe'),
     ['--debug', 'serve', '--port', port],
@@ -128,7 +125,6 @@ export async function createCoreServerProcess(_port = undefined) {
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
   const pid = await handleServerStartup(
     pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
-  logger.debug('returning', pid);
   return pid;
 }
 
@@ -144,7 +140,6 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   if (port === undefined) {
     port = await getFreePort();
   }
-  logger.debug('creating invest plugin server process');
   const micromamba = settingsStore.get('micromamba');
   const modelEnvPath = settingsStore.get(`plugins.${modelID}.env`);
   const args = [

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -25,9 +25,10 @@ async function getFreePort() {
  * @param {string} url - URL to poll for server status
  * @param {signal} signal - AbortController signal to abort trying to connect
  * @param {number} maxRetries - number of retries allowed
- * @returns {number} PID of the started process, or undefined if it fails to launch
+ * @returns undefined when the server is ready, or throws an error
+ *          if it fails to launch
  */
-async function getServerReady(url, signal, maxRetries = 500) {
+async function getFlaskIsReady(url, signal, maxRetries = 500) {
   let retries = 0;
   while (!signal.aborted && retries < maxRetries) {
     logger.debug(`retry # ${retries}`);

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -21,14 +21,43 @@ async function getFreePort() {
 }
 
 /**
- * Wait for a invest server process to start up, handling any errors.
- * @param  {ChildProcess} pythonServerProcess - server process instance.
- * @param {string} url - server status url to retry
+ * Wait for the server to become responsive.
+ * @param {signal} signal - AbortController signal to abort trying to connect
  * @param {number} maxRetries - number of retries allowed
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
-export async function handleServerStartup(pythonServerProcess, url, maxRetries=500) {
-  let processErrored = false;
+async function getServerReady(signal, maxRetries = 500) {
+  let retries = 0;
+  while (!signal.aborted && retries < maxRetries) {
+    logger.debug(`retry # ${retries}`);
+    try {
+      await fetch(`${HOSTNAME}:${port}/api/ready`, { method: 'get' });
+      logger.info('flask is ready');
+      return;
+    } catch (error) {
+      if (error.code === 'ECONNREFUSED') {
+        // wait 300ms before retrying
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        retries++;
+      } else {
+        logger.error(error);
+        throw error;
+      }
+    }
+  }
+  logger.error(`Not able to connect to server after ${retries} tries.`);
+  throw new Error('Could not connect');
+}
+
+/**
+ * Wait for a invest server process to start up, handling any errors.
+ * @param  {ChildProcess} pythonServerProcess - server process instance.
+ * @returns {number} PID of the started process, or undefined if it fails to launch
+ */
+export async function handleServerStartup(pythonServerProcess) {
+  const controller = new AbortController();
+  const signal = controller.signal;
+
   pythonServerProcess.stdout.on('data', (data) => {
     logger.debug(`${data}`);
   });
@@ -51,7 +80,7 @@ export async function handleServerStartup(pythonServerProcess, url, maxRetries=5
   pythonServerProcess.on('exit', (code) => {
     logger.debug(`Flask process exited with code ${code}`);
     if (code != 0) {
-      processErrored = true;
+      controller.abort();
     }
   });
   pythonServerProcess.on('close', (code, signal) => {
@@ -60,31 +89,14 @@ export async function handleServerStartup(pythonServerProcess, url, maxRetries=5
   pythonServerProcess.on('disconnect', () => {
     logger.debug('Flask process disconnected');
   });
-  pidToSubprocess[pythonServerProcess.pid] = pythonServerProcess;
 
-  // Wait for the server to start up
-  let retries = 0;
-  while (retries < 500) {
-    if (processErrored) {
-      return undefined;
-    }
-    logger.debug(`retry # ${retries}`);
-    try {
-      await fetch(url, { method: 'get' });
-      logger.info('flask is ready');
-      return pythonServerProcess.pid;
-    } catch (error) {
-      if (error.code === 'ECONNREFUSED') {
-        // wait 300ms before retrying
-        await new Promise((resolve) => setTimeout(resolve, 300));
-        retries++;
-      } else {
-        logger.error(error);
-        throw error;
-      }
-    }
+  try {
+    await getServerReady(signal);
+  } catch (error) {
+    return undefined;
   }
-  logger.error(`Not able to connect to server after ${retries} tries.`);
+  pidToSubprocess[pythonServerProcess.pid] = pythonServerProcess;
+  return pythonServerProcess.pid;
 }
 
 /**
@@ -109,8 +121,7 @@ export async function createCoreServerProcess(_port = undefined) {
   settingsStore.set('core.pid', pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-  const pid = await handleServerStartup(
-    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+  const pid = await handleServerStartup(pythonServerProcess);
   return pid;
 }
 
@@ -141,8 +152,7 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   settingsStore.set(`plugins.${modelID}.pid`, pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-  const pid = await handleServerStartup(
-    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+  const pid = await handleServerStartup(pythonServerProcess);
   return pid;
 }
 

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -22,16 +22,17 @@ async function getFreePort() {
 
 /**
  * Wait for the server to become responsive.
+ * @param {string} url - URL to poll for server status
  * @param {signal} signal - AbortController signal to abort trying to connect
  * @param {number} maxRetries - number of retries allowed
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
-async function getServerReady(signal, maxRetries = 500) {
+async function getServerReady(url, signal, maxRetries = 500) {
   let retries = 0;
   while (!signal.aborted && retries < maxRetries) {
     logger.debug(`retry # ${retries}`);
     try {
-      await fetch(`${HOSTNAME}:${port}/api/ready`, { method: 'get' });
+      await fetch(url, { method: 'get' });
       logger.info('flask is ready');
       return;
     } catch (error) {
@@ -51,10 +52,11 @@ async function getServerReady(signal, maxRetries = 500) {
 
 /**
  * Wait for a invest server process to start up, handling any errors.
- * @param  {ChildProcess} pythonServerProcess - server process instance.
+ * @param {ChildProcess} pythonServerProcess - server process instance.
+ * @param {string} url - URL to poll for server status
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
-export async function handleServerStartup(pythonServerProcess) {
+export async function handleServerStartup(pythonServerProcess, url) {
   const controller = new AbortController();
   const signal = controller.signal;
 
@@ -91,7 +93,7 @@ export async function handleServerStartup(pythonServerProcess) {
   });
 
   try {
-    await getServerReady(signal);
+    await getServerReady(url, signal);
   } catch (error) {
     return undefined;
   }
@@ -121,7 +123,8 @@ export async function createCoreServerProcess(_port = undefined) {
   settingsStore.set('core.pid', pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-  const pid = await handleServerStartup(pythonServerProcess);
+  const pid = await handleServerStartup(
+    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
   return pid;
 }
 
@@ -152,7 +155,8 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   settingsStore.set(`plugins.${modelID}.pid`, pythonServerProcess.pid);
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
-  const pid = await handleServerStartup(pythonServerProcess);
+  const pid = await handleServerStartup(
+    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
   return pid;
 }
 

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -58,6 +58,7 @@ async function getFlaskIsReady(url, signal, maxRetries = 500) {
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
 export async function handleServerStartup(pythonServerProcess, url) {
+  logger.debug('handle server startup');
   const controller = new AbortController();
   const signal = controller.signal;
 
@@ -94,6 +95,7 @@ export async function handleServerStartup(pythonServerProcess, url) {
   });
 
   try {
+    logger.debug('wait for server to be ready');
     await getServerReady(url, signal);
   } catch (error) {
     return undefined;
@@ -126,6 +128,7 @@ export async function createCoreServerProcess(_port = undefined) {
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
   const pid = await handleServerStartup(
     pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+  logger.debug('returning', pid);
   return pid;
 }
 

--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -114,6 +114,7 @@ export async function createCoreServerProcess(_port = undefined) {
   if (port === undefined) {
     port = await getFreePort();
   }
+  logger.debug('creating invest core server process');
   const pythonServerProcess = spawn(
     settingsStore.get('investExe'),
     ['--debug', 'serve', '--port', port],
@@ -140,6 +141,7 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
   if (port === undefined) {
     port = await getFreePort();
   }
+  logger.debug('creating invest plugin server process');
   const micromamba = settingsStore.get('micromamba');
   const modelEnvPath = settingsStore.get(`plugins.${modelID}.env`);
   const args = [

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -66,7 +66,7 @@ export function destroyWindow() {
 
 /** Create an Electron browser window and start the flask application. */
 export const createWindow = async () => {
-  logger.info(`Running invest-workbench version ${pkg.version}`);
+  logger.info(`Running!!!! invest-workbench version ${pkg.version}`);
   nativeTheme.themeSource = 'light'; // override OS/browser setting
 
   i18n.changeLanguage(settingsStore.get('language'));
@@ -92,7 +92,9 @@ export const createWindow = async () => {
     });
   }
 
+  logger.info('creating core server process');
   await createCoreServerProcess();
+  logger.info('created core server process');
   setupDialogs();
   setupCheckFilePermissions();
   setupCheckFirstRun();

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -66,7 +66,7 @@ export function destroyWindow() {
 
 /** Create an Electron browser window and start the flask application. */
 export const createWindow = async () => {
-  logger.info(`Running!!!! invest-workbench version ${pkg.version}`);
+  logger.info(`Running invest-workbench version ${pkg.version}`);
   nativeTheme.themeSource = 'light'; // override OS/browser setting
 
   i18n.changeLanguage(settingsStore.get('language'));
@@ -92,9 +92,7 @@ export const createWindow = async () => {
     });
   }
 
-  logger.info('creating core server process');
   await createCoreServerProcess();
-  logger.info('created core server process');
   setupDialogs();
   setupCheckFilePermissions();
   setupCheckFirstRun();

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -21,6 +21,7 @@ import LogTab from '../LogTab';
 import ResourcesLinks from '../ResourcesLinks';
 import { getSpec } from '../../server_requests';
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
+import { handleClickFindLogfiles } from '../../menubar/handlers';
 
 const { ipcRenderer } = window.Workbench.electron;
 const { logger } = window.Workbench;
@@ -227,11 +228,16 @@ class InvestTab extends React.Component {
     const { tabID, investList, t } = this.props;
 
     if (tabStatus === 'failed') {
-      return (
+      return (<>
         <div className="invest-tab-loading">
-          {t('Failed to launch plugin')}
+          {t('Failed to launch plugin. Check the workbench logs.')}
         </div>
-      );
+        <div className="text-center mt-3">
+          <Button onClick={handleClickFindLogfiles}>
+            {t('Find My Logs')}
+          </Button>
+        </div>
+      </>);
     }
 
     // Don't render the model setup & log until data has been fetched.

--- a/workbench/tests/main/main.test.js
+++ b/workbench/tests/main/main.test.js
@@ -27,7 +27,6 @@ import {
 } from '../../src/main/setupCheckFirstRun';
 import {
   createCoreServerProcess,
-  getFlaskIsReady
 } from '../../src/main/createPythonFlaskProcess';
 import { findInvestBinaries } from '../../src/main/findBinaries';
 import extractZipInplace from '../../src/main/extractZipInplace';
@@ -47,7 +46,6 @@ beforeEach(() => {
     error: null
   });
   createCoreServerProcess.mockImplementation(() => {});
-  getFlaskIsReady.mockResolvedValue(true);
   // These vars are only defined in an electron environment and our
   // app expects them to be defined.
   process.defaultApp = 'test'; // imitates dev mode


### PR DESCRIPTION
## Description
Fixes #2637 
Refactored the server startup process to solve a couple of issues:
- 'exit' events from the server process were not be handled other than to log them. Now an exit with non-zero code will cause the "Failed to launch plugin" screen to be displayed.
- This logic is now integrated with the server startup polling, so that it does not continue to retry connecting to the server after an exit.

Also improved the plugin 'failed to launch' screen, to direct users to find their logs.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
