### PR TITLE
Wind Energy: Remove redundant vector reprojection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -63,9 +63,14 @@
 
 
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+
+Wind Energy
+===========
+* Fixed a bug where the model would raise a ``RuntimeError`` if the input
+  land polygon and AOI had the same projection.
+  (`#2707 <https://github.com/natcap/invest/issues/2707>`_)
 
 3.20.1 (2026-08-13)
 -------------------

--- a/src/natcap/invest/wind_energy/wind_energy.py
+++ b/src/natcap/invest/wind_energy/wind_energy.py
@@ -2568,19 +2568,19 @@ def _clip_and_reproject_vector(base_vector_path, clip_vector_path,
     target_sr_wkt = pygeoprocessing.get_vector_info(clip_vector_path)[
         'projection_wkt']
 
-    # Create path for the reprojected shapefile
-    clipped_vector_path = os.path.join(
+    # Create path for the clipped base vector
+    clipped_base_vector_path = os.path.join(
         temp_dir, 'clipped_vector' + file_ext)
 
     # Clip the base vector to the AOI.
     # If the projections don't match, _clip_vector_by_vector will first
     # reproject the clip vector to the base vector's SRS
     _clip_vector_by_vector(
-        base_vector_path, clip_vector_path, clipped_vector_path, temp_dir)
+        base_vector_path, clip_vector_path, clipped_base_vector_path, temp_dir)
 
     # Reproject the clipped base vector to the spatial reference of clip vector
     pygeoprocessing.reproject_vector(
-        clipped_vector_path, target_sr_wkt, target_vector_path,
+        clipped_base_vector_path, target_sr_wkt, target_vector_path,
         driver_name=driver_name)
 
     shutil.rmtree(temp_dir, ignore_errors=True)

--- a/src/natcap/invest/wind_energy/wind_energy.py
+++ b/src/natcap/invest/wind_energy/wind_energy.py
@@ -2574,7 +2574,9 @@ def _clip_and_reproject_vector(base_vector_path, clip_vector_path,
 
     # Clip the base vector to the AOI.
     # If the projections don't match, _clip_vector_by_vector will first
-    # reproject the clip vector to the base vector's SRS
+    # reproject the clip vector to the base vector's SRS. Reprojecting
+    # the base vector to match the AOI's SRS first could be computationally
+    # expensive if the base vector is very large.
     _clip_vector_by_vector(
         base_vector_path, clip_vector_path, clipped_base_vector_path, temp_dir)
 
@@ -2614,10 +2616,14 @@ def _clip_vector_by_vector(
     # Get the base and target spatial reference in Well Known Text
     base_sr_wkt = pygeoprocessing.get_vector_info(base_vector_path)[
         'projection_wkt']
+    base_sr = osr.SpatialReference()
+    base_sr.ImportFromWkt(base_sr_wkt)
     target_sr_wkt = pygeoprocessing.get_vector_info(clip_vector_path)[
         'projection_wkt']
+    target_sr = osr.SpatialReference()
+    target_sr.ImportFromWkt(target_sr_wkt)
 
-    if base_sr_wkt != target_sr_wkt:
+    if not base_sr.IsSame(target_sr):
         # Reproject clip vector to the spatial reference of the base vector.
         # Note: reproject_vector can be expensive if vector has many features.
         temp_dir = tempfile.mkdtemp(dir=work_dir, prefix='clip-')
@@ -2655,11 +2661,11 @@ def _clip_vector_by_vector(
     target_layer = None
     target_vector = None
     clip_vector = None
-    clip_vector = None
+    clip_layer = None
     base_layer = None
     base_vector = None
 
-    if base_sr_wkt != target_sr_wkt:
+    if not base_sr.IsSame(target_sr):
         shutil.rmtree(temp_dir, ignore_errors=True)
 
     if empty_clip:

--- a/src/natcap/invest/wind_energy/wind_energy.py
+++ b/src/natcap/invest/wind_energy/wind_energy.py
@@ -2564,28 +2564,19 @@ def _clip_and_reproject_vector(base_vector_path, clip_vector_path,
     temp_dir = tempfile.mkdtemp(dir=work_dir, prefix='clip-reproject-')
     file_ext, driver_name = _get_file_ext_and_driver_name(target_vector_path)
 
-    # Get the base and target spatial reference in Well Known Text
-    base_sr_wkt = pygeoprocessing.get_vector_info(base_vector_path)[
-        'projection_wkt']
+    # Get the target spatial reference in Well Known Text
     target_sr_wkt = pygeoprocessing.get_vector_info(clip_vector_path)[
         'projection_wkt']
 
     # Create path for the reprojected shapefile
     clipped_vector_path = os.path.join(
         temp_dir, 'clipped_vector' + file_ext)
-    reprojected_clip_path = os.path.join(
-        temp_dir, 'reprojected_clip_vector' + file_ext)
 
-    if base_sr_wkt != target_sr_wkt:
-        # Reproject clip vector to the spatial reference of the base vector.
-        # Note: reproject_vector can be expensive if vector has many features.
-        pygeoprocessing.reproject_vector(
-            clip_vector_path, base_sr_wkt, reprojected_clip_path,
-            driver_name=driver_name)
-
-    # Clip the base vector to the AOI
+    # Clip the base vector to the AOI.
+    # If the projections don't match, _clip_vector_by_vector will first
+    # reproject the clip vector to the base vector's SRS
     _clip_vector_by_vector(
-        base_vector_path, reprojected_clip_path, clipped_vector_path, temp_dir)
+        base_vector_path, clip_vector_path, clipped_vector_path, temp_dir)
 
     # Reproject the clipped base vector to the spatial reference of clip vector
     pygeoprocessing.reproject_vector(
@@ -2601,8 +2592,9 @@ def _clip_vector_by_vector(
     """Clip a vector from another vector keeping features.
 
     Create a new target vector where base features are contained in the
-        polygon in clip_vector_path. Assumes all data are in the same
-        projection.
+        polygon in clip_vector_path. If the base vector and clip vector do
+        not have the same projection, the clip vector will first be
+        reprojected to the base vector's SRS.
 
     Args:
         base_vector_path (str): path to a vector to clip.


### PR DESCRIPTION
## Description
Fixes #2707

This PR fixes a bug where the model would raise a `RuntimeError` if the input land polygon and AOI already had the same projection. 

Specifically, the issue was in `_clip_and_reproject_vector`: If the base vector (land polygon) and clip vector (AOI) had the same projection, `reprojected_clip_path` was never created -- which would then cause `_clip_vector_by_vector` to fail because one of the inputs didn't exist.

I've removed the SRS check and associated reprojection in `_clip_and_reproject_vector` as it was redundant. `_clip_and_reproject_vector` always calls `_clip_vector_by_vector`, which already checks for matching SRS and reprojects the clip vector (in this case, AOI) to the spatial reference of the base vector (in this case, land polygon) if necessary prior to clipping. 

I also renamed the temp file `clipped_vector_path` created by `_clip_and_reproject_vector` to `clipped_base_vector_path`, for increased clarity. (I found having both `clip_vector_path` and `clipped_vector_path` -- which represent two completely different vectors -- to be unnecessarily confusing.)

Finally, I've updated the docstring of `_clip_vector_by_vector`, which incorrectly stated that the function "assumes all data are in the same projection."

I considered adding a test that uses an AOI and land polygon with the same projection, but decided that it probably wasn't worth the overhead / additional test data storage (as this model still uses files in the test data repo rather than data generated during testing). I did double-check that this fix addresses the issue in a local run with same-projection inputs.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
