### PR TITLE
Bugfix for Release Part 2: skip linux wheels

### DIFF
--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Create a PyPI release
         # this is the only step that can't be rolled back
         run: |
-          twine upload \
+          twine upload --verbose \
             --username="__token__" \
             --password=${{ secrets.PYPI_NATCAP_INVEST_TOKEN }} \
             artifacts/natcap_invest*

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -42,7 +42,10 @@ jobs:
         run: |
           mkdir artifacts
           # this will download a folder containing each artifact
-          gh run download $RUN_ID --dir artifacts --pattern "Wheel for *"
+          # Download wheels for Windows, Mac, but not Linux
+          # https://github.com/natcap/invest/issues/2713
+          gh run download $RUN_ID --dir artifacts --pattern "Wheel for windows*"
+          gh run download $RUN_ID --dir artifacts --pattern "Wheel for macos*"
           # move the artifacts out of the folders
           mv artifacts/*/* artifacts
           rm -rf artifacts/Wheel*

--- a/.readthedocs_environment.yml
+++ b/.readthedocs_environment.yml
@@ -13,3 +13,4 @@ dependencies:
 - python=3.11
 - gdal>=3.4.2
 - pip
+- pygeoprocessing

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -66,6 +66,13 @@
 Unreleased Changes
 ------------------
 
+General
+=======
+* Fixed a bug that prevented non-spatial files referenced in CSVs from being
+  added to datastack archives. Refactored some datastack creation logic into
+  class methods on input and output specs.
+  (`#2589 <https://github.com/natcap/invest/issues/2589>`_)
+
 Wind Energy
 ===========
 * Fixed a bug where the model would raise a ``RuntimeError`` if the input
@@ -81,9 +88,6 @@ General
   architectures, particularly on conda-forge.  This should also speed up
   the operation of ``setup.py``.
   (`#2630 <https://github.com/natcap/invest/issues/2630>`_)
-* Fixed a bug that prevented non-spatial files referenced in CSVs from being added to datastack archives. Refactored some
-  datastack creation logic into class methods on input and output specs.
-  (`#2589 <https://github.com/natcap/invest/issues/2589>`_)
 
 Workbench
 =========


### PR DESCRIPTION
Do not include wheels built on ubuntu in the collection of artifacts that get included in PyPI and GitHub releases.

Fixes #2713 
Fixes #2721 

I also updated the readthedocs environment file because we were running into this issue: https://github.com/natcap/pygeoprocessing/issues/490

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
