### PR TITLE
Add support for input group labels

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -63,9 +63,18 @@
 
 
 
-..
-  Unreleased Changes
-  ------------------
+Unreleased Changes
+------------------
+
+General
+=======
+* Added support for labeled input groups. ``spec.InputGroup`` was added to
+  represent a group of input fields that may have a label.
+  ``spec.ModelSpec.input_field_order`` can now contain ``spec.InputGroup``s
+  as well as lists. The ``spec.InputGroup.label`` will be displayed on that
+  section of the model input form in the workbench.
+  (`#1602 <https://github.com/natcap/invest/issues/1602>`_)
+
 
 3.20.2 (2026-09-02)
 -------------------

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -218,6 +218,11 @@ def set_metadata_field_descriptions(field_specs, resource):
             LOGGER.debug(error)
 
 
+class InputGroup(BaseModel):
+    name: str = ''
+    keys: list[str]
+
+
 class ImmutableBaseModel(BaseModel):
     """BaseModel with frozen attributes."""
 
@@ -2299,18 +2304,26 @@ class ModelSpec(ImmutableBaseModel):
     Example: ``"https://github.com/natcap/invest-demo-plugin/blob/main/README.md"``
     """
 
-    input_field_order: list[list[str]]
-    """A list that specifies the order and grouping of model inputs.
-    Inputs will be displayed in the input form from top to bottom in the order
-    listed here. Sub-lists represent groups of inputs that will be visually
-    separated by a horizontal line. This improves UX by breaking up long lists
-    and visually grouping related inputs. If you do not wish to use groups,
-    all inputs may go in the same sub-list. It is a convention to begin with a
-    group of ``workspace_dir`` and ``results_suffix``. Each item in the
-    sub-lists must match the key of an ``Input`` in ``inputs``. The key of each
+    input_field_order: list[InputGroup | list[str]]
+    """A list that specifies the order and grouping of model inputs that will be
+    displayed in the workbench input form. This list may contain lists and/or
+    spec.InputGroups. Each sub-list or InputGroup represents a group of inputs
+    that will be visually separated by a horizontal line. This improves UX by
+    breaking up long lists and visually grouping related inputs. You can give a
+    group a label, which will be displayed in the workbench, by using an
+    InputGroup and setting the ``name`` property. Note that groups and their
+    labels only affect workbench rendering and have no effect
+
+    The InputGroup was added to allow labeling groups. Using plain lists is
+    still supported for backwards compatibility. If you do not wish to use
+    groups, all inputs may go in the same sub-list.
+
+    It is a convention to begin with a group of ``workspace_dir`` and
+    ``results_suffix``. Each item in each sub-list or InputGroup.keys list must
+    match the key of an ``Input`` in ``inputs``. The key of each
     ``Input`` must be included exactly once, unless it is hidden.
 
-    Example: ``[['workspace_dir', 'results_suffix'], ['foo'], ['bar', baz']]``
+    Example: ``[['workspace_dir', 'results_suffix'], InputGroup(name='Group A', keys=['bar', baz'])``
     """
 
     inputs: list[Input]
