### PR TITLE
allow variable expansion in release instructions

### DIFF
--- a/.github/workflows/release-part-1.yml
+++ b/.github/workflows/release-part-1.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Instructions
         if: env.RUN == 'true'
         run: |
-          cat << 'EOF'
+          cat << EOF
 
           Next steps:
 


### PR DESCRIPTION
## Description
Fixes a minor bug where env variables in the release instructions were not being expanded.

## Checklist
- [ ] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
