### PR TITLE
Show "View Results" button when a plugin has generated a report

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -83,6 +83,8 @@ Workbench
   (`#1798 <https://github.com/natcap/invest/issues/1798>`_)
 * React dependency has been updated to its latest stable version (19.2.7).
   (`#2481 <https://github.com/natcap/invest/issues/2481>`_)
+* The "View Results" button now supports plugins.
+  (`#2638 <https://github.com/natcap/invest/issues/2638>`_)
 
 3.20.0 (2026-06-11)
 -------------------

--- a/workbench/src/main/setupInvestHandlers.js
+++ b/workbench/src/main/setupInvestHandlers.js
@@ -68,8 +68,10 @@ export function setupInvestRunHandlers() {
     if (resultsSuffix && !resultsSuffix.startsWith('_')) {
       resultsSuffix = `_${resultsSuffix}`;
     }
+    // Strip version info from plugin ID before forming report filepath.
+    const baseModelId = modelID.includes('@') ? modelID.split('@')[0] : modelID;
     const reportFilepath = path.join(
-      args.workspace_dir, `${modelID}_report${resultsSuffix}.html`
+      args.workspace_dir, `${baseModelId}_report${resultsSuffix}.html`
     );
 
     // Write a temporary datastack json for passing to invest CLI


### PR DESCRIPTION
## Description
Fixes #2638. Confirmed this works for the Birb Habitat plugin and continues to work for core models as well.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
