### PR TITLE
Support drag-and-drop in plugins modal

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -93,6 +93,9 @@ Workbench
   (`#2637 https://github.com/natcap/invest/issues/2637`)
 * The "View Results" button now supports plugins.
   (`#2638 <https://github.com/natcap/invest/issues/2638>`_)
+* Fixed a bug in the Manage Plugins modal where dragging and dropping
+  a plugin directory into the local filepath would open a new window.
+  (`#2642 <https://github.com/natcap/invest/issues/2642>`_)
 
 3.20.0 (2026-06-11)
 -------------------

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -17,7 +17,7 @@ import {
 import { openLinkInBrowser } from '../../utils';
 import { ipcMainChannels } from '../../../main/ipcMainChannels';
 
-const { ipcRenderer } = window.Workbench.electron;
+const { getFilePath, ipcRenderer } = window.Workbench.electron;
 
 export default function PluginModal(props) {
   const {
@@ -208,6 +208,22 @@ export default function PluginModal(props) {
     }
   };
 
+  const handlePluginPathDragOver = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+  
+  const handlePluginPathDrop = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  
+    const droppedFile = event.dataTransfer.files[0];
+    if (droppedFile) {
+      setPath(getFilePath(droppedFile));
+    }
+  };
+
   const selectFile = async (event) => {
     const data = await ipcRenderer.invoke(
       ipcMainChannels.SHOW_OPEN_DIALOG, { properties: ['openFile'] }
@@ -309,6 +325,8 @@ export default function PluginModal(props) {
               : 'C:\\Documents\\path\\to\\plugin\\'}
             value={path}
             onChange={(event) => setPath(event.currentTarget.value)}
+            onDragOver={handlePluginPathDragOver}
+            onDrop={handlePluginPathDrop}
             aria-describedby={pluginSourceMissingError ? 'path-error' : ''}
           />
           <Button

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -208,20 +208,23 @@ export default function PluginModal(props) {
     }
   };
 
-  const handlePluginPathDragOver = (event) => {
+  const dragOverHandler = (event) => {
     event.preventDefault();
     event.stopPropagation();
     event.dataTransfer.dropEffect = 'copy';
   };
   
-  const handlePluginPathDrop = (event) => {
+  const getDroppedFilePath = (event) => {
     event.preventDefault();
     event.stopPropagation();
   
     const droppedFile = event.dataTransfer.files[0];
-    if (droppedFile) {
-      setPath(getFilePath(droppedFile));
-    }
+    return droppedFile ? getFilePath(droppedFile) : undefined;
+  };
+
+  const ignoreDrop = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
   };
 
   const selectFile = async (event) => {
@@ -270,6 +273,8 @@ export default function PluginModal(props) {
             placeholder="https://github.com/owner/repo.git"
             value={url}
             onChange={(event) => setURL(event.currentTarget.value)}
+            onDragOver={ignoreDrop}
+            onDrop={ignoreDrop}
             aria-describedby={`about-git-url${pluginSourceMissingError ? ' url-error' : ''}`}
           />
           <Form.Text
@@ -325,8 +330,13 @@ export default function PluginModal(props) {
               : 'C:\\Documents\\path\\to\\plugin\\'}
             value={path}
             onChange={(event) => setPath(event.currentTarget.value)}
-            onDragOver={handlePluginPathDragOver}
-            onDrop={handlePluginPathDrop}
+            onDragOver={dragOverHandler}
+            onDrop={(event) => {
+              const droppedPath = getDroppedFilePath(event);
+              if (droppedPath) {
+                setPath(droppedPath);
+              }
+            }}
             aria-describedby={pluginSourceMissingError ? 'path-error' : ''}
           />
           <Button
@@ -532,6 +542,13 @@ export default function PluginModal(props) {
               type="text"
               value={condaPath}
               onChange={(event) => setCondaPath(event.target.value)}
+              onDragOver={dragOverHandler}
+              onDrop={(event) => {
+                const droppedPath = getDroppedFilePath(event);
+                if (droppedPath) {
+                  setCondaPath(droppedPath);
+                }
+              }}
               className="me-1"
             />
             <Button
@@ -583,6 +600,16 @@ export default function PluginModal(props) {
                 onChange={(event) => setPluginEnvs(
                   {...pluginEnvs, [pluginID]: event.target.value}
                 )}
+                onDragOver={dragOverHandler}
+                onDrop={(event) => {
+                  const droppedPath = getDroppedFilePath(event);
+                  if (droppedPath) {
+                    setPluginEnvs({
+                      ...pluginEnvs,
+                      [pluginID]: droppedPath,
+                    });
+                  }
+                }}
                 className="me-1"
               />
               <Button

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -242,7 +242,6 @@ export default function PluginModal(props) {
       throw new Error('Error handling input file drop');
     }
     event.currentTarget.focus();
-    triggerScrollEvent();
   }
 
   const rejectDropHandler = (event) => {

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -208,24 +208,68 @@ export default function PluginModal(props) {
     }
   };
 
-  const dragOverHandler = (event) => {
+  /**
+   * Prevent the default case for onDragOver so onDrop event will be fired.
+   *
+   * @param {Event} event - dragover event
+   */
+  function dragOverHandler(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.currentTarget.disabled) {
+      event.dataTransfer.dropEffect = 'none';
+    } else {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  function getDroppedFilePath(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.classList.remove('input-dragging');
+  
+    if (event.currentTarget.disabled) {
+      return undefined;
+    }
+  
+    const fileList = event.dataTransfer.files;
+    if (fileList.length !== 1) {
+      //return undefined;
+      alert(t('Only drop one file at a time.')); // eslint-disable-line no-alert
+    } else if (fileList.length === 1) {
+      return getFilePath(fileList[0]);
+    } else {
+      throw new Error('Error handling input file drop');
+    }
+    event.currentTarget.focus();
+    triggerScrollEvent();
+  }
+
+  const rejectDropHandler = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = 'none';
+    event.currentTarget.classList.remove('input-dragging');
+  };
+
+  function dragEnterHandler(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.currentTarget.disabled) {
+      event.dataTransfer.dropEffect = 'none';
+    } else {
+      event.dataTransfer.dropEffect = 'copy';
+      event.currentTarget.classList.add('input-dragging');
+    }
+  }
+
+  function dragLeavingHandler(event) {
     event.preventDefault();
     event.stopPropagation();
     event.dataTransfer.dropEffect = 'copy';
-  };
-  
-  const getDroppedFilePath = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  
-    const droppedFile = event.dataTransfer.files[0];
-    return droppedFile ? getFilePath(droppedFile) : undefined;
-  };
+    event.currentTarget.classList.remove('input-dragging');
+  }
 
-  const ignoreDrop = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
 
   const selectFile = async (event) => {
     const data = await ipcRenderer.invoke(
@@ -273,8 +317,8 @@ export default function PluginModal(props) {
             placeholder="https://github.com/owner/repo.git"
             value={url}
             onChange={(event) => setURL(event.currentTarget.value)}
-            onDragOver={ignoreDrop}
-            onDrop={ignoreDrop}
+            onDragOver={rejectDropHandler}
+            onDrop={rejectDropHandler}
             aria-describedby={`about-git-url${pluginSourceMissingError ? ' url-error' : ''}`}
           />
           <Form.Text
@@ -331,6 +375,8 @@ export default function PluginModal(props) {
             value={path}
             onChange={(event) => setPath(event.currentTarget.value)}
             onDragOver={dragOverHandler}
+            onDragEnter={dragEnterHandler}
+            onDragLeave={dragLeavingHandler}
             onDrop={(event) => {
               const droppedPath = getDroppedFilePath(event);
               if (droppedPath) {
@@ -543,6 +589,8 @@ export default function PluginModal(props) {
               value={condaPath || ''}
               onChange={(event) => setCondaPath(event.target.value)}
               onDragOver={dragOverHandler}
+              onDragEnter={dragEnterHandler}
+              onDragLeave={dragLeavingHandler}
               onDrop={(event) => {
                 const droppedPath = getDroppedFilePath(event);
                 if (droppedPath) {
@@ -601,6 +649,8 @@ export default function PluginModal(props) {
                   {...pluginEnvs, [pluginID]: event.target.value}
                 )}
                 onDragOver={dragOverHandler}
+                onDragEnter={dragEnterHandler}
+                onDragLeave={dragLeavingHandler}
                 onDrop={(event) => {
                   const droppedPath = getDroppedFilePath(event);
                   if (droppedPath) {

--- a/workbench/src/renderer/components/PluginModal/index.jsx
+++ b/workbench/src/renderer/components/PluginModal/index.jsx
@@ -236,12 +236,11 @@ export default function PluginModal(props) {
     if (fileList.length !== 1) {
       //return undefined;
       alert(t('Only drop one file at a time.')); // eslint-disable-line no-alert
-    } else if (fileList.length === 1) {
-      return getFilePath(fileList[0]);
-    } else {
-      throw new Error('Error handling input file drop');
-    }
+      return undefined;
+    } 
+    
     event.currentTarget.focus();
+    return getFilePath(fileList[0]);
   }
 
   const rejectDropHandler = (event) => {

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -331,57 +331,16 @@ describe('Manage Plugins modal', () => {
       'button', { name: /browse for conda executable/ }));
     await waitFor(() => { expect(input).toHaveValue('foo'); });
 
-    const div = await findByLabelText('Configure conda executable (Advanced)')
-    const saveButton = await within(div).findByRole('button', { name: /Save/ });
-    await userEvent.click(saveButton);
-    await waitFor(() => {
-      expect(spy).toHaveBeenCalledWith(
-        ipcMainChannels.SET_SETTING,
-        'userDefinedMicromamba',
-        'foo'
-      );
-    });
-
-    const resetButton = await within(div).findByRole('button', { name: /Reset/ });
-    await userEvent.click(resetButton);
-    await waitFor(() => { expect(input).toHaveValue('micromamba'); });
-  });
-
-  test('Replace the conda executable via drag-and-drop', async () => {
-    ipcRenderer.invoke.mockImplementation((channel, setting) => {
-      if (channel === ipcMainChannels.GET_SETTING) {
-        if (setting === 'plugins') {
-          return Promise.resolve({});
-        } else if (setting === 'micromamba') {
-          return Promise.resolve('micromamba')
-        }
-      } else if (channel === ipcMainChannels.SHOW_OPEN_DIALOG) {
-        return Promise.resolve({ filePaths: ['foo'] })
-      }
-      return Promise.resolve();
-    });
-    const {
-      findByText, findByRole, findByLabelText,
-    } = render(<App />);
-
-    const spy = jest.spyOn(ipcRenderer, 'send');
-    await userEvent.click(await findByRole('button', { name: 'menu' }));
-    const managePluginsButton = await findByText(/Manage plugins/i);
-    await userEvent.click(managePluginsButton);
-
-    const input = await findByLabelText('Conda or mamba executable');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'conda');
-    await waitFor(() => expect(input).toHaveValue('conda'));
-
     const file = new File([], 'my-conda');
-    fireEvent.drop(input, {
-      dataTransfer: {
-        files: [file],
-      },
+    fireEvent.dragEnter(input, {dataTransfer: {files: [file]}});
+    expect(input).toHaveClass('input-dragging');
+    fireEvent.drop(input, {dataTransfer: {files: [file]}});
+  
+    await waitFor(() => {
+      expect(input).not.toHaveClass('input-dragging');
+      expect(input).toHaveValue('my-conda');
+      expect(input).toHaveFocus();
     });
-
-    await waitFor(() => { expect(input).toHaveValue('my-conda'); });
 
     const div = await findByLabelText('Configure conda executable (Advanced)')
     const saveButton = await within(div).findByRole('button', { name: /Save/ });

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ipcRenderer } from 'electron';
 import '@testing-library/jest-dom';
 import {
-  within, render, waitFor,
+  within, render, waitFor, fireEvent, createEvent,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -346,6 +346,59 @@ describe('Manage Plugins modal', () => {
     await userEvent.click(resetButton);
     await waitFor(() => { expect(input).toHaveValue('micromamba'); });
   });
+
+  test('Replace the conda executable via drag-and-drop', async () => {
+    ipcRenderer.invoke.mockImplementation((channel, setting) => {
+      if (channel === ipcMainChannels.GET_SETTING) {
+        if (setting === 'plugins') {
+          return Promise.resolve({});
+        } else if (setting === 'micromamba') {
+          return Promise.resolve('micromamba')
+        }
+      } else if (channel === ipcMainChannels.SHOW_OPEN_DIALOG) {
+        return Promise.resolve({ filePaths: ['foo'] })
+      }
+      return Promise.resolve();
+    });
+    const {
+      findByText, findByRole, findByLabelText,
+    } = render(<App />);
+
+    const spy = jest.spyOn(ipcRenderer, 'send');
+    await userEvent.click(await findByRole('button', { name: 'menu' }));
+    const managePluginsButton = await findByText(/Manage plugins/i);
+    await userEvent.click(managePluginsButton);
+
+    const input = await findByLabelText('Conda or mamba executable');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'conda');
+    await waitFor(() => expect(input).toHaveValue('conda'));
+
+    const file = new File([], 'my-conda');
+    fireEvent.drop(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+
+    await waitFor(() => { expect(input).toHaveValue('my-conda'); });
+
+    const div = await findByLabelText('Configure conda executable (Advanced)')
+    const saveButton = await within(div).findByRole('button', { name: /Save/ });
+    await userEvent.click(saveButton);
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(
+        ipcMainChannels.SET_SETTING,
+        'userDefinedMicromamba',
+        'my-conda'
+      );
+    });
+
+    const resetButton = await within(div).findByRole('button', { name: /Reset/ });
+    await userEvent.click(resetButton);
+    await waitFor(() => { expect(input).toHaveValue('micromamba'); });
+  });
+
   test('Change a plugin env', async () => {
     ipcRenderer.invoke.mockImplementation((channel, setting) => {
       if (channel === ipcMainChannels.GET_SETTING) {
@@ -394,5 +447,183 @@ describe('Manage Plugins modal', () => {
     const resetButton = await within(div).findByRole('button', { name: /Reset/ });
     await userEvent.click(resetButton);
     await waitFor(() => { expect(input).toHaveValue(PLUGIN_SETTING_ITEM.foo.env); });
+  });
+
+  test('Drag-and-drop populates the local plugin path', async () => {
+    ipcRenderer.invoke.mockImplementation((channel, setting) => {
+      if (channel === ipcMainChannels.GET_SETTING) {
+        if (setting === 'plugins') {
+          return Promise.resolve({});
+        }
+      } else if (channel === ipcMainChannels.HAS_MSVC) {
+        return Promise.resolve(true);
+      }
+  
+      return Promise.resolve();
+    });
+  
+    const {
+      findByText, findByRole, findByLabelText,
+    } = render(<App />);
+  
+    await userEvent.click(await findByRole('button', { name: 'menu' }));
+    await userEvent.click(await findByText(/Manage plugins/i));
+  
+    await userEvent.selectOptions(
+      await findByLabelText('Install from'),
+      'local path'
+    );
+  
+    const input = await findByLabelText('Local absolute path');
+    const file = new File([], 'plugin-dir');
+  
+    fireEvent.dragEnter(input, {
+      dataTransfer: { files: [file] },
+    });
+  
+    expect(input).toHaveClass('input-dragging');
+  
+    fireEvent.drop(input, {
+      dataTransfer: { files: [file] },
+    });
+  
+    await waitFor(() => {
+      expect(input).not.toHaveClass('input-dragging');
+      expect(input).toHaveValue('plugin-dir');
+      expect(input).toHaveFocus();
+    });
+  });
+
+  test('Drag-and-drop populates a plugin environment input', async () => {
+    ipcRenderer.invoke.mockImplementation((channel, setting) => {
+      if (channel === ipcMainChannels.GET_SETTING) {
+        if (setting === 'plugins') {
+          return Promise.resolve(PLUGIN_SETTING_ITEM);
+        }
+        if (setting === 'micromamba') {
+          return Promise.resolve('micromamba');
+        }
+      } else if (channel === ipcMainChannels.HAS_MSVC) {
+        return Promise.resolve(true);
+      }
+  
+      return Promise.resolve();
+    });
+  
+    const {
+      findByText, findByRole, findByLabelText,
+    } = render(<App />);
+  
+    await userEvent.click(await findByRole('button', { name: 'menu' }));
+    await userEvent.click(await findByText(/Manage plugins/i));
+  
+    const div = await findByLabelText(
+      'Configure plugin environments (Advanced)'
+    );
+    const input = await within(div).findByLabelText('foo');
+  
+    const file = new File([], 'plugin-environment');
+  
+    fireEvent.dragEnter(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+  
+    expect(input).toHaveClass('input-dragging');
+  
+    fireEvent.drop(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+  
+    await waitFor(() => {
+      expect(input).not.toHaveClass('input-dragging');
+      expect(input).toHaveValue('plugin-environment');
+      expect(input).toHaveFocus();
+    });
+  });
+
+  test('Drag-leave removes input-dragging from a filepath input', async () => {
+    ipcRenderer.invoke.mockImplementation((channel, setting) => {
+      if (channel === ipcMainChannels.GET_SETTING) {
+        if (setting === 'plugins') {
+          return Promise.resolve(PLUGIN_SETTING_ITEM);
+        }
+      } else if (channel === ipcMainChannels.HAS_MSVC) {
+        return Promise.resolve(true);
+      }
+  
+      return Promise.resolve();
+    });
+  
+    const {
+      findByText, findByRole, findByLabelText,
+    } = render(<App />);
+  
+    await userEvent.click(await findByRole('button', { name: 'menu' }));
+    await userEvent.click(await findByText(/Manage plugins/i));
+  
+    await userEvent.selectOptions(
+      await findByLabelText('Install from'),
+      'path'
+    );
+  
+    const input = await findByLabelText('Local absolute path');
+    const file = new File([], 'plugin-directory');
+  
+    fireEvent.dragEnter(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+  
+    expect(input).toHaveClass('input-dragging');
+  
+    fireEvent.dragLeave(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+  
+    expect(input).not.toHaveClass('input-dragging');
+  });
+
+  test('Drag-and-drop on the git URL input does nothing', async () => {
+    ipcRenderer.invoke.mockImplementation((channel, setting) => {
+      if (channel === ipcMainChannels.GET_SETTING) {
+        if (setting === 'plugins') {
+          return Promise.resolve({});
+        }
+      } else if (channel === ipcMainChannels.HAS_MSVC) {
+        return Promise.resolve(true);
+      }
+  
+      return Promise.resolve();
+    });
+  
+    const {
+      findByText, findByRole, findByLabelText,
+    } = render(<App />);
+  
+    await userEvent.click(await findByRole('button', { name: 'menu' }));
+    await userEvent.click(await findByText(/Manage plugins/i));
+  
+    const input = await findByLabelText('Git URL');
+  
+    const file = new File([], 'plugin-directory');
+    const dropEvent = createEvent.drop(input, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+    
+    const preventDefaultSpy = jest.spyOn(dropEvent, 'preventDefault');
+    
+    fireEvent(input, dropEvent);
+    
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(input).toHaveValue('');
   });
 });


### PR DESCRIPTION
## Description
Fixes a bug where dragging-and-dropping a plugin directory into the local absolute path would open a new window. Now this filepath populates correctly. I also added drag-and-drop support for the conda executable and plugin environments inputs. Finally, if the user intends to install a plugin from a git URL, dragging-and-dropping a directory does nothing (vs. previously this would also open a new blank window).
 
Fixes #2642 

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [x] Tested the Workbench UI (if relevant)