@@ -2366,6 +2379,8 @@ class ModelSpec(ImmutableBaseModel):
         or are marked as hidden."""
         found_keys = set()
         for group in self.input_field_order:
+            if isinstance(group, InputGroup):
+                group = group.keys
             for key in group:
                 if key in found_keys:
                     raise ValueError(
@@ -2432,6 +2447,20 @@ class ModelSpec(ImmutableBaseModel):
         spec_dict.pop('inputs')
         spec_dict['args'] = {_input.id: _input for _input in self.inputs}
         spec_dict['outputs'] = {_output.id: _output for _output in self.outputs}
+        spec_dict['input_field_order'] = []
+        # Encode the input field order as a list of dicts, where each dict
+        # contains a single item representing an input group. Each dict has two
+        # entries: 'name' which stores the group label (or '' if no label),
+        # and 'input_keys' and the value is the list of input ids in that group.
+        for input_group in self.input_field_order:
+            if isinstance(input_group, InputGroup):
+                spec_dict['input_field_order'].append({
+                    'name': input_group.name,
+                    'input_keys': input_group.keys})
+            else:  # is a list of keys
+                spec_dict['input_field_order'].append({
+                    'name': '',
+                    'input_keys': input_group})
         return json.dumps(spec_dict, default=fallback_serializer, ensure_ascii=False)
 
     def preprocess_inputs(self, input_values):

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -221,11 +221,11 @@ def set_metadata_field_descriptions(field_specs, resource):
 class InputGroup(BaseModel):
     """Represent a group of input fields for display in the workbench."""
 
-    name: str = ''
+    label: str = ''
     """Optional label that will be displayed in the workbench above
        this group of inputs."""
 
-    input_keys: list[str]
+    input_ids: list[str]
     """List of model input ids that belong to this group. Each string must
        match the id of an Input in the model."""
 
@@ -2318,7 +2318,7 @@ class ModelSpec(ImmutableBaseModel):
     that will be visually separated by a horizontal line. This improves UX by
     breaking up long lists and visually grouping related inputs. You can give a
     group a label, which will be displayed in the workbench, by using an
-    InputGroup and setting the ``name`` property. Note that groups and their
+    InputGroup and setting the ``label`` property. Note that groups and their
     labels only affect workbench rendering and have no effect
 
     The InputGroup was added to allow labeling groups. Using plain lists is
@@ -2326,11 +2326,11 @@ class ModelSpec(ImmutableBaseModel):
     groups, all inputs may go in the same sub-list.
 
     It is a convention to begin with a group of ``workspace_dir`` and
-    ``results_suffix``. Each item in each sub-list or InputGroup.keys list must
-    match the key of an ``Input`` in ``inputs``. The key of each
+    ``results_suffix``. Each item in each sub-list or InputGroup.input_ids
+    list must match the key of an ``Input`` in ``inputs``. The key of each
     ``Input`` must be included exactly once, unless it is hidden.
 
-    Example: ``[['workspace_dir', 'results_suffix'], InputGroup(name='Group A', keys=['bar', baz'])``
+    Example: ``[['workspace_dir', 'results_suffix'], InputGroup(label='Group A', input_ids=['bar', baz'])``
     """
 
     inputs: list[Input]
@@ -2387,7 +2387,7 @@ class ModelSpec(ImmutableBaseModel):
         found_keys = set()
         for group in self.input_field_order:
             if isinstance(group, InputGroup):
-                group = group.input_keys
+                group = group.input_ids
             for key in group:
                 if key in found_keys:
                     raise ValueError(
@@ -2462,12 +2462,12 @@ class ModelSpec(ImmutableBaseModel):
         for input_group in self.input_field_order:
             if isinstance(input_group, InputGroup):
                 spec_dict['input_field_order'].append({
-                    'name': input_group.name,
-                    'input_keys': input_group.input_keys})
+                    'label': input_group.label,
+                    'input_ids': input_group.input_ids})
             else:  # is a list of keys
                 spec_dict['input_field_order'].append({
-                    'name': '',
-                    'input_keys': input_group})
+                    'label': '',
+                    'input_ids': input_group})
         return json.dumps(spec_dict, default=fallback_serializer, ensure_ascii=False)
 
     def preprocess_inputs(self, input_values):

--- a/src/natcap/invest/spec.py
+++ b/src/natcap/invest/spec.py
@@ -219,8 +219,15 @@ def set_metadata_field_descriptions(field_specs, resource):
 
 
 class InputGroup(BaseModel):
+    """Represent a group of input fields for display in the workbench."""
+
     name: str = ''
-    keys: list[str]
+    """Optional label that will be displayed in the workbench above
+       this group of inputs."""
+
+    input_keys: list[str]
+    """List of model input ids that belong to this group. Each string must
+       match the id of an Input in the model."""
 
 
 class ImmutableBaseModel(BaseModel):
@@ -2380,7 +2387,7 @@ class ModelSpec(ImmutableBaseModel):
         found_keys = set()
         for group in self.input_field_order:
             if isinstance(group, InputGroup):
