### PR TITLE
Updated snapshot test for Matplotlib 3.11.1 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SAMPLE_DATA_REPO_REV    := 098183806c0c715e6422d4d0570db91321c0f4e8
 
 GIT_TEST_DATA_REPO          := https://bitbucket.org/natcap/invest-test-data.git
 GIT_TEST_DATA_REPO_PATH     := $(DATA_DIR)/invest-test-data
-GIT_TEST_DATA_REPO_REV      := e5541ca176a3ac1c6cdca9c0159b0f1b94c47e69
+GIT_TEST_DATA_REPO_REV      := 44a4fdcc550c094050c9d4247d5f8f1ca1c2488e
 
 GIT_UG_REPO                 := https://github.com/natcap/invest.users-guide
 GIT_UG_REPO_PATH            := doc/users-guide

--- a/tests/reports/test_raster_utils.py
+++ b/tests/reports/test_raster_utils.py
@@ -332,7 +332,7 @@ class RasterPlotDatatypeAndTransformTests(unittest.TestCase):
 
 
 @unittest.skipIf(
-    MPL_VERSION < (3, 11, 0), 'Snapshots were created with matplotlib 3.11.0')
+    MPL_VERSION < (3, 11, 1), 'Snapshots were created with matplotlib 3.11.1')
 class RasterPlotLegendTests(unittest.TestCase):
     """Snapshot tests for legend placement on nominal rasters."""
 


### PR DESCRIPTION
The latest matplotlib release broke one of our snapshot tests. I updated the snapshot in the test data repo. I considered refactoring some of the legend tests do use assertions based on something other than a snapshot so we can avoid having to update snapshots for stuff like this, but ultimately I wasn't very pleased with those options.

Making assertions based on attributes of a `Figure` object and the bounding box and anchor position of the legend felt like it would be based on too many implementation details of matplotlib. And unit-testing `_get_legend_kwargs` felt like just testing "magic numbers" that we came up with by experiment. The snapshot tests have value during development because they give us a convenient way to view the plots we create, in addition to guarding against regressions. Those other tests would only guard against regressions.

If matplotlib releases continue to break our snapshot tests, we can explore those options again.

Fixes #2670

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
