### PR TITLE
require a modern version of twine in our build workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,7 @@ jobs:
             ${{ env.CONDA_DEFAULT_DEPENDENCIES }}
             ${{ matrix.platform-specific-dependencies }}
             python=${{ matrix.python-version }}
-            twine
+            twine>=6.1.0
             gdal==${{ env.GDAL_VERSION_FOR_WHEEL_BUILD }}
             wheel
 


### PR DESCRIPTION
For some reason `conda` kept installing `twine 3.0` on the Ubuntu / Python 3.14 job, when `7.0` is currently the latest.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