-                group = group.keys
+                group = group.input_keys
             for key in group:
                 if key in found_keys:
                     raise ValueError(
@@ -2456,7 +2463,7 @@ class ModelSpec(ImmutableBaseModel):
             if isinstance(input_group, InputGroup):
                 spec_dict['input_field_order'].append({
                     'name': input_group.name,
-                    'input_keys': input_group.keys})
+                    'input_keys': input_group.input_keys})
             else:  # is a list of keys
                 spec_dict['input_field_order'].append({
                     'name': '',

--- a/src/natcap/invest/stormwater/stormwater.py
+++ b/src/natcap/invest/stormwater/stormwater.py
@@ -29,7 +29,7 @@ MODEL_SPEC = spec.ModelSpec(
     aliases=(),
     module_name=__name__,
     input_field_order=[
-        ["workspace_dir", "results_suffix"],
+        spec.InputGroup(name='Group A', keys=["workspace_dir", "results_suffix"]),
         ["lulc_path", "soil_group_path", "precipitation_path", "biophysical_table"],
         ["adjust_retention_ratios", "retention_radius", "road_centerlines_path"],
         ["aggregate_areas_path", "replacement_cost"]

--- a/src/natcap/invest/stormwater/stormwater.py
+++ b/src/natcap/invest/stormwater/stormwater.py
@@ -29,7 +29,7 @@ MODEL_SPEC = spec.ModelSpec(
     aliases=(),
     module_name=__name__,
     input_field_order=[
-        spec.InputGroup(name='Group A', keys=["workspace_dir", "results_suffix"]),
+        ["workspace_dir", "results_suffix"],
         ["lulc_path", "soil_group_path", "precipitation_path", "biophysical_table"],
         ["adjust_retention_ratios", "retention_radius", "road_centerlines_path"],
         ["aggregate_areas_path", "replacement_cost"]

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -580,7 +580,7 @@ class ModelSpecTests(unittest.TestCase):
             module_name=__name__,
             input_field_order=[
                 ["workspace_dir"],
-                spec.InputGroup(name="Group A", keys=["baz"])
+                spec.InputGroup(label="Group A", input_ids=["baz"])
             ],
             inputs=[
                 spec.WORKSPACE,
@@ -603,8 +603,8 @@ class ModelSpecTests(unittest.TestCase):
             'reporter': '',
             'about': '',
             'input_field_order': [
-                {'name': '', 'input_keys': ['workspace_dir']},
-                {'name': 'Group A', 'input_keys': ['baz']}
+                {'label': '', 'input_ids': ['workspace_dir']},
+                {'label': 'Group A', 'input_ids': ['baz']}
             ],
             'different_projections_ok': False,
             'validate_spatial_overlap': True,

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -564,3 +565,80 @@ class ModelSpecTests(unittest.TestCase):
         from natcap.invest.carbon import MODEL_SPEC
         with self.assertRaises(ValidationError):
             MODEL_SPEC.model_id = 'foo'
+
+    def test_json_serialization(self):
+        """Test serizalizing the ModelSpec."""
+        test_spec = spec.ModelSpec(
+            model_id="foo",
+            model_title="Foo",
+            userguide="",
+            reporter="",
+            about="",
+            validate_spatial_overlap=True,
+            different_projections_ok=False,
+            aliases=(),
+            module_name=__name__,
+            input_field_order=[
+                ["workspace_dir"],
+                spec.InputGroup(name="Group A", keys=["baz"])
+            ],
+            inputs=[
+                spec.WORKSPACE,
+                spec.NumberInput(id="baz", data_type=int, units=None)
+            ],
+            outputs=[
+                spec.SingleBandRasterOutput(
+                    id="c_storage_bas",
+                    path="c_storage_bas.tif",
+                    data_type=float,
+                    units=u.metric_ton / u.hectare
+                )
+            ]
+        )
+        self.assertEqual(json.loads(test_spec.to_json()), {
+            'model_id': 'foo',
+            'model_title': 'Foo',
+            'userguide': '',
+            'aliases': 'set()',
+            'reporter': '',
+            'about': '',
+            'input_field_order': [
+                {'name': '', 'input_keys': ['workspace_dir']},
+                {'name': 'Group A', 'input_keys': ['baz']}
+            ],
+            'different_projections_ok': False,
+            'validate_spatial_overlap': True,
+            'args': {
+                'workspace_dir': {
+                    'about': spec.WORKSPACE.about,
+                    'required': True,
+                    'allowed': True,
+                    'hidden': False,
+                    'id': 'workspace_dir',
+                    'name': 'workspace directory',
+                    'type': 'workspace'
+                },
+                'baz': {
+                    'id': 'baz',
+                    'about': None,
+                    'name': None,
+                    'required': True,
+                    'allowed': True,
+                    'hidden': False,
+                    'units': None,
+                    'expression': None,
+                    'type': 'number'
+                }
+            },
+            'outputs': {
+                'c_storage_bas': {
+                    'id': 'c_storage_bas',
+                    'about': None,
+                    'created_if': True,
+                    'path': 'c_storage_bas.tif',
+                    'data_type': 'number',
+                    'units': 't/ha'
+                }
+            },
+            'module_name': __name__
+        })

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -76,7 +76,6 @@ class InvestTab extends React.Component {
     }
     try {
       const { args, ...model_spec } = await getSpec(job.modelID);
-      console.log(model_spec)
       this.setState({
         modelSpec: model_spec,
         argsSpec: args,

--- a/workbench/src/renderer/components/InvestTab/index.jsx
+++ b/workbench/src/renderer/components/InvestTab/index.jsx
@@ -76,6 +76,7 @@ class InvestTab extends React.Component {
     }
     try {
       const { args, ...model_spec } = await getSpec(job.modelID);
+      console.log(model_spec)
       this.setState({
         modelSpec: model_spec,
         argsSpec: args,

--- a/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -157,14 +157,16 @@ class ArgsForm extends React.Component {
       // Separate each group of input fields with a dotted line and label if
       // applicable. Omit the dotted line above the first group if it has
       // no label.
-      let fieldsetClassName = "dotted-fieldset";
+      let fieldsetClassName = "arg-group-dotted-fieldset";
       if (k === 0 && !inputGroup.name) {
         fieldsetClassName = "mt-3"
       }
       formItems.push(
-        <fieldset className={fieldsetClassName}>
-          {inputGroup.name && <legend className="dotted-legend">{inputGroup.name}</legend>}
-          <Form.Group className="arg-group" key={k}>
+        <fieldset className={fieldsetClassName} key={k}>
+          {inputGroup.name &&
+            <legend className="arg-group-dotted-legend">{inputGroup.name}</legend>
+          }
+          <Form.Group className="arg-group">
             {groupItems}
           </Form.Group>
         </fieldset>

--- a/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -132,7 +132,7 @@ class ArgsForm extends React.Component {
     let k = 0;
     argsOrder.forEach((inputGroup) => {
       const groupItems = [];
-      inputGroup.input_keys.forEach((argkey) => {
+      inputGroup.input_ids.forEach((argkey) => {
         groupItems.push(
           <ArgInput
             argkey={argkey}
@@ -158,13 +158,13 @@ class ArgsForm extends React.Component {
       // applicable. Omit the dotted line above the first group if it has
       // no label.
       let fieldsetClassName = "arg-group-dotted-fieldset";
-      if (k === 0 && !inputGroup.name) {
+      if (k === 0 && !inputGroup.label) {
         fieldsetClassName = "mt-3"
       }
       formItems.push(
         <fieldset className={fieldsetClassName} key={k}>
-          {inputGroup.name &&
-            <legend className="arg-group-dotted-legend">{inputGroup.name}</legend>
+          {inputGroup.label &&
+            <legend className="arg-group-dotted-legend">{inputGroup.label}</legend>
           }
           <Form.Group className="arg-group">
             {groupItems}

--- a/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/ArgsForm/index.jsx
@@ -130,10 +130,9 @@ class ArgsForm extends React.Component {
     } = this.props;
     const formItems = [];
     let k = 0;
-    argsOrder.forEach((groupArray) => {
-      k += 1;
+    argsOrder.forEach((inputGroup) => {
       const groupItems = [];
-      groupArray.forEach((argkey) => {
+      inputGroup.input_keys.forEach((argkey) => {
         groupItems.push(
           <ArgInput
             argkey={argkey}
@@ -155,11 +154,23 @@ class ArgsForm extends React.Component {
           />
         );
       });
+      // Separate each group of input fields with a dotted line and label if
+      // applicable. Omit the dotted line above the first group if it has
+      // no label.
+      let fieldsetClassName = "dotted-fieldset";
+      if (k === 0 && !inputGroup.name) {
+        fieldsetClassName = "mt-3"
+      }
       formItems.push(
-        <div className="arg-group" key={k}>
-          {groupItems}
-        </div>
+        <fieldset className={fieldsetClassName}>
+          {inputGroup.name && <legend className="dotted-legend">{inputGroup.name}</legend>}
+          <Form.Group className="arg-group" key={k}>
+            {groupItems}
+          </Form.Group>
+        </fieldset>
+
       );
+      k += 1;
     });
 
     return (

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -48,7 +48,10 @@ function initializeArgValues(argsSpec, inputFieldOrder, argsDict) {
   const initIsEmpty = Object.keys(argsDict).length === 0;
   const argsValues = {};
   const argsDropdownOptions = {};
-  inputFieldOrder.flat().forEach((argkey) => {
+
+  inputFieldOrder.map(
+    (inputGroup) => inputGroup.input_keys
+  ).flat().forEach((argkey) => {
     // When initializing with undefined values, assign defaults so that,
     // a) values are handled well by the html inputs and
     // b) the object exported to JSON on "Save" or "Execute" includes defaults.
@@ -145,7 +148,9 @@ class SetupTab extends React.Component {
     // here we only use the keys in inputFieldOrder because args that
     // aren't displayed in the form don't need an enabled/disabled state.
     // all args default to being enabled
-    const argsEnabled = inputFieldOrder.flat().reduce((acc, argkey) => {
+    const argsEnabled = inputFieldOrder.map(
+      (inputGroup) => inputGroup.input_keys
+    ).flat().reduce((acc, argkey) => {
       acc[argkey] = true;
       return acc;
     }, {});

--- a/workbench/src/renderer/components/SetupTab/index.jsx
+++ b/workbench/src/renderer/components/SetupTab/index.jsx
@@ -50,7 +50,7 @@ function initializeArgValues(argsSpec, inputFieldOrder, argsDict) {
   const argsDropdownOptions = {};
 
   inputFieldOrder.map(
-    (inputGroup) => inputGroup.input_keys
+    (inputGroup) => inputGroup.input_ids
   ).flat().forEach((argkey) => {
     // When initializing with undefined values, assign defaults so that,
     // a) values are handled well by the html inputs and
@@ -149,7 +149,7 @@ class SetupTab extends React.Component {
     // aren't displayed in the form don't need an enabled/disabled state.
     // all args default to being enabled
     const argsEnabled = inputFieldOrder.map(
-      (inputGroup) => inputGroup.input_keys
+      (inputGroup) => inputGroup.input_ids
     ).flat().reduce((acc, argkey) => {
       acc[argkey] = true;
       return acc;

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -632,18 +632,17 @@ exceed 100% of window.*/
   opacity: 0.2;
 }
 
-.dotted-fieldset {
+.arg-group-dotted-fieldset {
   border: none;
   border-top: 2px dotted #dee2e6;
   padding-top: 1rem;
   margin-top: 1.5rem;
 }
 
-/* Overrides Bootstrap's legend styling to render inline with the top border */
-.dotted-legend {
+.arg-group-dotted-legend {
   float: none;
   width: auto;
-  padding: 0 0.75rem 0 0; /* Adds spacing between text and the line on the right */
+  padding: 0 0.75rem 0 0;
   margin-bottom: 0;
   font-size: 0.9rem;
   font-weight: 600;

--- a/workbench/src/renderer/styles/style.css
+++ b/workbench/src/renderer/styles/style.css
@@ -632,16 +632,30 @@ exceed 100% of window.*/
   opacity: 0.2;
 }
 
+.dotted-fieldset {
+  border: none;
+  border-top: 2px dotted #dee2e6;
+  padding-top: 1rem;
+  margin-top: 1.5rem;
+}
+
+/* Overrides Bootstrap's legend styling to render inline with the top border */
+.dotted-legend {
+  float: none;
+  width: auto;
+  padding: 0 0.75rem 0 0; /* Adds spacing between text and the line on the right */
+  margin-bottom: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #6c757d;
+}
+
 .arg-group {
   display: flex;
   flex-direction: column;
   gap: 16px;
   margin: 0;
   padding: 1rem 0;
-  border-bottom: 1px dotted;
-  &:last-of-type {
-    border-bottom: none;
-  }
 }
 
 .arg-hide {

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -46,7 +46,7 @@ const SAMPLE_SPEC = {
       type: 'csv',
     },
   },
-  input_field_order: [['workspace_dir', 'carbon_pools_path']],
+  input_field_order: [{ name: '', input_keys: ['workspace_dir', 'carbon_pools_path']}],
 };
 
 describe('Various ways to open and close InVEST models', () => {

--- a/workbench/tests/renderer/app.test.js
+++ b/workbench/tests/renderer/app.test.js
@@ -46,7 +46,7 @@ const SAMPLE_SPEC = {
       type: 'csv',
     },
   },
-  input_field_order: [{ name: '', input_keys: ['workspace_dir', 'carbon_pools_path']}],
+  input_field_order: [{ label: '', input_ids: ['workspace_dir', 'carbon_pools_path']}],
 };
 
 describe('Various ways to open and close InVEST models', () => {

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -47,7 +47,7 @@ describe('InVEST subprocess testing', () => {
         type: 'freestyle_string',
       },
     },
-    input_field_order: [['workspace_dir', 'results_suffix']],
+    input_field_order: [{ name: '', input_keys: ['workspace_dir', 'results_suffix']}],
     model_title: 'Eco Model',
     model_id: 'eco',
     module_name: 'natcap.invest.eco',

--- a/workbench/tests/renderer/invest_subprocess.test.js
+++ b/workbench/tests/renderer/invest_subprocess.test.js
@@ -47,7 +47,7 @@ describe('InVEST subprocess testing', () => {
         type: 'freestyle_string',
       },
     },
-    input_field_order: [{ name: '', input_keys: ['workspace_dir', 'results_suffix']}],
+    input_field_order: [{ label: '', input_ids: ['workspace_dir', 'results_suffix']}],
     model_title: 'Eco Model',
     model_id: 'eco',
     module_name: 'natcap.invest.eco',

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -53,7 +53,7 @@ describe('Run status Alert renders with status from a recent run', () => {
     pyname: 'natcap.invest.foo',
     model_title: 'Foo Model',
     userguide: 'foo.html',
-    input_field_order: [{ name: '', input_keys: ['workspace']}],
+    input_field_order: [{ label: '', input_ids: ['workspace']}],
     args: {
       workspace: {
         name: 'Workspace',
@@ -213,7 +213,7 @@ describe('Sidebar Buttons', () => {
     pyname: 'natcap.invest.foo',
     model_title: 'Foo Model',
     userguide: 'foo.html',
-    input_field_order: [{ name: '', input_keys: ['workspace', 'port']}],
+    input_field_order: [{ label: '', input_ids: ['workspace', 'port']}],
     args: {
       workspace: {
         name: 'Workspace',
@@ -633,7 +633,7 @@ describe('InVEST Run Button', () => {
     pyname: 'natcap.invest.bar',
     model_title: 'Bar Model',
     userguide: 'bar.html',
-    input_field_order: [{ name: '', input_keys: ['a', 'b', 'c']}],
+    input_field_order: [{ label: '', input_ids: ['a', 'b', 'c']}],
     args: {
       a: {
         name: 'abar',

--- a/workbench/tests/renderer/investtab.test.js
+++ b/workbench/tests/renderer/investtab.test.js
@@ -53,7 +53,7 @@ describe('Run status Alert renders with status from a recent run', () => {
     pyname: 'natcap.invest.foo',
     model_title: 'Foo Model',
     userguide: 'foo.html',
-    input_field_order: [['workspace']],
+    input_field_order: [{ name: '', input_keys: ['workspace']}],
     args: {
       workspace: {
         name: 'Workspace',
@@ -213,7 +213,7 @@ describe('Sidebar Buttons', () => {
     pyname: 'natcap.invest.foo',
     model_title: 'Foo Model',
     userguide: 'foo.html',
-    input_field_order: [['workspace', 'port']],
+    input_field_order: [{ name: '', input_keys: ['workspace', 'port']}],
     args: {
       workspace: {
         name: 'Workspace',
@@ -633,7 +633,7 @@ describe('InVEST Run Button', () => {
     pyname: 'natcap.invest.bar',
     model_title: 'Bar Model',
     userguide: 'bar.html',
-    input_field_order: [['a', 'b', 'c']],
+    input_field_order: [{ name: '', input_keys: ['a', 'b', 'c']}],
     args: {
       a: {
         name: 'abar',

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -44,7 +44,7 @@ describe('Manage Plugins modal', () => {
           type: 'raster',
         },
       },
-      input_field_order: [['workspace_dir', 'input_path']],
+      input_field_order: [{ name: '', input_keys: ['workspace_dir', 'input_path']}],
     });
 
     fetchArgsEnabled.mockResolvedValue({

--- a/workbench/tests/renderer/plugin.test.js
+++ b/workbench/tests/renderer/plugin.test.js
@@ -44,7 +44,7 @@ describe('Manage Plugins modal', () => {
           type: 'raster',
         },
       },
-      input_field_order: [{ name: '', input_keys: ['workspace_dir', 'input_path']}],
+      input_field_order: [{ label: '', input_ids: ['workspace_dir', 'input_path']}],
     });
 
     fetchArgsEnabled.mockResolvedValue({

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -53,7 +53,7 @@ const BASE_ARGS_ENABLED = {}
 Object.keys(BASE_MODEL_SPEC.args).forEach((arg) => {
   BASE_ARGS_ENABLED[arg] = true;
 });
-const INPUT_FIELD_ORDER = [Object.keys(BASE_MODEL_SPEC.args)];
+const INPUT_FIELD_ORDER = [{ name: '', input_keys: Object.keys(BASE_MODEL_SPEC.args)}];
 
 /**
  * Render a SetupTab component given the necessary specs.
@@ -410,7 +410,7 @@ describe('UI spec functionality', () => {
     };
     fetchArgsEnabled.mockResolvedValue({ arg1: false, arg2: true });
 
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
 
     const { findByLabelText } = renderSetupFromSpec(spec, inputFieldOrder);
     const arg1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
@@ -441,7 +441,7 @@ describe('UI spec functionality', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
 
     const {
       findByLabelText, findByText, queryByText,
@@ -491,7 +491,12 @@ describe('UI spec functionality', () => {
     });
 
     // intentionally leaving out arg6, it should not be in the setup form
-    const inputFieldOrder = [['arg4'], ['arg3', 'arg2'], ['arg1'], ['arg5']];
+    const inputFieldOrder = [
+      { name: '', input_keys: ['arg4'] },
+      { name: '', input_keys: ['arg3', 'arg2'] },
+      { name: '', input_keys: ['arg1'] },
+      { name: '', input_keys: ['arg5'] }
+    ];
 
     const { findByTestId, queryByText } = renderSetupFromSpec(spec, inputFieldOrder);
     const form = await findByTestId('setup-form');
@@ -503,9 +508,9 @@ describe('UI spec functionality', () => {
       // Input nodes should be in the order defined in the spec
       expect(form.childNodes[0])
         .toHaveTextContent(RegExp(`${spec.args.arg4.name}`));
-      expect(form.childNodes[1].childNodes[0])
+      expect(form.childNodes[1].childNodes[0].childNodes[0])
         .toHaveTextContent(RegExp(`${spec.args.arg3.name}`));
-      expect(form.childNodes[1].childNodes[1])
+      expect(form.childNodes[1].childNodes[0].childNodes[1])
         .toHaveTextContent(RegExp(`${spec.args.arg2.name}`));
       expect(form.childNodes[2])
         .toHaveTextContent(RegExp(`${spec.args.arg1.name}`));
@@ -535,7 +540,7 @@ describe('Misc form validation stuff', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
 
     // Mocking to return the payload so we can assert we always send
     // correct payload to this endpoint.
@@ -567,7 +572,7 @@ describe('Misc form validation stuff', () => {
         },
       },
     };
-    const inputFieldOrder =[Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     const vectorValue = './vector.shp';
     const expectedVal1 = '-84.9';
     const vectorBox = `[${expectedVal1}, 19.1, -69.1, 29.5]`;
@@ -628,7 +633,7 @@ describe('Misc form validation stuff', () => {
     );
     fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
 
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
 
     const { findByLabelText, queryByText } = renderSetupFromSpec(
       spec, inputFieldOrder, { arg1: false, arg2: false } );
@@ -680,7 +685,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -730,7 +735,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -778,7 +783,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -829,7 +834,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -869,7 +874,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -919,7 +924,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -968,7 +973,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
 
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
@@ -1020,7 +1025,7 @@ describe('loadParametersFromFile', () => {
         },
       },
     };
-    const inputFieldOrder = [Object.keys(spec.args)];
+    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
     const mockDatastack = {
       model_id: 'coastal_purple_carbon',
       model_title: 'Coastal Purple Carbon',

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -53,7 +53,7 @@ const BASE_ARGS_ENABLED = {}
 Object.keys(BASE_MODEL_SPEC.args).forEach((arg) => {
   BASE_ARGS_ENABLED[arg] = true;
 });
-const INPUT_FIELD_ORDER = [{ name: '', input_keys: Object.keys(BASE_MODEL_SPEC.args)}];
+const INPUT_FIELD_ORDER = [{ label: '', input_ids: Object.keys(BASE_MODEL_SPEC.args)}];
 
 /**
  * Render a SetupTab component given the necessary specs.
@@ -410,7 +410,7 @@ describe('UI spec functionality', () => {
     };
     fetchArgsEnabled.mockResolvedValue({ arg1: false, arg2: true });
 
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
 
     const { findByLabelText } = renderSetupFromSpec(spec, inputFieldOrder);
     const arg1 = await findByLabelText((content) => content.startsWith(spec.args.arg1.name));
@@ -441,7 +441,7 @@ describe('UI spec functionality', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
 
     const {
       findByLabelText, findByText, queryByText,
@@ -492,10 +492,10 @@ describe('UI spec functionality', () => {
 
     // intentionally leaving out arg6, it should not be in the setup form
     const inputFieldOrder = [
-      { name: '', input_keys: ['arg4'] },
-      { name: '', input_keys: ['arg3', 'arg2'] },
-      { name: 'Group A', input_keys: ['arg1'] },
-      { name: '', input_keys: ['arg5'] }
+      { label: '', input_ids: ['arg4'] },
+      { label: '', input_ids: ['arg3', 'arg2'] },
+      { label: 'Group A', input_ids: ['arg1'] },
+      { label: '', input_ids: ['arg5'] }
     ];
 
     const { findByTestId, queryByText } = renderSetupFromSpec(spec, inputFieldOrder);
@@ -542,7 +542,7 @@ describe('Misc form validation stuff', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
 
     // Mocking to return the payload so we can assert we always send
     // correct payload to this endpoint.
@@ -574,7 +574,7 @@ describe('Misc form validation stuff', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     const vectorValue = './vector.shp';
     const expectedVal1 = '-84.9';
     const vectorBox = `[${expectedVal1}, 19.1, -69.1, 29.5]`;
@@ -635,7 +635,7 @@ describe('Misc form validation stuff', () => {
     );
     fetchArgsEnabled.mockResolvedValue({ arg1: true, arg2: true });
 
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
 
     const { findByLabelText, queryByText } = renderSetupFromSpec(
       spec, inputFieldOrder, { arg1: false, arg2: false } );
@@ -687,7 +687,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -737,7 +737,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -785,7 +785,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -836,7 +836,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -876,7 +876,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -926,7 +926,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
     );
@@ -975,7 +975,7 @@ describe('Form drag-and-drop', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
 
     fetchValidation.mockResolvedValue(
       [[Object.keys(spec.args), VALIDATION_MESSAGE]]
@@ -1027,7 +1027,7 @@ describe('loadParametersFromFile', () => {
         },
       },
     };
-    const inputFieldOrder = [{ name: '', input_keys: Object.keys(spec.args)}];
+    const inputFieldOrder = [{ label: '', input_ids: Object.keys(spec.args)}];
     const mockDatastack = {
       model_id: 'coastal_purple_carbon',
       model_title: 'Coastal Purple Carbon',

--- a/workbench/tests/renderer/setuptab.test.js
+++ b/workbench/tests/renderer/setuptab.test.js
@@ -494,7 +494,7 @@ describe('UI spec functionality', () => {
     const inputFieldOrder = [
       { name: '', input_keys: ['arg4'] },
       { name: '', input_keys: ['arg3', 'arg2'] },
-      { name: '', input_keys: ['arg1'] },
+      { name: 'Group A', input_keys: ['arg1'] },
       { name: '', input_keys: ['arg5'] }
     ];
 
@@ -512,7 +512,9 @@ describe('UI spec functionality', () => {
         .toHaveTextContent(RegExp(`${spec.args.arg3.name}`));
       expect(form.childNodes[1].childNodes[0].childNodes[1])
         .toHaveTextContent(RegExp(`${spec.args.arg2.name}`));
-      expect(form.childNodes[2])
+      expect(form.childNodes[2].childNodes[0])
+        .toHaveTextContent('Group A');
+      expect(form.childNodes[2].childNodes[0].childNodes[0])
         .toHaveTextContent(RegExp(`${spec.args.arg1.name}`));
       expect(form.childNodes[3])
         .toHaveTextContent(RegExp(`${spec.args.arg5.name}`));


### PR DESCRIPTION
## Description
Fixes #1602
<img width="941" height="445" alt="image" src="https://github.com/user-attachments/assets/21f3fab8-8166-4978-8ab7-72d8d57a324b" />

On the invest side, added a new `spec.InputGroup` class which may be used instead of a plain list of strings to represent a group of inputs with an optional label. When the model spec is JSON serialized, the `input_field_order` is now returned as a list of dicts, not a list of lists. The `name` attribute (which can be left as an empty string) is then rendered in the workbench.

Like before, a dotted line visually separates input groups. If a group has a label, it will be displayed at the beginning of the dotted line. I think I like this layout generally, but open to feedback on how it looks.

## Checklist
- [x] Updated HISTORY.rst and link to any relevant issue (if these changes are user-facing)
- [ ] Updated the user's guide (if needed)
- [ ] Tested the Workbench UI (if relevant)
