### PR TITLE
Add dependabot configuration for non-security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "workbench"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
-    versioning-strategy: increase-if-necessary
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    rebase-strategy: "disabled"
-    versioning-strategy: increase-if-necessary
-
   - package-ecosystem: "docker"
     directory: "docker"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "workbench"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    versioning-strategy: increase-if-necessary
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    versioning-strategy: increase-if-necessary
+
+  - package-ecosystem: "docker"
+    directory: "docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    groups:
+      action-updates:
+        patterns:
+          - "*" # Groups ALL GitHub Actions updates together
+


### PR DESCRIPTION
This PR adds supplementary dependabot configuration to trigger version bumps for github actions and docker builds.  I'm hoping that this will help us keep on top of action version updates (in GHA) and updated debian releases (in docker).

Note that this does not affect security PRs, which are controlled through repo settings and not through this configuration file.

RE:#856