### PR TITLE
Add apple silicon builds for the workbench.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [windows-latest, macos-15-intel]
+        os: [windows-latest, macos-15-intel, macos-15]
 
     steps:
       - name: Check out repo
@@ -301,15 +301,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-15-intel]
+        os: [windows-latest, macos-15-intel, macos-15]
         include:
           - os: macos-15-intel
             puppeteer-log: ~/Library/Logs/invest-workbench/
-            workspace-path: InVEST-failed-mac-workspace.tar
+            workspace-path: InVEST-failed-mac-x64-workspace.tar
             binary-extension: dmg
+            micromamba-subdir: osx-x64
+          - os: macos-15
+            puppeteer-log: ~/Library/Logs/invest-workbench/
+            workspace-path: InVEST-failed-mac-arm64-workspace.tar
+            binary-extension: dmg
+            micromamba-subdir: osx-arm64
           - os: windows-latest
             puppeteer-log: ~/AppData/Roaming/invest-workbench/logs/
-            workspace-path: InVEST-failed-windows-workspace.tar
+            workspace-path: InVEST-failed-windows-x64-workspace.tar
             binary-extension: exe
     steps:
       - uses: actions/checkout@v7
@@ -373,9 +379,9 @@ jobs:
           yarn install
 
       - name: Download micromamba for distribution (MacOS)
-        if: matrix.os == 'macos-15-intel'
+        if: runner.os == 'macOS'  # capture both intel and arm runners
         run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+          curl -Ls https://micro.mamba.pm/api/micromamba/${{ matrix.micromamba-subdir }}/latest | tar -xvj bin/micromamba
           mv bin/micromamba dist/
           ./dist/micromamba --help  # make sure the executable works
 
