### PR TITLE
no need to check the micromamba exe on Workbench startup.

### DIFF
--- a/workbench/src/main/createPythonFlaskProcess.js
+++ b/workbench/src/main/createPythonFlaskProcess.js
@@ -52,14 +52,16 @@ async function getFlaskIsReady(url, signal, maxRetries = 500) {
 }
 
 /**
- * Wait for a invest server process to start up, handling any errors.
+ * Wait for an invest server process to start up, handling any errors.
  * @param {ChildProcess} pythonServerProcess - server process instance.
+ * @param {string} modelID - the plugin key used in the settings store,
+ *        or 'core' if the model is not a plugin.
  * @param {string} url - URL to poll for server status
  * @returns {number} PID of the started process, or undefined if it fails to launch
  */
-export async function handleServerStartup(pythonServerProcess, url) {
+export async function handleServerStartup(pythonServerProcess, modelID, url) {
   const controller = new AbortController();
-  const signal = controller.signal;
+  const { signal } = controller;
 
   pythonServerProcess.stdout.on('data', (data) => {
     logger.debug(`${data}`);
@@ -82,12 +84,21 @@ export async function handleServerStartup(pythonServerProcess, url) {
   // typo in the micromamba command or a plugin failing to import
   pythonServerProcess.on('exit', (code) => {
     logger.debug(`Flask process exited with code ${code}`);
-    if (code != 0) {
+    if (code !== 0) {
       controller.abort();
     }
+    if (modelID !== 'core') {
+      // Clear these because the process is no longer running and these
+      // values signal to the renderer if it needs to launch the process
+      // or not when the model tab is opened.
+      // If it was the core model process, the user must close and re-open
+      // the Workbench anyway, which will clear these values.
+      settingsStore.set(`plugins.${modelID}.pid`, '');
+      settingsStore.set(`plugins.${modelID}.port`, '');
+    }
   });
-  pythonServerProcess.on('close', (code, signal) => {
-    logger.debug(`Flask process closed with code ${code} and signal ${signal}`);
+  pythonServerProcess.on('close', (code, sig) => {
+    logger.debug(`Flask process closed with code ${code} and signal ${sig}`);
   });
   pythonServerProcess.on('disconnect', () => {
     logger.debug('Flask process disconnected');
@@ -125,7 +136,7 @@ export async function createCoreServerProcess(_port = undefined) {
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
   const pid = await handleServerStartup(
-    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+    pythonServerProcess, 'core', `${HOSTNAME}:${port}/api/ready`);
   return pid;
 }
 
@@ -157,7 +168,7 @@ export async function createPluginServerProcess(modelID, _port = undefined) {
 
   logger.debug(`Started python process as PID ${pythonServerProcess.pid}`);
   const pid = await handleServerStartup(
-    pythonServerProcess, `${HOSTNAME}:${port}/api/ready`);
+    pythonServerProcess, modelID, `${HOSTNAME}:${port}/api/ready`);
   return pid;
 }
 

--- a/workbench/src/main/findBinaries.js
+++ b/workbench/src/main/findBinaries.js
@@ -56,19 +56,12 @@ export function findInvestBinaries(isDevMode) {
  * @param {boolean} isDevMode - a boolean designating dev mode or not.
  * @returns {string} micromamba executable.
  */
-export function findMicromambaExecutable(isDevMode) {
+export function setDefaultMicromambaExecutable(isDevMode) {
   let micromambaExe;
-  if (isDevMode) {
-    micromambaExe = 'micromamba'; // assume that micromamba is available
-  } else {
+  if (!isDevMode) {
     micromambaExe = `"${upath.join(process.resourcesPath, 'micromamba')}"`;
-  }
-  // Check that the executable is working
-  const { stderr, error } = spawnSync(micromambaExe, ['--help'], { shell: true });
-  if (error) {
-    logger.error(stderr.toString());
-    logger.error('micromamba executable is not where we expected it.');
-    throw error;
+  } else {
+    micromambaExe = 'micromamba'; // assume that micromamba is available
   }
   logger.info(`using micromamba executable '${micromambaExe}'`);
   return micromambaExe;

--- a/workbench/src/main/main.js
+++ b/workbench/src/main/main.js
@@ -15,7 +15,7 @@ import {
   createCoreServerProcess,
   shutdownPythonProcess
 } from './createPythonFlaskProcess';
-import { findInvestBinaries, findMicromambaExecutable } from './findBinaries';
+import { findInvestBinaries, setDefaultMicromambaExecutable } from './findBinaries';
 import setupDownloadHandlers from './setupDownloadHandlers';
 import setupDialogs from './setupDialogs';
 import setupCheckFilePermissions from './setupCheckFilePermissions';
@@ -81,7 +81,7 @@ export const createWindow = async () => {
   splashScreen.loadURL(new URL('splash.html', BASE_URL).href);
 
   settingsStore.set('investExe', findInvestBinaries(ELECTRON_DEV_MODE));
-  settingsStore.set('micromamba', findMicromambaExecutable(ELECTRON_DEV_MODE));
+  settingsStore.set('micromamba', setDefaultMicromambaExecutable(ELECTRON_DEV_MODE));
   // No plugin server processes should persist between workbench sessions
   // In case any were left behind, remove them
   const plugins = settingsStore.get('plugins');

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -228,16 +228,21 @@ class InvestTab extends React.Component {
     const { tabID, investList, t } = this.props;
 
     if (tabStatus === 'failed') {
-      return (<>
+      return (
         <div className="invest-tab-loading">
-          {t('Failed to launch plugin. Check the workbench logs.')}
+          <p>{t('Failed to launch plugin. Check the workbench logs.')}</p>
+          <div className="text-center mt-3">
+            <Button onClick={handleClickFindLogfiles}>
+              {t('Find My Logs')}
+            </Button>
+          </div>
+          <p>
+            {t(`You may wish to manually configure the conda executeable
+              or the plugin environment.`)}
+          </p>
+          <p>{t('See the "Advanced" options in the Manage Plugins menu.')}</p>
         </div>
-        <div className="text-center mt-3">
-          <Button onClick={handleClickFindLogfiles}>
-            {t('Find My Logs')}
-          </Button>
-        </div>
-      </>);
+      );
     }
 
     // Don't render the model setup & log until data has been fetched.

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -228,21 +228,16 @@ class InvestTab extends React.Component {
     const { tabID, investList, t } = this.props;
 
     if (tabStatus === 'failed') {
-      return (
+      return (<>
         <div className="invest-tab-loading">
-          <p>{t('Failed to launch plugin. Check the workbench logs.')}</p>
-          <div className="text-center mt-3">
-            <Button onClick={handleClickFindLogfiles}>
-              {t('Find My Logs')}
-            </Button>
-          </div>
-          <p>
-            {t(`You may wish to manually configure the conda executeable
-              or the plugin environment.`)}
-          </p>
-          <p>{t('See the "Advanced" options in the Manage Plugins menu.')}</p>
+          {t('Failed to launch plugin. Check the workbench logs.')}
         </div>
-      );
+        <div className="text-center mt-3">
+          <Button onClick={handleClickFindLogfiles}>
+            {t('Find My Logs')}
+          </Button>
+        </div>
+      </>);
     }
 
     // Don't render the model setup & log until data has been fetched.

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -512,7 +512,7 @@ export default function PluginModal(props) {
             <Form.Control
               id="condaPath"
               type="text"
-              value={condaPath}
+              value={condaPath || ''}
               onChange={(event) => setCondaPath(event.target.value)}
               className="me-1"
             />

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -17,6 +17,15 @@ import App from '../../src/renderer/app';
 
 jest.mock('../../src/renderer/server_requests');
 
+const PLUGIN_SETTING_ITEM = {
+  foo: {
+    modelTitle: 'Foo',
+    type: 'plugin',
+    version: '1.0',
+    env: 'foo/bar/baz/',
+  },
+};
+
 describe('Manage Plugins modal', () => {
   beforeEach(() => {
     getSpec.mockResolvedValue({
@@ -53,12 +62,7 @@ describe('Manage Plugins modal', () => {
       spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
         if (channel === ipcMainChannels.GET_SETTING) {
           if (setting === 'plugins') {
-            return Promise.resolve({
-              foo: {
-                modelTitle: 'Foo',
-                type: 'plugin',
-              },
-            });
+            return Promise.resolve(PLUGIN_SETTING_ITEM);
           }
         } else if (channel === ipcMainChannels.HAS_MSVC) {
           return Promise.resolve(true);
@@ -140,12 +144,7 @@ describe('Manage Plugins modal', () => {
     const spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
-          return Promise.resolve({
-            foo: {
-              modelTitle: 'Foo',
-              type: 'plugin',
-            },
-          });
+          return Promise.resolve(PLUGIN_SETTING_ITEM);
         }
       } else if (channel === ipcMainChannels.HAS_MSVC) {
         return Promise.resolve(true);
@@ -229,12 +228,7 @@ describe('Manage Plugins modal', () => {
     ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
-          return Promise.resolve({
-            foo: {
-              modelTitle: 'Foo',
-              type: 'plugin',
-            },
-          });
+          return Promise.resolve(PLUGIN_SETTING_ITEM);
         }
       } else if (channel === ipcMainChannels.LAUNCH_PLUGIN_SERVER) {
         return 1111; // a fake PID
@@ -262,19 +256,15 @@ describe('Manage Plugins modal', () => {
   });
 
   test('Remove a plugin', async () => {
-    let plugins = {
-      foo: {
-        modelTitle: 'Foo',
-        type: 'plugin',
-        version: '1.0',
-      },
-    };
+    let plugins = PLUGIN_SETTING_ITEM;
     const spy = ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
           return Promise.resolve(plugins);
         }
       } else if (channel === ipcMainChannels.REMOVE_PLUGIN) {
+        // after REMOVE_PLUGIN there will be a subsequent call to GET_SETTING,
+        // so this effectively replaces the mocked settings data
         plugins = {};
       } else if (channel === ipcMainChannels.HAS_MSVC) {
         return Promise.resolve(true);
@@ -324,7 +314,7 @@ describe('Manage Plugins modal', () => {
       return Promise.resolve();
     });
     const {
-      findByText, findByRole, getByRole, findByLabelText, queryByRole,
+      findByText, findByRole, findByLabelText,
     } = render(<App />);
 
     const spy = jest.spyOn(ipcRenderer, 'send');
@@ -360,17 +350,12 @@ describe('Manage Plugins modal', () => {
     ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
         if (setting === 'plugins') {
-          return Promise.resolve({
-            foo: {
-              modelTitle: 'Foo',
-              type: 'plugin',
-            },
-          });
+          return Promise.resolve(PLUGIN_SETTING_ITEM);
         } else if (setting === 'plugins.foo.env') {
-          return Promise.resolve('default_env');
+          return Promise.resolve(PLUGIN_SETTING_ITEM.foo.env);
         }
       } else if (channel === ipcMainChannels.SHOW_OPEN_DIALOG) {
-        return Promise.resolve({ filePaths: ['/path/to/my_env'] })
+        return Promise.resolve({ filePaths: ['/path/to/my_env'] });
       } else if (channel === ipcMainChannels.HAS_MSVC) {
         return Promise.resolve(true);
       }
@@ -387,7 +372,9 @@ describe('Manage Plugins modal', () => {
 
     const div = await findByLabelText('Configure plugin environments (Advanced)')
     const input = await within(div).findByLabelText('foo');
-    await userEvent.type(input, 'my_env')
+    expect(input).toHaveValue(PLUGIN_SETTING_ITEM.foo.env);
+    await userEvent.clear(input);
+    await userEvent.type(input, 'my_env');
     await waitFor(() => expect(input).toHaveValue('my_env'));
 
     await userEvent.click(await findByRole(
@@ -406,6 +393,6 @@ describe('Manage Plugins modal', () => {
 
     const resetButton = await within(div).findByRole('button', { name: /Reset/ });
     await userEvent.click(resetButton);
-    await waitFor(() => { expect(input).toHaveValue('default_env'); });
+    await waitFor(() => { expect(input).toHaveValue(PLUGIN_SETTING_ITEM.foo.env); });
   });
 });

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -17,7 +17,7 @@ import App from '../../src/renderer/app';
 
 jest.mock('../../src/renderer/server_requests');
 
-describe('Add plugin modal', () => {
+describe('Manage Plugins modal', () => {
   beforeEach(() => {
     getSpec.mockResolvedValue({
       model_id: 'foo',
@@ -237,7 +237,7 @@ describe('Add plugin modal', () => {
           });
         }
       } else if (channel === ipcMainChannels.LAUNCH_PLUGIN_SERVER) {
-        return 1;
+        return 1111; // a fake PID
       }
       return Promise.resolve();
     });
@@ -278,6 +278,8 @@ describe('Add plugin modal', () => {
         plugins = {};
       } else if (channel === ipcMainChannels.HAS_MSVC) {
         return Promise.resolve(true);
+      } else if (channel === ipcMainChannels.LAUNCH_PLUGIN_SERVER) {
+        return 1111; // a fake PID
       }
       return Promise.resolve();
     });


### PR DESCRIPTION
I decided that there is not much value in running a `micromamba` command every time the Workbench launches, just to test the exe. #2656 describes a bug in that function.

In production, we point to the `micromamba` packaged with the Workbench. If for some reason that exe doesn't work, the new Advanced Plugins options are the user's main recourse. Many Workbench users will not end up using plugins or `micromamba`, so it seems okay to wait until they do to discover if there is a problem, rather than alert users to a problem that may not effect them.

In dev mode it is arguably more useful to test that the local `micromamba` works, since it's not using the one packaged with the Workbench. But in this case as well, I think it's okay to wait until the app tries to use `micromamba` to discover if there's a problem, and then suggest the user re-configure things via "Manage Plugins".

The case on my system in dev mode was weird: the check using `spawnSync(micromamba --help)` failed to find the `micromamba` command. But opening a plugin with `spawn(micromamba ...)` _did_ work. Something to do with the shell? I do have `micromamba.bat` on the PATH, but that's not usable by my `git-bash` shell. Anyway, the checks we were doing were buggy and unnecessary.

Fixes #2656

Most of the changes to `plugin.test.js` were just to resolve warnings from React about uncontrolled components changing to controlled components.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
