### PR TITLE
Reports: support "userguide" link for plugins

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -78,21 +78,24 @@ Workbench
 * Added a file browse button to the input field for selecting a
   local plugin directory to install.
   (`#2641 <https://github.com/natcap/invest/issues/2641>`_)
-* Bootstrap and React Bootstrap dependencies have been updated to their latest
-  stable versions (Bootstrap 5.3.8, React Bootstrap 2.10.10).
-  (`#1798 <https://github.com/natcap/invest/issues/1798>`_)
 * Added an option in the Manage Plugins modal to configure which
   conda executable is used to run plugins.
   (`#2645 <https://github.com/natcap/invest/issues/2645>`_)
 * Added an option in the Manage Plugins modal to configure which
   conda environment is used to run each plugin.
   (`#2646 <https://github.com/natcap/invest/issues/2646>`_)
-* React dependency has been updated to its latest stable version (19.2.7).
-  (`#2481 <https://github.com/natcap/invest/issues/2481>`_)
-* Improved handling of errors on plugin server startup
+* Improved handling of errors on plugin server startup.
   (`#2637 https://github.com/natcap/invest/issues/2637`)
 * The "View Results" button now supports plugins.
   (`#2638 <https://github.com/natcap/invest/issues/2638>`_)
+* The base report template now better supports plugins by including a link to
+  plugin-specific documentation instead of a link to the InVEST User Guide.
+  (`#2640 <https://github.com/natcap/invest/issues/2640>`_)
+* Bootstrap and React Bootstrap dependencies have been updated to their latest
+  stable versions (Bootstrap 5.3.8, React Bootstrap 2.10.10).
+  (`#1798 <https://github.com/natcap/invest/issues/1798>`_)
+* React dependency has been updated to its latest stable version (19.2.7).
+  (`#2481 <https://github.com/natcap/invest/issues/2481>`_)
 
 3.20.0 (2026-06-11)
 -------------------

--- a/src/natcap/invest/reports/templates/base.html
+++ b/src/natcap/invest/reports/templates/base.html
@@ -12,16 +12,14 @@
   <main class="report-container">
     {% from 'globals.html' import globals %}
     {% from 'accordion-section.html' import accordion_section with context %}
+    {% from 'userguide-link.html' import userguide_link %}
 
     {% block content scoped %}
       <h1>{{ self.page_title() }}</h1>
       <p>{{ model_description }}</p>
-      <p>To learn more about the {{ model_name }} model, visit the
-        <a
-          target="_blank"
-          href="https://storage.googleapis.com/releases.naturalcapitalproject.org/invest-userguide/latest/en/{{ userguide_page }}"
-        >InVEST User Guide (opens in new browser window)</a>.
-      </p>
+      {% if userguide_page is defined %}
+        {{ userguide_link(model_id, userguide_page, model_name) }}
+      {% endif %}
     {% endblock content %}
   </main>
   {% block footer %}

--- a/src/natcap/invest/reports/templates/userguide-link.html
+++ b/src/natcap/invest/reports/templates/userguide-link.html
@@ -1,0 +1,65 @@
+<!--
+  - `model_id` (str): the `model_id` defined on the `MODEL_SPEC`. Checked
+    against a list of known core model IDs to determine whether to link to the
+    InVEST User Guide.
+  - `userguide_page` (str): the `userguide` defined on the `MODEL_SPEC`. Used
+    to render a link to the InVEST User Guide, or, in the case of plugins
+    (i.e., non-core models), to the plugin documentation. If `userguide_page`
+    is empty, no link is rendered.
+  - `model_name` (str): the `model_name` defined on the `MODEL_SPEC.` Used in
+    the visible link text.
+
+  Note that `core_models` is a list containing the `MODEL_SPEC`-defined
+  `model_id` for every core InVEST model. Since model IDs are stable by
+  design, this list shouldn't require updates except when a new model is added
+  or when a model is deprecated (and removed from the User Guide).
+\-->
+
+{% macro userguide_link(
+  model_id, userguide_page, model_name
+) -%}
+  {% set core_models = [
+    'annual_water_yield',
+    'carbon',
+    'coastal_blue_carbon',
+    'coastal_blue_carbon_preprocessor',
+    'coastal_vulnerability',
+    'crop_production_percentile',
+    'crop_production_regression',
+    'delineateit',
+    'forest_carbon_edge_effect',
+    'habitat_quality',
+    'habitat_risk_assessment',
+    'ndr',
+    'pollination',
+    'recreation',
+    'routedem',
+    'scenario_generator_proximity',
+    'scenic_quality',
+    'sdr',
+    'seasonal_water_yield',
+    'stormwater',
+    'urban_cooling_model',
+    'urban_flood_risk_mitigation',
+    'urban_mental_health',
+    'urban_nature_access',
+    'wave_energy',
+    'wind_energy'
+  ] %}
+  {% set is_core_model = True if model_id in core_models else False %}
+  {% if is_core_model and userguide_page %}
+    <p>To learn more about the {{ model_name }} model, visit the
+      <a
+        target="_blank"
+        href="https://storage.googleapis.com/releases.naturalcapitalproject.org/invest-userguide/latest/en/{{ userguide_page }}"
+      >InVEST User Guide (opens in new browser window)</a>.
+    </p>
+  {% elif userguide_page %}
+    <p>To learn more about the {{ model_name }} plugin, visit the
+      <a
+        target="_blank"
+        href="{{ userguide_page }}"
+      >{{ model_name }} documentation (opens in new browser window)</a>.
+    </p>
+  {% endif %}
+{%- endmacro %}


### PR DESCRIPTION
## Description
Fixes #2640.

## Examples
### Plugin with non-empty `userguide_page` links to the specified URL
<img width="1419" height="301" alt="report_ug_link-plugin-2026_07_29" src="https://github.com/user-attachments/assets/9b49fb25-527a-4655-80a2-03b79538b138" />

### Core model links to InVEST User Guide (no change)
<img width="1485" height="282" alt="report_ug_link-core_model-2026_07_29" src="https://github.com/user-attachments/assets/26fa8e00-eef6-4515-83c3-72113ac4172a" />

### Report with undefined `userguide_page` renders no link (mocked by temporarily removing that arg from the carbon reporter)
<img width="969" height="256" alt="report_ug_link-empty_userguide-2026_07_29" src="https://github.com/user-attachments/assets/bdb1a30d-29b1-4166-931c-f486c2fffdcb" />

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
- [x] Tested the Workbench UI (if relevant)