@@ -427,7 +433,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: Workbench-${{ runner.os }}-binary
+          name: Workbench-${{ runner.os }}-${{ runner.arch }}-binary
           path: workbench/dist/*.${{ matrix.binary-extension }}
 
       - name: Upload user's guide artifact (Windows)
@@ -467,14 +473,14 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: ${{ runner.os }}_puppeteer_log.zip'
+          name: ${{ runner.os }}_${{ runner.arch }}_puppeteer_log.zip'
           path: ${{ matrix.puppeteer-log }}
 
       - name: Upload workspace on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: InVEST-failed-${{ runner.os }}-workspace
+          name: InVEST-failed-${{ runner.os }}-${{ runner.arch }}-workspace
           path: ${{ github.workspace }}
 
   build-sampledata:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -283,13 +283,17 @@ jobs:
 
       - name: Install workbench dependencies
         if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+        shell: bash -e {0}  # Don't use a login shell - should use local node.js
         working-directory: workbench
         run: |
+          echo "Node version: $(node --version)"
+          echo "Node path: $(which node)"
           yarn config set network-timeout 600000 -g
           yarn install
 
       - name: Run workbench tests
         working-directory: workbench
+        shell: bash -e {0}  # Don't use a login shell - should use local node.js
         env:
           CI: true
         run: yarn test
@@ -373,8 +377,11 @@ jobs:
 
       - name: Install Workbench Dependencies
         if: steps.nodemodules-cache.outputs.cache-hit != 'true'
+        shell: bash -e {0}  # Don't use a login shell - should use local node.js
         working-directory: workbench
         run: |
+          echo "Node version: $(node --version)"
+          echo "Node path: $(which node)"
           yarn config set network-timeout 600000 -g
           yarn install
 
@@ -406,6 +413,7 @@ jobs:
 
       - name: Build Workbench
         working-directory: workbench
+        shell: bash -e {0}  # Don't use a login shell - should use local node.js
         env:
           GH_TOKEN: env.GITHUB_TOKEN
           DEBUG: electron-builder
@@ -466,6 +474,7 @@ jobs:
           gcloud storage rsync -r ${{ steps.invest-autotest-deploy.outputs.REPORTS_BASE_URL }} $DEST
 
       - name: Test electron app with puppeteer
+        shell: bash -e {0}  # Don't use a login shell - should use local node.js
         working-directory: workbench
         run: npx cross-env CI=true yarn run test-electron-app
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: [windows-latest, macos-15-intel, ubuntu-latest]
+        os: [windows-latest, macos-26-intel, ubuntu-latest]
         include:
           - os: ubuntu-latest
             python-version: "3.10"
@@ -175,7 +175,7 @@ jobs:
       # Only upload sdist from one of the matrix cases because they should all be the same
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v7
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-26-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         with:
           name: Source distribution
           path: dist/*.tar.gz
@@ -209,7 +209,7 @@ jobs:
 
       # Only upload sdist from one of the matrix cases because they should all be the same
       - name: Deploy sdist to GCS
-        if: github.event_name != 'pull_request' && matrix.os == 'macos-15-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
+        if: github.event_name != 'pull_request' && matrix.os == 'macos-26-intel' && matrix.python-version == env.LATEST_SUPPORTED_PYTHON_VERSION
         run: make deploy_sdist
 
   validate-resources:
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        os: [windows-latest, macos-15-intel, macos-15]
+        os: [windows-latest, macos-26-intel, macos-latest]
 
     steps:
       - name: Check out repo
@@ -301,14 +301,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-15-intel, macos-15]
+        os: [windows-latest, macos-26-intel, macos-latest]
         include:
-          - os: macos-15-intel
+          - os: macos-26-intel
             puppeteer-log: ~/Library/Logs/invest-workbench/
             workspace-path: InVEST-failed-mac-x64-workspace.tar
             binary-extension: dmg
             micromamba-subdir: osx-x64
-          - os: macos-15
+          - os: macos-latest
             puppeteer-log: ~/Library/Logs/invest-workbench/
             workspace-path: InVEST-failed-mac-arm64-workspace.tar
             binary-extension: dmg

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -296,7 +296,11 @@ jobs:
         shell: bash -e {0}  # Don't use a login shell - should use local node.js
         env:
           CI: true
-        run: yarn test
+        run: |
+          echo "Node version: $(node --version)"
+          echo "Node path: $(which node)"
+          echo "Yarn path: $(which yarn)"
+          yarn test
 
   build-binaries:
     name: Build binaries

--- a/.github/workflows/release-part-2.yml
+++ b/.github/workflows/release-part-2.yml
@@ -61,6 +61,7 @@ jobs:
           # download the signed workbench files from GCS
           wget --directory-prefix=artifacts https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/${{ env.VERSION }}/workbench/invest_${{ env.VERSION }}_workbench_win32_x64.exe
           wget --directory-prefix=artifacts https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/${{ env.VERSION }}/workbench/invest_${{ env.VERSION }}_workbench_darwin_x64.dmg
+          wget --directory-prefix=artifacts https://storage.googleapis.com/releases.naturalcapitalproject.org/invest/${{ env.VERSION }}/workbench/invest_${{ env.VERSION }}_workbench_darwin_arm64.dmg
 
       - name: Create release notes
         shell: python

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -63,9 +63,14 @@
 
 
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+
+Workbench
+=========
+* The InVEST workbench is now built for both Intel and Apple Silicon
+  architectures. (`#1586 <https://github.com/natcap/invest/issues/1586>`_)
+
 
 3.20.2 (2026-09-02)
 -------------------


### PR DESCRIPTION
This PR adds Apple Silicon builds for the workbench.  This does, unfortunately require the usage of another runner in GHA until we decide to drop intel builds.  Per #1586 we are not building or testing any wheels at this time, which will come later on.

This does not close the linked issue, only updates it until the wheels are also addressed.

A built apple silicon workbench is/will be available here: https://storage.googleapis.com/natcap-dev-build-artifacts/invest/phargogh/3.20.3.dev4+g16e6facd8/workbench/invest_3.20.3.dev4+g16e6facd8_workbench_darwin_arm64.dmg

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
~~- [ ] Updated the user's guide (if needed)~~
~~- [ ] Tested the Workbench UI (if relevant)~~
