### PR TITLE
Speedup for Workbench tests that sometimes timed out

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -441,8 +441,7 @@ jobs:
         id: invest-autotest
         if : |
           (github.event_name == 'push' &&
-          (startsWith(github.ref, 'refs/heads/release') || github.ref == 'refs/heads/main')) ||
-          (github.event_name == 'pull_request' && startsWith(github.head_ref, 'autorelease'))
+          (startsWith(github.ref, 'refs/heads/release') || startsWith(github.head_ref, 'autorelease') || github.ref == 'refs/heads/main'))
         run: |
           mkdir autotest_dir
           make invest_autotest AUTOTEST_DIR=autotest_dir

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -98,7 +98,6 @@ describe('InVEST subprocess testing', () => {
     tempTestWorkspace = fs.mkdtempSync(
       path.join(os.tmpdir(), 'workbench-test-')
     );
-    console.log(tempTestWorkspace)
   });
 
   afterAll(() => {
@@ -122,15 +121,13 @@ describe('InVEST subprocess testing', () => {
       fs.writeFileSync(payload.filepath, 'foo');
       return Promise.resolve({ text: () => 'foo' });
     });
-    // tempWorkspace = fs.mkdtempSync(os.tmpdir());
   });
 
   afterEach(async () => {
     await InvestJob.clearStore();
-    // fs.rmSync(tempWorkspace, { recursive: true });
   });
 
-  test.only('exit without error - expect log & alert display', async () => {
+  test('exit without error - expect log & alert display', async () => {
     const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
@@ -148,8 +145,8 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
-    console.log(tempWorkspace);
-    await userEvent.type(workspaceInput, tempWorkspace);
+    await userEvent.click(workspaceInput);
+    await userEvent.paste(tempWorkspace);
     // Write a report to the workspace because that's something
     // that execute will normally do.
     fs.writeFileSync(
@@ -194,7 +191,7 @@ describe('InVEST subprocess testing', () => {
     expect(status).toBeInTheDocument();
   });
 
-  test.only('exit with error - expect log & alert display', async () => {
+  test('exit with error - expect log & alert display', async () => {
     const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
@@ -212,8 +209,8 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
-    console.log(tempWorkspace);
-    await userEvent.type(workspaceInput, tempWorkspace);
+    await userEvent.click(workspaceInput);
+    await userEvent.paste(tempWorkspace);
 
     const execute = await findByRole('button', { name: /Run/ });
     await userEvent.click(execute);
@@ -272,7 +269,8 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
-    await userEvent.type(workspaceInput, tempWorkspace);
+    await userEvent.click(workspaceInput);
+    await userEvent.paste(tempWorkspace);
 
     const execute = await findByRole('button', { name: /Run/ });
     await userEvent.click(execute);
@@ -326,7 +324,8 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
-    await userEvent.type(workspaceInput, tempWorkspace);
+    await userEvent.click(workspaceInput);
+    await userEvent.paste(tempWorkspace);
 
     const execute = await findByRole('button', { name: /Run/ });
     await userEvent.click(execute);

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -54,7 +54,7 @@ describe('InVEST subprocess testing', () => {
     userguide: 'eco.html',
     reporter: 'natcap.invest.reports.eco',
   };
-  let tempWorkspace;
+  let tempTestWorkspace;
   // invest always emits this message, and the workbench always listens for it:
   const stdOutLogfileSignal = 'Writing log messages to [/foo/bar/invest-log.txt]';
   const stdOutText = 'hello from invest';
@@ -95,10 +95,12 @@ describe('InVEST subprocess testing', () => {
       text: async () => 'foo',
     };
     fetch.mockResolvedValue(response);
+    tempTestWorkspace = fs.mkdtempSync(os.tmpdir());
   });
 
   afterAll(() => {
     removeIpcMainListeners();
+    fs.rmSync(tempTestWorkspace, { recursive: true });
   });
 
   beforeEach(() => {
@@ -117,15 +119,16 @@ describe('InVEST subprocess testing', () => {
       fs.writeFileSync(payload.filepath, 'foo');
       return Promise.resolve({ text: () => 'foo' });
     });
-    tempWorkspace = fs.mkdtempSync(os.tmpdir());
+    // tempWorkspace = fs.mkdtempSync(os.tmpdir());
   });
 
   afterEach(async () => {
     await InvestJob.clearStore();
-    fs.rmSync(tempWorkspace, { recursive: true });
+    // fs.rmSync(tempWorkspace, { recursive: true });
   });
 
   test('exit without error - expect log & alert display', async () => {
+    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -142,6 +145,7 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
+    console.log(tempWorkspace);
     await userEvent.type(workspaceInput, tempWorkspace);
     // Write a report to the workspace because that's something
     // that execute will normally do.
@@ -188,6 +192,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('exit with error - expect log & alert display', async () => {
+    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -246,6 +251,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('user terminates process - expect log & alert display', async () => {
+    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -301,6 +307,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('Run & re-run a job - expect new log display', async () => {
+    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -363,6 +370,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('Load Recent run & re-run it - expect new log display', async () => {
+    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const argsValues = {
       workspace_dir: tempWorkspace,

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -95,7 +95,10 @@ describe('InVEST subprocess testing', () => {
       text: async () => 'foo',
     };
     fetch.mockResolvedValue(response);
-    tempTestWorkspace = fs.mkdtempSync(os.tmpdir());
+    tempTestWorkspace = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'workbench-test-')
+    );
+    console.log(tempTestWorkspace)
   });
 
   afterAll(() => {
@@ -128,7 +131,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test.only('exit without error - expect log & alert display', async () => {
-    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
+    const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -192,7 +195,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test.only('exit with error - expect log & alert display', async () => {
-    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
+    const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -252,7 +255,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('user terminates process - expect log & alert display', async () => {
-    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
+    const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -308,7 +311,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('Run & re-run a job - expect new log display', async () => {
-    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
+    const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const {
       findByText,
@@ -371,7 +374,7 @@ describe('InVEST subprocess testing', () => {
   });
 
   test('Load Recent run & re-run it - expect new log display', async () => {
-    const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
+    const tempWorkspace = fs.mkdtempSync(path.join(tempTestWorkspace, 'ws-'));
     const mockInvestProc = getMockedInvestProcess();
     const argsValues = {
       workspace_dir: tempWorkspace,

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -127,7 +127,7 @@ describe('InVEST subprocess testing', () => {
     // fs.rmSync(tempWorkspace, { recursive: true });
   });
 
-  test('exit without error - expect log & alert display', async () => {
+  test.only('exit without error - expect log & alert display', async () => {
     const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
@@ -191,7 +191,7 @@ describe('InVEST subprocess testing', () => {
     expect(status).toBeInTheDocument();
   });
 
-  test('exit with error - expect log & alert display', async () => {
+  test.only('exit with error - expect log & alert display', async () => {
     const tempWorkspace = fs.mkdtempSync(tempTestWorkspace);
     const mockInvestProc = getMockedInvestProcess();
     const {
@@ -209,6 +209,7 @@ describe('InVEST subprocess testing', () => {
     const workspaceInput = await findByLabelText(
       (content) => content.startsWith(spec.args.workspace_dir.name)
     );
+    console.log(tempWorkspace);
     await userEvent.type(workspaceInput, tempWorkspace);
 
     const execute = await findByRole('button', { name: /Run/ });


### PR DESCRIPTION
Pasting text is a lot faster than typing. I also re-structured the use of the temp workspaces to make extra sure that each test was isolated from each other. See more details in #2695 

As a bonus I also fixed #2618 here instead of opening another PR and adding to the backlog of queued jobs. 

Fixes #2695 

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
